### PR TITLE
Feat/#1 init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,11 @@
-# Created by https://www.toptal.com/developers/gitignore/api/macos,swift,swiftpackagemanager,xcode
-# Edit at https://www.toptal.com/developers/gitignore?templates=macos,swift,swiftpackagemanager,xcode
+# Created by https://www.toptal.com/developers/gitignore/api/macos,xcode,swiftpm,swiftpackagemanager,swift
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,xcode,swiftpm,swiftpackagemanager,swift
 
 ### macOS ###
 # General
 .DS_Store
 .AppleDouble
 .LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
-._*
 
 # Files that might appear in the root of a volume
 .DocumentRevisions-V100
@@ -121,7 +114,9 @@ iOSInjectionProject/
 ### SwiftPackageManager ###
 Packages
 xcuserdata
-*.xcodeproj
+
+
+### SwiftPM ###
 
 
 ### Xcode ###
@@ -136,8 +131,8 @@ xcuserdata
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
+GAM/GAM.xcodeproj/project.xcworkspace/xcuserdata/jungbin.xcuserdatad/UserInterfaceState.xcuserstate
+*.xcuserstate
 
-### SECRET_KEY ###
+### SECRET KEY ###
 *.xcconfig
-
-# End of https://www.toptal.com/developers/gitignore/api/macos,swift,swiftpackagemanager,xcode

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -1,0 +1,787 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		84781BCD2B5BDAFC00D37921 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781BCC2B5BDAFC00D37921 /* AppDelegate.swift */; };
+		84781BCF2B5BDAFC00D37921 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781BCE2B5BDAFC00D37921 /* SceneDelegate.swift */; };
+		84781BD62B5BDAFD00D37921 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84781BD52B5BDAFD00D37921 /* Assets.xcassets */; };
+		84781BD92B5BDAFD00D37921 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84781BD72B5BDAFD00D37921 /* LaunchScreen.storyboard */; };
+		84781BE82B5BE17400D37921 /* Enviroment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781BE72B5BE17400D37921 /* Enviroment.swift */; };
+		84781BEE2B5BE3B600D37921 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781BED2B5BE3B600D37921 /* NetworkError.swift */; };
+		84781BF02B5BE3C000D37921 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781BEF2B5BE3C000D37921 /* Networking.swift */; };
+		84781C642B5BE9C100D37921 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C632B5BE9C100D37921 /* Moya */; };
+		84781C662B5BE9C100D37921 /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C652B5BE9C100D37921 /* ReactiveMoya */; };
+		84781C682B5BE9C100D37921 /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C672B5BE9C100D37921 /* RxMoya */; };
+		84781C6B2B5BEA0000D37921 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C6A2B5BEA0000D37921 /* SnapKit */; };
+		84781C6D2B5BEA3800D37921 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */; };
+		84781C702B5BEAB800D37921 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C6F2B5BEAB800D37921 /* UserDefaults+.swift */; };
+		84781C722B5BEAC800D37921 /* RxMoya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C712B5BEAC800D37921 /* RxMoya+.swift */; };
+		84781C752B5BEB5600D37921 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C742B5BEB5600D37921 /* UserDefaultsManager.swift */; };
+		84781C772B5BEB8500D37921 /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C762B5BEB8500D37921 /* UserDefaultsKey.swift */; };
+		84781C7E2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C7D2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift */; };
+		84781C802B5BEC1400D37921 /* KakaoLoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C7F2B5BEC1400D37921 /* KakaoLoginResponseDTO.swift */; };
+		84781C822B5BEC3900D37921 /* BaseResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C812B5BEC3900D37921 /* BaseResponseDTO.swift */; };
+		84781C872B5BED9A00D37921 /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C862B5BED9A00D37921 /* BaseAPI.swift */; };
+		84781C892B5BEDAA00D37921 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C882B5BEDAA00D37921 /* AuthAPI.swift */; };
+		84781C952B5BF15A00D37921 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C942B5BF15A00D37921 /* RxKakaoSDKAuth */; };
+		84781C972B5BF15A00D37921 /* RxKakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C962B5BF15A00D37921 /* RxKakaoSDKCommon */; };
+		84781C992B5BF15A00D37921 /* RxKakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 84781C982B5BF15A00D37921 /* RxKakaoSDKUser */; };
+		84781C9D2B5BF68900D37921 /* RootDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C9C2B5BF68900D37921 /* RootDIContainer.swift */; };
+		84781C9F2B5BF6A000D37921 /* RootNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C9E2B5BF6A000D37921 /* RootNavigationDelegate.swift */; };
+		84781CA12B5BF6AB00D37921 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA02B5BF6AB00D37921 /* RootViewController.swift */; };
+		84781CA32B5BF6BF00D37921 /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA22B5BF6BF00D37921 /* RootViewModel.swift */; };
+		84781CA62B5BF6F500D37921 /* SplashDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA52B5BF6F500D37921 /* SplashDIContainer.swift */; };
+		84781CA82B5BF71900D37921 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA72B5BF71900D37921 /* SplashViewController.swift */; };
+		84781CAA2B5BF72200D37921 /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA92B5BF72200D37921 /* SplashViewModel.swift */; };
+		84781CAD2B5BF7A200D37921 /* TabBarDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CAC2B5BF7A200D37921 /* TabBarDIContainer.swift */; };
+		84781CAF2B5BF7CA00D37921 /* HomeTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CAE2B5BF7CA00D37921 /* HomeTab.swift */; };
+		84781CB12B5BF85400D37921 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CB02B5BF85400D37921 /* TabBarController.swift */; };
+		84781CBA2B5BF90C00D37921 /* TabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CB92B5BF90C00D37921 /* TabBarViewModel.swift */; };
+		84781CBE2B5BF95100D37921 /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CBD2B5BF95100D37921 /* MyPageDIContainer.swift */; };
+		84781CC02B5BF98600D37921 /* MypageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CBF2B5BF98600D37921 /* MypageViewController.swift */; };
+		84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CC12B5BF9A700D37921 /* MyPageViewModel.swift */; };
+		84781CC52B5BF9DE00D37921 /* TicketViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CC42B5BF9DE00D37921 /* TicketViewController.swift */; };
+		84781CC72B5BF9F700D37921 /* TicketDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CC62B5BF9F700D37921 /* TicketDIContainer.swift */; };
+		84781CC92B5BFA1C00D37921 /* TicketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CC82B5BFA1C00D37921 /* TicketViewModel.swift */; };
+		84781CCC2B5C003700D37921 /* ConcertDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCB2B5C003700D37921 /* ConcertDIContainer.swift */; };
+		84781CCE2B5C005600D37921 /* ConcertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCD2B5C005600D37921 /* ConcertViewController.swift */; };
+		84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCF2B5C006500D37921 /* ConcertViewModel.swift */; };
+		84781CD42B5C06EC00D37921 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CD32B5C06EC00D37921 /* AuthService.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		84781BC92B5BDAFC00D37921 /* Boolti.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Boolti.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		84781BCC2B5BDAFC00D37921 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		84781BCE2B5BDAFC00D37921 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		84781BD52B5BDAFD00D37921 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		84781BD82B5BDAFD00D37921 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		84781BDA2B5BDAFD00D37921 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		84781BE52B5BE06400D37921 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		84781BE62B5BE0BB00D37921 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
+		84781BE72B5BE17400D37921 /* Enviroment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enviroment.swift; sourceTree = "<group>"; };
+		84781BE92B5BE19900D37921 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		84781BED2B5BE3B600D37921 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		84781BEF2B5BE3C000D37921 /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
+		84781C6F2B5BEAB800D37921 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
+		84781C712B5BEAC800D37921 /* RxMoya+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxMoya+.swift"; sourceTree = "<group>"; };
+		84781C742B5BEB5600D37921 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		84781C762B5BEB8500D37921 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
+		84781C7D2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginRequestDTO.swift; sourceTree = "<group>"; };
+		84781C7F2B5BEC1400D37921 /* KakaoLoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginResponseDTO.swift; sourceTree = "<group>"; };
+		84781C812B5BEC3900D37921 /* BaseResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponseDTO.swift; sourceTree = "<group>"; };
+		84781C862B5BED9A00D37921 /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
+		84781C882B5BEDAA00D37921 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		84781C9C2B5BF68900D37921 /* RootDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootDIContainer.swift; sourceTree = "<group>"; };
+		84781C9E2B5BF6A000D37921 /* RootNavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationDelegate.swift; sourceTree = "<group>"; };
+		84781CA02B5BF6AB00D37921 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
+		84781CA22B5BF6BF00D37921 /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
+		84781CA52B5BF6F500D37921 /* SplashDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashDIContainer.swift; sourceTree = "<group>"; };
+		84781CA72B5BF71900D37921 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
+		84781CA92B5BF72200D37921 /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
+		84781CAC2B5BF7A200D37921 /* TabBarDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDIContainer.swift; sourceTree = "<group>"; };
+		84781CAE2B5BF7CA00D37921 /* HomeTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTab.swift; sourceTree = "<group>"; };
+		84781CB02B5BF85400D37921 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		84781CB92B5BF90C00D37921 /* TabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewModel.swift; sourceTree = "<group>"; };
+		84781CBD2B5BF95100D37921 /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
+		84781CBF2B5BF98600D37921 /* MypageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewController.swift; sourceTree = "<group>"; };
+		84781CC12B5BF9A700D37921 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
+		84781CC42B5BF9DE00D37921 /* TicketViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketViewController.swift; sourceTree = "<group>"; };
+		84781CC62B5BF9F700D37921 /* TicketDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDIContainer.swift; sourceTree = "<group>"; };
+		84781CC82B5BFA1C00D37921 /* TicketViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketViewModel.swift; sourceTree = "<group>"; };
+		84781CCB2B5C003700D37921 /* ConcertDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDIContainer.swift; sourceTree = "<group>"; };
+		84781CCD2B5C005600D37921 /* ConcertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertViewController.swift; sourceTree = "<group>"; };
+		84781CCF2B5C006500D37921 /* ConcertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertViewModel.swift; sourceTree = "<group>"; };
+		84781CD32B5C06EC00D37921 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		84781BC62B5BDAFC00D37921 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84781C972B5BF15A00D37921 /* RxKakaoSDKCommon in Frameworks */,
+				84781C682B5BE9C100D37921 /* RxMoya in Frameworks */,
+				84781C6B2B5BEA0000D37921 /* SnapKit in Frameworks */,
+				84781C642B5BE9C100D37921 /* Moya in Frameworks */,
+				84781C952B5BF15A00D37921 /* RxKakaoSDKAuth in Frameworks */,
+				84781C992B5BF15A00D37921 /* RxKakaoSDKUser in Frameworks */,
+				84781C662B5BE9C100D37921 /* ReactiveMoya in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		84781BC02B5BDAFC00D37921 = {
+			isa = PBXGroup;
+			children = (
+				84781BCB2B5BDAFC00D37921 /* Boolti */,
+				84781BCA2B5BDAFC00D37921 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		84781BCA2B5BDAFC00D37921 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84781BC92B5BDAFC00D37921 /* Boolti.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84781BCB2B5BDAFC00D37921 /* Boolti */ = {
+			isa = PBXGroup;
+			children = (
+				84781BE22B5BDCB900D37921 /* Application */,
+				84781BE42B5BE03600D37921 /* Support */,
+				84781BE12B5BDC9000D37921 /* Resources */,
+				84781BE02B5BDC8400D37921 /* Sources */,
+				84781BD72B5BDAFD00D37921 /* LaunchScreen.storyboard */,
+			);
+			path = Boolti;
+			sourceTree = "<group>";
+		};
+		84781BE02B5BDC8400D37921 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				84781BE32B5BDD9100D37921 /* Global */,
+				84781BEA2B5BE36100D37921 /* Network */,
+				84781C9A2B5BF4F800D37921 /* UILayer */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		84781BE12B5BDC9000D37921 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				84781BD52B5BDAFD00D37921 /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		84781BE22B5BDCB900D37921 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				84781BCC2B5BDAFC00D37921 /* AppDelegate.swift */,
+				84781BCE2B5BDAFC00D37921 /* SceneDelegate.swift */,
+				84781BDA2B5BDAFD00D37921 /* Info.plist */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		84781BE32B5BDD9100D37921 /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				84781C842B5BED3200D37921 /* Enums */,
+				84781C782B5BEBB800D37921 /* Utils */,
+				84781C6E2B5BEA9E00D37921 /* Extensions */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
+		84781BE42B5BE03600D37921 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				84781BE62B5BE0BB00D37921 /* Shared.xcconfig */,
+				84781BE52B5BE06400D37921 /* Debug.xcconfig */,
+				84781BE92B5BE19900D37921 /* Release.xcconfig */,
+				84781BE72B5BE17400D37921 /* Enviroment.swift */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+		84781BEA2B5BE36100D37921 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				84781BEB2B5BE38900D37921 /* Foundation */,
+				84781C792B5BEBDA00D37921 /* DTO */,
+				84781C852B5BED8D00D37921 /* APIs */,
+				84781CD12B5C064100D37921 /* Services */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		84781BEB2B5BE38900D37921 /* Foundation */ = {
+			isa = PBXGroup;
+			children = (
+				84781BED2B5BE3B600D37921 /* NetworkError.swift */,
+				84781BEF2B5BE3C000D37921 /* Networking.swift */,
+				84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */,
+			);
+			path = Foundation;
+			sourceTree = "<group>";
+		};
+		84781C6E2B5BEA9E00D37921 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				84781C6F2B5BEAB800D37921 /* UserDefaults+.swift */,
+				84781C712B5BEAC800D37921 /* RxMoya+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		84781C782B5BEBB800D37921 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				84781C742B5BEB5600D37921 /* UserDefaultsManager.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		84781C792B5BEBDA00D37921 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				84781C812B5BEC3900D37921 /* BaseResponseDTO.swift */,
+				84781C7A2B5BEBE500D37921 /* Auth */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		84781C7A2B5BEBE500D37921 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				84781C7B2B5BEBEA00D37921 /* Request */,
+				84781C7C2B5BEBF200D37921 /* Response */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		84781C7B2B5BEBEA00D37921 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				84781C7D2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		84781C7C2B5BEBF200D37921 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				84781C7F2B5BEC1400D37921 /* KakaoLoginResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		84781C842B5BED3200D37921 /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				84781C762B5BEB8500D37921 /* UserDefaultsKey.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
+		84781C852B5BED8D00D37921 /* APIs */ = {
+			isa = PBXGroup;
+			children = (
+				84781C862B5BED9A00D37921 /* BaseAPI.swift */,
+				84781C882B5BEDAA00D37921 /* AuthAPI.swift */,
+			);
+			path = APIs;
+			sourceTree = "<group>";
+		};
+		84781C9A2B5BF4F800D37921 /* UILayer */ = {
+			isa = PBXGroup;
+			children = (
+				84781CCA2B5C002D00D37921 /* Concert */,
+				84781CC32B5BF9C600D37921 /* Ticket */,
+				84781CBB2B5BF94100D37921 /* MyPage */,
+				84781CAB2B5BF79000D37921 /* TabBar */,
+				84781CA42B5BF6E800D37921 /* Splash */,
+				84781C9B2B5BF67E00D37921 /* Root */,
+			);
+			path = UILayer;
+			sourceTree = "<group>";
+		};
+		84781C9B2B5BF67E00D37921 /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				84781C9C2B5BF68900D37921 /* RootDIContainer.swift */,
+				84781C9E2B5BF6A000D37921 /* RootNavigationDelegate.swift */,
+				84781CA02B5BF6AB00D37921 /* RootViewController.swift */,
+				84781CA22B5BF6BF00D37921 /* RootViewModel.swift */,
+			);
+			path = Root;
+			sourceTree = "<group>";
+		};
+		84781CA42B5BF6E800D37921 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				84781CA52B5BF6F500D37921 /* SplashDIContainer.swift */,
+				84781CA72B5BF71900D37921 /* SplashViewController.swift */,
+				84781CA92B5BF72200D37921 /* SplashViewModel.swift */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
+		84781CAB2B5BF79000D37921 /* TabBar */ = {
+			isa = PBXGroup;
+			children = (
+				84781CAE2B5BF7CA00D37921 /* HomeTab.swift */,
+				84781CAC2B5BF7A200D37921 /* TabBarDIContainer.swift */,
+				84781CB02B5BF85400D37921 /* TabBarController.swift */,
+				84781CB92B5BF90C00D37921 /* TabBarViewModel.swift */,
+			);
+			path = TabBar;
+			sourceTree = "<group>";
+		};
+		84781CBB2B5BF94100D37921 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				84781CBD2B5BF95100D37921 /* MyPageDIContainer.swift */,
+				84781CBF2B5BF98600D37921 /* MypageViewController.swift */,
+				84781CC12B5BF9A700D37921 /* MyPageViewModel.swift */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		84781CC32B5BF9C600D37921 /* Ticket */ = {
+			isa = PBXGroup;
+			children = (
+				84781CC62B5BF9F700D37921 /* TicketDIContainer.swift */,
+				84781CC42B5BF9DE00D37921 /* TicketViewController.swift */,
+				84781CC82B5BFA1C00D37921 /* TicketViewModel.swift */,
+			);
+			path = Ticket;
+			sourceTree = "<group>";
+		};
+		84781CCA2B5C002D00D37921 /* Concert */ = {
+			isa = PBXGroup;
+			children = (
+				84781CCB2B5C003700D37921 /* ConcertDIContainer.swift */,
+				84781CCD2B5C005600D37921 /* ConcertViewController.swift */,
+				84781CCF2B5C006500D37921 /* ConcertViewModel.swift */,
+			);
+			path = Concert;
+			sourceTree = "<group>";
+		};
+		84781CD12B5C064100D37921 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				84781CD32B5C06EC00D37921 /* AuthService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		84781BC82B5BDAFC00D37921 /* Boolti */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 84781BDD2B5BDAFD00D37921 /* Build configuration list for PBXNativeTarget "Boolti" */;
+			buildPhases = (
+				84781BC52B5BDAFC00D37921 /* Sources */,
+				84781BC62B5BDAFC00D37921 /* Frameworks */,
+				84781BC72B5BDAFC00D37921 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Boolti;
+			packageProductDependencies = (
+				84781C632B5BE9C100D37921 /* Moya */,
+				84781C652B5BE9C100D37921 /* ReactiveMoya */,
+				84781C672B5BE9C100D37921 /* RxMoya */,
+				84781C6A2B5BEA0000D37921 /* SnapKit */,
+				84781C942B5BF15A00D37921 /* RxKakaoSDKAuth */,
+				84781C962B5BF15A00D37921 /* RxKakaoSDKCommon */,
+				84781C982B5BF15A00D37921 /* RxKakaoSDKUser */,
+			);
+			productName = Boolti;
+			productReference = 84781BC92B5BDAFC00D37921 /* Boolti.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		84781BC12B5BDAFC00D37921 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1520;
+				LastUpgradeCheck = 1520;
+				TargetAttributes = {
+					84781BC82B5BDAFC00D37921 = {
+						CreatedOnToolsVersion = 15.2;
+					};
+				};
+			};
+			buildConfigurationList = 84781BC42B5BDAFC00D37921 /* Build configuration list for PBXProject "Boolti" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 84781BC02B5BDAFC00D37921;
+			packageReferences = (
+				84781C622B5BE9C000D37921 /* XCRemoteSwiftPackageReference "Moya" */,
+				84781C692B5BEA0000D37921 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */,
+			);
+			productRefGroup = 84781BCA2B5BDAFC00D37921 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				84781BC82B5BDAFC00D37921 /* Boolti */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		84781BC72B5BDAFC00D37921 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84781BD92B5BDAFD00D37921 /* LaunchScreen.storyboard in Resources */,
+				84781BD62B5BDAFD00D37921 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		84781BC52B5BDAFC00D37921 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84781CC92B5BFA1C00D37921 /* TicketViewModel.swift in Sources */,
+				84781CCC2B5C003700D37921 /* ConcertDIContainer.swift in Sources */,
+				84781CB12B5BF85400D37921 /* TabBarController.swift in Sources */,
+				84781CD42B5C06EC00D37921 /* AuthService.swift in Sources */,
+				84781CAF2B5BF7CA00D37921 /* HomeTab.swift in Sources */,
+				84781C702B5BEAB800D37921 /* UserDefaults+.swift in Sources */,
+				84781C892B5BEDAA00D37921 /* AuthAPI.swift in Sources */,
+				84781CA12B5BF6AB00D37921 /* RootViewController.swift in Sources */,
+				84781C9F2B5BF6A000D37921 /* RootNavigationDelegate.swift in Sources */,
+				84781CA32B5BF6BF00D37921 /* RootViewModel.swift in Sources */,
+				84781BCD2B5BDAFC00D37921 /* AppDelegate.swift in Sources */,
+				84781BF02B5BE3C000D37921 /* Networking.swift in Sources */,
+				84781C9D2B5BF68900D37921 /* RootDIContainer.swift in Sources */,
+				84781C722B5BEAC800D37921 /* RxMoya+.swift in Sources */,
+				84781C802B5BEC1400D37921 /* KakaoLoginResponseDTO.swift in Sources */,
+				84781C772B5BEB8500D37921 /* UserDefaultsKey.swift in Sources */,
+				84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */,
+				84781BEE2B5BE3B600D37921 /* NetworkError.swift in Sources */,
+				84781CA82B5BF71900D37921 /* SplashViewController.swift in Sources */,
+				84781C822B5BEC3900D37921 /* BaseResponseDTO.swift in Sources */,
+				84781CAD2B5BF7A200D37921 /* TabBarDIContainer.swift in Sources */,
+				84781C752B5BEB5600D37921 /* UserDefaultsManager.swift in Sources */,
+				84781CAA2B5BF72200D37921 /* SplashViewModel.swift in Sources */,
+				84781C6D2B5BEA3800D37921 /* AuthInterceptor.swift in Sources */,
+				84781CBE2B5BF95100D37921 /* MyPageDIContainer.swift in Sources */,
+				84781BCF2B5BDAFC00D37921 /* SceneDelegate.swift in Sources */,
+				84781CBA2B5BF90C00D37921 /* TabBarViewModel.swift in Sources */,
+				84781CC72B5BF9F700D37921 /* TicketDIContainer.swift in Sources */,
+				84781CC02B5BF98600D37921 /* MypageViewController.swift in Sources */,
+				84781C7E2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift in Sources */,
+				84781CC52B5BF9DE00D37921 /* TicketViewController.swift in Sources */,
+				84781CA62B5BF6F500D37921 /* SplashDIContainer.swift in Sources */,
+				84781BE82B5BE17400D37921 /* Enviroment.swift in Sources */,
+				84781C872B5BED9A00D37921 /* BaseAPI.swift in Sources */,
+				84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */,
+				84781CCE2B5C005600D37921 /* ConcertViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		84781BD72B5BDAFD00D37921 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				84781BD82B5BDAFD00D37921 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		84781BDB2B5BDAFD00D37921 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84781BE52B5BE06400D37921 /* Debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		84781BDC2B5BDAFD00D37921 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84781BE92B5BE19900D37921 /* Release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		84781BDE2B5BDAFD00D37921 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84781BE52B5BE06400D37921 /* Debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 83B9Y749K7;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Boolti/Application/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "불티";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		84781BDF2B5BDAFD00D37921 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84781BE92B5BE19900D37921 /* Release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 83B9Y749K7;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Boolti/Application/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "불티";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		84781BC42B5BDAFC00D37921 /* Build configuration list for PBXProject "Boolti" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				84781BDB2B5BDAFD00D37921 /* Debug */,
+				84781BDC2B5BDAFD00D37921 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		84781BDD2B5BDAFD00D37921 /* Build configuration list for PBXNativeTarget "Boolti" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				84781BDE2B5BDAFD00D37921 /* Debug */,
+				84781BDF2B5BDAFD00D37921 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		84781C622B5BE9C000D37921 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+		84781C692B5BEA0000D37921 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk-rx";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		84781C632B5BE9C100D37921 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C622B5BE9C000D37921 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+		84781C652B5BE9C100D37921 /* ReactiveMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C622B5BE9C000D37921 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = ReactiveMoya;
+		};
+		84781C672B5BE9C100D37921 /* RxMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C622B5BE9C000D37921 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = RxMoya;
+		};
+		84781C6A2B5BEA0000D37921 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C692B5BEA0000D37921 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		84781C942B5BF15A00D37921 /* RxKakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKAuth;
+		};
+		84781C962B5BF15A00D37921 /* RxKakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKCommon;
+		};
+		84781C982B5BF15A00D37921 /* RxKakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKUser;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 84781BC12B5BDAFC00D37921 /* Project object */;
+}

--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,86 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
+        "version" : "5.8.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk.git",
+      "state" : {
+        "revision" : "ae3c60cbd4e3b348775f8c766e5b908fa1e66c5a",
+        "version" : "2.20.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk-rx",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
+      "state" : {
+        "branch" : "master",
+        "revision" : "4f3a1e5f17c1bb881ac00ab87c5579ed852f992b"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "branch" : "master",
+        "revision" : "963654cd4f82d17d7546b9d6127c29f6df091717"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxalamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxAlamofire.git",
+      "state" : {
+        "revision" : "9535b58695b91fb67f56d58d6fd0c76462d7743a",
+        "version" : "6.1.2"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift",
+      "state" : {
+        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "version" : "6.6.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "e74fe2a978d1216c3602b129447c7301573cc2d8",
+        "version" : "5.7.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -1,0 +1,26 @@
+//
+//  AppDelegate.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import UIKit
+import RxKakaoSDKCommon
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        RxKakaoSDK.initSDK(appKey: Environment.KAKAO_NATIVE_APP_KEY)
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) { }
+}

--- a/Boolti/Boolti/Application/Info.plist
+++ b/Boolti/Boolti/Application/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>${KAKAO_NATIVE_APP_KEY}</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao${KAKAO_NATIVE_APP_KEY}</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -1,0 +1,66 @@
+//
+//  SceneDelegate.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import UIKit
+import RxKakaoSDKAuth
+import KakaoSDKAuth
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    
+    var window: UIWindow?
+    
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
+        window?.overrideUserInterfaceStyle = .light
+        
+        let rootDIContainer = RootDIContainer()
+        let rootViewController = rootDIContainer.createRootViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.isNavigationBarHidden = true
+        window?.rootViewController = navigationController
+        window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.rx.handleOpenUrl(url: url)
+            }
+        }
+    }
+    
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+    
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}
+

--- a/Boolti/Boolti/Base.lproj/LaunchScreen.storyboard
+++ b/Boolti/Boolti/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Boolti/Boolti/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Boolti/Boolti/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boolti/Boolti/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Boolti/Boolti/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boolti/Boolti/Resources/Assets.xcassets/Contents.json
+++ b/Boolti/Boolti/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boolti/Boolti/Sources/Global/Enums/UserDefaultsKey.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/UserDefaultsKey.swift
@@ -1,0 +1,16 @@
+//
+//  UserDefaultsKey.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+enum UserDefaultsKey: String, CaseIterable {
+    case userId
+    case accessToken
+    case refreshToken
+    case deviceToken
+    case isFirstLaunch
+}

--- a/Boolti/Boolti/Sources/Global/Extensions/RxMoya+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/RxMoya+.swift
@@ -1,6 +1,6 @@
 //
 //  RxMoya+.swift
-//  DIContainer
+//  Boolti
 //
 //  Created by Juhyeon Byun on 1/20/24.
 //

--- a/Boolti/Boolti/Sources/Global/Extensions/RxMoya+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/RxMoya+.swift
@@ -1,0 +1,40 @@
+//
+//  RxMoya+.swift
+//  DIContainer
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+import Moya
+import RxSwift
+
+extension PrimitiveSequence where Trait == SingleTrait, Element == Moya.Response {
+
+    var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        return decoder
+    }
+
+    /// Wrap to common response
+    /// - Common response로 감싼 객체로 매핑해주는 메소드
+    func map<Response: Decodable>(
+        _ type: Response.Type
+    ) -> PrimitiveSequence<Trait, BaseResponseDTO<Response>> {
+        return map(BaseResponseDTO<Response>.self, using: decoder)
+    }
+
+    /// Map to pure
+    /// - Pure data로 매핑해주는 메소드
+    /// - 옵셔널 타입으로 반환합니다.
+    /*
+    - statusCode
+    - message
+    - data? <- Pure data in our service
+    */
+    func map<Response: Decodable>(
+        _ type: Response.Type
+    ) -> PrimitiveSequence<Trait, Response?> {
+        return map(Response.self).map { $0.data }
+    }
+}

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -1,0 +1,35 @@
+//
+//  RxMoya+.swift
+//  DIContainer
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    // MARK: - Properties
+    @UserDefault<Int>(key: UserDefaultsKey.userId.rawValue, defaultValue: -1)
+    static var userId
+    
+    @UserDefault<String>(key: UserDefaultsKey.accessToken.rawValue, defaultValue: "")
+    static var accessToken
+    
+    @UserDefault<String>(key: UserDefaultsKey.refreshToken.rawValue, defaultValue: "")
+    static var refreshToken
+    
+    @UserDefault<String>(key: UserDefaultsKey.deviceToken.rawValue, defaultValue: "")
+    static var deviceToken
+    
+    @UserDefault<Bool>(key: UserDefaultsKey.isFirstLaunch.rawValue, defaultValue: true)
+    static var isFirstLaunch
+    
+    // MARK: - Custom Methods
+    
+    // UserDefaults에 저장된 모든 유저 정보를 제거하는 메서드
+    func removeAllUserDefaulsKeys() {
+        UserDefaultsKey.allCases
+            .forEach { UserDefaults.standard.removeObject(forKey: $0.rawValue) }
+    }
+}

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -1,6 +1,6 @@
 //
-//  RxMoya+.swift
-//  DIContainer
+//  UserDefaults+.swift
+//  Boolti
 //
 //  Created by Juhyeon Byun on 1/20/24.
 //

--- a/Boolti/Boolti/Sources/Global/Utils/UserDefaultsManager.swift
+++ b/Boolti/Boolti/Sources/Global/Utils/UserDefaultsManager.swift
@@ -1,0 +1,26 @@
+//
+//  UserDefaultsManager.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefault<T> {
+    
+    private let key: String
+    private let defaultValue: T
+    
+    init(key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+    
+    var wrappedValue: T {
+        get { UserDefaults.standard.object(forKey: key) as? T ?? defaultValue }
+        set { UserDefaults.standard.set(newValue, forKey: key) }
+    }
+}
+

--- a/Boolti/Boolti/Sources/Network/APIs/AuthAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/AuthAPI.swift
@@ -35,4 +35,14 @@ extension AuthAPI: BaseAPI {
             return .requestJSONEncodable(requestDTO)
         }
     }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .kakaoLogin:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": UserDefaults.accessToken
+            ]
+        }
+    }
 }

--- a/Boolti/Boolti/Sources/Network/APIs/AuthAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/AuthAPI.swift
@@ -1,0 +1,38 @@
+//
+//  AuthAPI.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+import Moya
+
+enum AuthAPI {
+    // 불티 서버와 통신
+    case kakaoLogin(requestDTO: KakaoLoginRequestDTO)
+}
+
+extension AuthAPI: BaseAPI {
+
+    var path: String {
+        switch self {
+        case .kakaoLogin:
+            return "/login/kakao"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .kakaoLogin:
+            return .post
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .kakaoLogin(let requestDTO):
+            return .requestJSONEncodable(requestDTO)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/Network/APIs/BaseAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/BaseAPI.swift
@@ -11,14 +11,10 @@ import Moya
 protocol BaseAPI: TargetType { }
 
 extension BaseAPI {
+    
     var baseURL: URL {
         
         // TODO: base url 키 숨기기, 환경변수로 등록
         return URL(string: "~/app/papi/v1")!
-    }
-    
-    // token은 intercepter에서 처리함
-    var headers: [String: String]? {
-        return ["Content-Type": "application/json"]
     }
 }

--- a/Boolti/Boolti/Sources/Network/APIs/BaseAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/BaseAPI.swift
@@ -1,0 +1,24 @@
+//
+//  BaseAPI.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+import Moya
+
+protocol BaseAPI: TargetType { }
+
+extension BaseAPI {
+    var baseURL: URL {
+        
+        // TODO: base url 키 숨기기, 환경변수로 등록
+        return URL(string: "~/app/papi/v1")!
+    }
+    
+    // token은 intercepter에서 처리함
+    var headers: [String: String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Request/KakaoLoginRequestDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Request/KakaoLoginRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  KakaoLoginRequestDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+struct KakaoLoginRequestDTO: Encodable {
+    let token: String
+}

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Response/KakaoLoginResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Response/KakaoLoginResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  KakaoLoginResponseDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+struct KakaoLoginResponseDTO: Decodable {
+    let accessToken: String
+}

--- a/Boolti/Boolti/Sources/Network/DTO/BaseResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/BaseResponseDTO.swift
@@ -1,0 +1,27 @@
+//
+//  BaseResponseDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+struct BaseResponseDTO<T: Decodable>: Decodable {
+    let statusCode: Int
+    let message: String
+    let data: T?
+    
+    enum CodingKeys: CodingKey {
+        case statusCode
+        case message
+        case data
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.statusCode = (try? container.decode(Int.self, forKey: .statusCode)) ?? 500
+        self.message = (try? container.decode(String.self, forKey: .message)) ?? ""
+        self.data = try container.decodeIfPresent(T.self, forKey: .data)
+    }
+}

--- a/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
@@ -17,9 +17,7 @@ final class AuthInterceptor: RequestInterceptor {
                for session: Session,
                completion: @escaping (Result<URLRequest, Error>) -> Void) {
         
-        // 모든 경로에 access token 넣음
         var urlRequest = urlRequest
-        urlRequest.headers.add(.authorization(bearerToken: UserDefaults.accessToken))
         
         // refesh 재발급 경로면 refresh token을 넣음
         if let urlString = urlRequest.url?.absoluteString, urlString.hasSuffix("/refeshToken") {

--- a/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 import RxSwift
 
-final class NetworkIntercepter: RequestInterceptor {
+final class AuthInterceptor: RequestInterceptor {
     
     private let disposeBag = DisposeBag()
  

--- a/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
@@ -1,0 +1,59 @@
+//
+//  AuthInterceptor.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+import Alamofire
+import RxSwift
+
+final class NetworkIntercepter: RequestInterceptor {
+    
+    private let disposeBag = DisposeBag()
+ 
+    func adapt(_ urlRequest: URLRequest,
+               for session: Session,
+               completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        
+        // 모든 경로에 access token 넣음
+        var urlRequest = urlRequest
+        urlRequest.headers.add(.authorization(bearerToken: UserDefaults.accessToken))
+        
+        // refesh 재발급 경로면 refresh token을 넣음
+        if let urlString = urlRequest.url?.absoluteString, urlString.hasSuffix("/refeshToken") {
+            urlRequest.headers.add(.authorization(bearerToken: UserDefaults.refreshToken))
+        }
+        completion(.success(urlRequest))
+    }
+    
+    func retry(_ request: Request,
+               for _: Session,
+               dueTo error: Error,
+               completion: @escaping (RetryResult) -> Void) {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
+        else {
+            completion(.doNotRetryWithError(error))
+            return
+        }
+        
+        // 리프레시 요청 response의 statusCdoe가 401이면 재요청 하지 않음
+        if let urlString = response.url?.absoluteString, urlString.hasSuffix("/refeshToken") {
+            completion(.doNotRetry)
+            return
+        }
+        
+        // 토큰 재발급 요청 (401일 떄)
+//        ReissueAPIService.shared.reissueAuthentication()
+//            .subscribe(onSuccess: { result in
+//              // userdefault에 새로 저장
+//                completion(.retry)
+//            }, onFailure: { error in
+//                // refreshToken 만료 시 로그인 화면으로 전환
+//                NotificationCenter.default.post(name: NotificationCenterKey.refreshTokenHasExpired, object: nil)
+//                completion(.doNotRetryWithError(error))
+//            })
+//            .disposed(by: disposeBag)
+    }
+}

--- a/Boolti/Boolti/Sources/Network/Foundation/NetworkError.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/NetworkError.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkError.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+enum NetworkError: Int {
+    case invalidRequest = 400
+    case unauthorized   = 401
+    case forbidden      = 403
+    case notFound       = 404
+    case duplicated     = 409
+    case serverError    = 500
+}

--- a/Boolti/Boolti/Sources/Network/Foundation/Networking.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/Networking.swift
@@ -1,0 +1,63 @@
+//
+//  Networking.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import RxSwift
+import RxMoya
+import Moya
+
+protocol Networking {
+    associatedtype API: BaseAPI
+    
+    func request(_ api: API, file: StaticString, function: StaticString, line: UInt) -> Single<Response>
+}
+
+extension Networking {
+    
+    func request(
+        _ api: API,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> Single<Response> {
+        self.request(api, file: file, function: function, line: line)
+    }
+}
+
+final class NetworkProvider<API: BaseAPI>: Networking {
+
+    private let provider: MoyaProvider<API>
+    
+    init(plugins: [PluginType] = []) {
+        let session = Session(interceptor: NetworkIntercepter())
+        session.sessionConfiguration.timeoutIntervalForRequest = 10
+     
+        self.provider = MoyaProvider<API>(session: session, plugins: plugins)
+    }
+    
+    func request(
+        _ api: API,
+        file: StaticString = #file,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> Single<Response> {
+        let requestString = "\(api.path)"
+        return provider.rx.request(api)
+            .filterSuccessfulStatusCodes()
+            .do(
+                onSuccess: { response in
+                    print("SUCCESS: \(requestString) (\(response.statusCode))")
+                },
+                onError: { _ in
+                    print("ERROR: \(requestString)")
+                },
+                onSubscribed: {
+                    print("REQUEST: \(requestString)")
+                }
+            )
+    }
+}
+

--- a/Boolti/Boolti/Sources/Network/Foundation/Networking.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/Networking.swift
@@ -32,7 +32,7 @@ final class NetworkProvider<API: BaseAPI>: Networking {
     private let provider: MoyaProvider<API>
     
     init(plugins: [PluginType] = []) {
-        let session = Session(interceptor: NetworkIntercepter())
+        let session = Session(interceptor: AuthInterceptor())
         session.sessionConfiguration.timeoutIntervalForRequest = 10
      
         self.provider = MoyaProvider<API>(session: session, plugins: plugins)

--- a/Boolti/Boolti/Sources/Network/Services/AuthService.swift
+++ b/Boolti/Boolti/Sources/Network/Services/AuthService.swift
@@ -12,12 +12,20 @@ import RxCocoa
 import RxSwift
 
 protocol AuthAPIServiceType {
-//    func login() -> Single<Void>
+    func login(accessToken: String) -> Single<KakaoLoginResponseDTO>
 }
 
-final class AuthService: Networking, AuthAPIServiceType {
+final class AuthService: AuthAPIServiceType {
     
-    typealias API = AuthAPI
+    private typealias API = AuthAPI
+    private let provider: NetworkProvider
     
-    private let provider = NetworkProvider<API>()
+    init(provider: NetworkProvider) {
+        self.provider = provider
+    }
+    
+    func login(accessToken: String) -> Single<KakaoLoginResponseDTO> {
+        return provider.request(API.kakaoLogin(requestDTO: KakaoLoginRequestDTO(token: accessToken)))
+            .map(KakaoLoginResponseDTO.self)
+    }
 }

--- a/Boolti/Boolti/Sources/Network/Services/AuthService.swift
+++ b/Boolti/Boolti/Sources/Network/Services/AuthService.swift
@@ -1,0 +1,23 @@
+//
+//  AuthService.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+import Moya
+import RxCocoa
+import RxSwift
+
+protocol AuthAPIServiceType {
+//    func login() -> Single<Void>
+}
+
+final class AuthService: Networking, AuthAPIServiceType {
+    
+    typealias API = AuthAPI
+    
+    private let provider = NetworkProvider<API>()
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDIContainer.swift
@@ -1,0 +1,15 @@
+//
+//  ConcertDIContainer.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+final class ConcertDIContainer {
+
+    func createConcertViewController() -> ConcertViewController {
+        return ConcertViewController()
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertViewController.swift
@@ -1,0 +1,18 @@
+//
+//  ConcertViewController.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import UIKit
+
+final class ConcertViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // TODO: 화면 넘어가는 거 확인용. 나중에 지워야함!
+        self.view.backgroundColor = .yellow
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  ConcertViewModel.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+final class ConcertViewModel {
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/MyPageDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/MyPageDIContainer.swift
@@ -1,0 +1,15 @@
+//
+//  MyPageDIContainer.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class MyPageDIContainer {
+
+    func createMyPageViewController() -> MyPageViewController {
+        return MyPageViewController()
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/MyPageViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/MyPageViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  MyPageViewModel.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+final class MyPageViewModel {
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/MypageViewController.swift
@@ -1,0 +1,18 @@
+//
+//  MyPageViewController.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+
+final class MyPageViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // TODO: 화면 넘어가는 거 확인용. 나중에 지워야함!
+        self.view.backgroundColor = .blue
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -1,0 +1,43 @@
+//
+//  RootDIContainer.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class RootDIContainer {
+
+    let rootViewModel: RootViewModel
+
+    init() {
+        self.rootViewModel = RootViewModel()
+    }
+
+    func createRootViewController() -> RootViewController {
+        let splashViewControllerFactory: () -> SplashViewController = {
+            let DIContainer = self.createSplashDIContainer()
+            return DIContainer.createSplashViewController()
+        }
+
+        let tabBarControllerFactory: () -> TabBarController = {
+            let DIContainer = self.createHomeDIContainer()
+            return DIContainer.createTabBarController()
+        }
+
+        return RootViewController(
+            viewModel: rootViewModel,
+            splashViewControllerFactory: splashViewControllerFactory,
+            tabBarControllerFactory: tabBarControllerFactory
+        )
+    }
+
+    private func createSplashDIContainer() -> SplashDIContainer {
+        return SplashDIContainer(rootDIContainer: self)
+    }
+
+    private func createHomeDIContainer() -> TabBarDIContainer {
+        return TabBarDIContainer(rootDIContainer: self)
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -9,10 +9,12 @@ import Foundation
 
 final class RootDIContainer {
 
-    let rootViewModel: RootViewModel
+    private let rootViewModel: RootViewModel
+    private let networkProvider: NetworkProvider
 
     init() {
         self.rootViewModel = RootViewModel()
+        self.networkProvider = NetworkProvider()
     }
 
     func createRootViewController() -> RootViewController {
@@ -22,7 +24,7 @@ final class RootDIContainer {
         }
 
         let tabBarControllerFactory: () -> TabBarController = {
-            let DIContainer = self.createHomeDIContainer()
+            let DIContainer = self.createTabBarDIContainer()
             return DIContainer.createTabBarController()
         }
 
@@ -34,10 +36,10 @@ final class RootDIContainer {
     }
 
     private func createSplashDIContainer() -> SplashDIContainer {
-        return SplashDIContainer(rootDIContainer: self)
+        return SplashDIContainer(rootDIContainer: self, networkProvider: networkProvider)
     }
 
-    private func createHomeDIContainer() -> TabBarDIContainer {
+    private func createTabBarDIContainer() -> TabBarDIContainer {
         return TabBarDIContainer(rootDIContainer: self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootNavigationDelegate.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootNavigationDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  RootNavigationDelegate.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+protocol SplashViewControllerDelegate {
+    func splashViewController(_ didSplashViewDismissed: SplashViewModel)
+}

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -38,13 +38,13 @@ final class RootViewController: UIViewController {
         let splashDuration: DispatchTimeInterval = .seconds(2)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + splashDuration) { [weak self] in
-//            let splashViewController = self?.splashViewControllerFactory() ?? UIViewController()
-//            self?.navigationController?.pushViewController(splashViewController, animated: true)
+            let splashViewController = self?.splashViewControllerFactory() ?? UIViewController()
+            self?.navigationController?.pushViewController(splashViewController, animated: true)
             
-            let tabBarController = self?.tabBarControllerFactory() ?? UITabBarController()
-            tabBarController.modalTransitionStyle = .crossDissolve
-            tabBarController.modalPresentationStyle = .overFullScreen
-            self?.present(tabBarController, animated: true)
+//            let tabBarController = self?.tabBarControllerFactory() ?? UITabBarController()
+//            tabBarController.modalTransitionStyle = .crossDissolve
+//            tabBarController.modalPresentationStyle = .overFullScreen
+//            self?.present(tabBarController, animated: true)
         }
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -1,0 +1,70 @@
+//
+//  RootViewController.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+
+final class RootViewController: UIViewController {
+
+    private let viewModel: RootViewModel
+    private let splashViewControllerFactory: () -> SplashViewController
+    private let tabBarControllerFactory: () -> TabBarController
+    
+    init(
+        viewModel: RootViewModel,
+        splashViewControllerFactory: @escaping () -> SplashViewController,
+        tabBarControllerFactory: @escaping () -> TabBarController
+    ) {
+        self.viewModel = viewModel
+        self.splashViewControllerFactory = splashViewControllerFactory
+        self.tabBarControllerFactory = tabBarControllerFactory
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // TODO: 화면 넘어가는 거 확인용. 나중에 지워야함!
+        self.view.backgroundColor = .red
+        
+        let splashDuration: DispatchTimeInterval = .seconds(2)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + splashDuration) { [weak self] in
+//            let splashViewController = self?.splashViewControllerFactory() ?? UIViewController()
+//            self?.navigationController?.pushViewController(splashViewController, animated: true)
+            
+            let tabBarController = self?.tabBarControllerFactory() ?? UITabBarController()
+            tabBarController.modalTransitionStyle = .crossDissolve
+            tabBarController.modalPresentationStyle = .overFullScreen
+            self?.present(tabBarController, animated: true)
+        }
+    }
+
+}
+
+extension RootViewController: SplashViewControllerDelegate {
+
+    func splashViewController(_ didSplashViewDismissed: SplashViewModel) {
+    }
+    // TODO: Delegate을 활용해서 Splash View -> RootView -> TabBar로 넘어가는 로직 구현할 예정!
+
+        // HomeTab으로 navigate하기!..
+//        if let presentedViewController = self.presentedViewController {
+//            presentedViewController.dismiss(animated: false, completion: { [weak self] in
+//                viewController.modalPresentationStyle = .fullScreen
+//                self?.present(viewController, animated: animated, completion: nil)
+//            })
+//        } else {
+//            viewController.modalPresentationStyle = .fullScreen
+//            self.present(viewController, animated: animated, completion: nil)
+//        }
+//    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  RootViewModel.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class RootViewModel {
+
+}

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
@@ -1,0 +1,29 @@
+//
+//  SplashDIContainer.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class SplashDIContainer {
+
+    let rootDIContainer: RootDIContainer
+
+    init(rootDIContainer: RootDIContainer) {
+        self.rootDIContainer = rootDIContainer
+    }
+
+    func createSplashViewController() -> SplashViewController {
+        let viewController = SplashViewController(viewModel: createSplashViewModel())
+        return viewController
+    }
+
+    private func createSplashViewModel() -> SplashViewModel {
+        // TODO: 네트워크 의존성 주입하는 방법임!! 나중에 지워야함!
+        let viewModel = SplashViewModel(networkService: AuthService())
+
+        return viewModel
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
@@ -9,10 +9,12 @@ import Foundation
 
 final class SplashDIContainer {
 
-    let rootDIContainer: RootDIContainer
+    private let rootDIContainer: RootDIContainer
+    private let networkProvider: NetworkProvider
 
-    init(rootDIContainer: RootDIContainer) {
+    init(rootDIContainer: RootDIContainer, networkProvider: NetworkProvider) {
         self.rootDIContainer = rootDIContainer
+        self.networkProvider = networkProvider
     }
 
     func createSplashViewController() -> SplashViewController {
@@ -22,7 +24,7 @@ final class SplashDIContainer {
 
     private func createSplashViewModel() -> SplashViewModel {
         // TODO: 네트워크 의존성 주입하는 방법임!! 나중에 지워야함!
-        let viewModel = SplashViewModel(networkService: AuthService())
+        let viewModel = SplashViewModel(networkService: AuthService(provider: networkProvider))
 
         return viewModel
     }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewController.swift
@@ -1,0 +1,45 @@
+//
+//  SplashViewController.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+
+final class SplashViewController: UIViewController {
+
+    // 여기서 Token이 있는 지 확인해서
+    // 아예 AuthenticationRepository에 Home에서 해당 Token을 넣어주는 것도 좋을 듯
+    // Authentication은 프로퍼티로 토큰을 갖고!..
+
+    private let viewModel: SplashViewModel
+    
+    init(viewModel: SplashViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // TODO: 화면 넘어가는 거 확인용. 나중에 지워야함!
+        self.view.backgroundColor = .orange
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        let splashDuration: DispatchTimeInterval = .seconds(2)
+
+        // TODO: Delegate을 활용해서 Splash View -> RootView -> TabBar로 넘어가는 로직 구현할 예정!
+        DispatchQueue.main.asyncAfter(deadline: .now() + splashDuration) { [weak self] in
+            // ViewModel의 메소드를 실행시킨다.
+
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  SplashViewModel.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class SplashViewModel {
+    
+    private let networkService: AuthService
+
+    init(networkService: AuthService) {
+        self.networkService = networkService
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTab.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTab.swift
@@ -1,0 +1,53 @@
+//
+//  HomeTab.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+
+enum HomeTab: Int, CaseIterable {
+    case concert
+    case ticket
+    case myPage
+}
+
+extension HomeTab: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .concert: return "공연 리스트"
+        case .ticket: return "티켓 내역"
+        case .myPage: return "마이 페이지"
+        }
+    }
+}
+
+extension HomeTab {
+
+    var icon: UIImage? {
+        switch self {
+        case .concert: return UIImage(named: "공연 리스트")
+        case .ticket: return UIImage(named: "티켓 내역")
+        case .myPage: return UIImage(named: "마이 페이지")
+        }
+    }
+
+    var tag: Int {
+        switch self {
+        case .concert: return 0
+        case .ticket: return 1
+        case .myPage: return 2
+        }
+    }
+}
+
+extension HomeTab {
+    func asTabBarItem() -> UITabBarItem {
+        return UITabBarItem(
+            title: description,
+            image: icon,
+            tag: tag
+        )
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/TabBar/TabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/TabBarController.swift
@@ -1,0 +1,69 @@
+//
+//  TabBarController.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+import RxSwift
+
+final class TabBarController: UITabBarController {
+
+    private let viewModel: TabBarViewModel
+    private let viewControllerFactory: (HomeTab) -> UIViewController
+    private let disposeBag = DisposeBag()
+
+    init(
+        viewModel: TabBarViewModel,
+        viewControllerFactory: @escaping (HomeTab) -> UIViewController
+    ) {
+        self.viewModel = viewModel
+        self.viewControllerFactory = viewControllerFactory
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bind()
+    }
+
+    private func bind() {
+
+        self.rx.didSelect.distinctUntilChanged()
+            .map { [weak self] selected in self?.viewControllers?.firstIndex(where: { selected === $0 }) }
+            .compactMap { $0 }
+            .subscribe(onNext: { [weak self] in
+                self?.viewModel.selectTab(index: $0)
+            })
+            .disposed(by: disposeBag)
+
+        viewModel.tabItems.distinctUntilChanged()
+            .subscribe( onNext: { [weak self] tabItems in
+                guard let self = self else { return }
+                let viewControllers = tabItems.map { tabItem -> UIViewController in
+                    let viewController = self.viewControllerFactory(tabItem)
+                    return viewController
+                }
+                self.setViewControllers(viewControllers, animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        viewModel.currentTab.distinctUntilChanged()
+            .map { $0.rawValue }
+            .filter { [weak self] currentTab in
+                let isVaildTab = currentTab < self?.viewControllers?.count ?? 0
+                let isNotSameTab = currentTab != self?.selectedIndex
+                return isVaildTab && isNotSameTab
+            }.subscribe(onNext: { [weak self] selectedIndex in
+                self?.selectedIndex = selectedIndex
+            })
+            .disposed(by: disposeBag)
+    }
+
+
+}

--- a/Boolti/Boolti/Sources/UILayer/TabBar/TabBarDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/TabBarDIContainer.swift
@@ -11,7 +11,7 @@ final class TabBarDIContainer {
 
     // TODO: 아래의 의존성은 다시 설정할 예정
 
-    let rootDIContainer: RootDIContainer
+    private let rootDIContainer: RootDIContainer
 
     init(rootDIContainer: RootDIContainer) {
         self.rootDIContainer = rootDIContainer

--- a/Boolti/Boolti/Sources/UILayer/TabBar/TabBarDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/TabBarDIContainer.swift
@@ -1,0 +1,62 @@
+//
+//  TabBarDIContainer.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+
+final class TabBarDIContainer {
+
+    // TODO: 아래의 의존성은 다시 설정할 예정
+
+    let rootDIContainer: RootDIContainer
+
+    init(rootDIContainer: RootDIContainer) {
+        self.rootDIContainer = rootDIContainer
+    }
+
+    func createTabBarController() -> TabBarController {
+        return TabBarController(
+        viewModel: createTabBarViewModel(),
+        viewControllerFactory: createViewController(of:)
+        )
+    }
+
+    private func createTabBarViewModel() -> TabBarViewModel {
+        return TabBarViewModel()
+    }
+
+
+    private func createViewController(of tab: HomeTab) -> UIViewController {
+        let viewController: UIViewController
+        switch tab {
+        case .concert:
+            let dependencyContainer = createConcertDIContainer()
+            viewController = dependencyContainer.createConcertViewController()
+        case .ticket:
+            let dependencyContainer = createTicketDIContainer()
+            viewController = dependencyContainer.createTicketViewController()
+        case .myPage:
+            let dependencyContainer = createMyPageDIContainer()
+            viewController = dependencyContainer.createMyPageViewController()
+        }
+
+        viewController.tabBarItem = tab.asTabBarItem()
+        return viewController
+    }
+
+    private func createConcertDIContainer() -> ConcertDIContainer {
+        return ConcertDIContainer()
+    }
+
+    private func createTicketDIContainer() -> TicketDIContainer {
+        return TicketDIContainer()
+    }
+
+    private func createMyPageDIContainer() -> MyPageDIContainer {
+        return MyPageDIContainer()
+    }
+
+}

--- a/Boolti/Boolti/Sources/UILayer/TabBar/TabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/TabBarViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  TabBarViewModel.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+
+final class TabBarViewModel {
+
+    let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
+    let currentTab = PublishRelay<HomeTab>()
+
+    func selectTab(index: Int) {
+        guard let selectedTab = HomeTab(rawValue: index) else { return }
+        currentTab.accept(selectedTab)
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDIContainer.swift
@@ -1,0 +1,15 @@
+//
+//  TicketDIContainer.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class TicketDIContainer {
+
+    func createTicketViewController() -> TicketViewController {
+        return TicketViewController()
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketViewController.swift
@@ -1,0 +1,18 @@
+//
+//  TicketViewController.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import UIKit
+
+final class TicketViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // TODO: 화면 넘어가는 거 확인용. 나중에 지워야함!
+        self.view.backgroundColor = .green
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  TicketViewModel.swift
+//  Boolti
+//
+//  Created by Miro on 1/20/24.
+//
+
+import Foundation
+
+final class TicketViewModel {
+    
+    // TODO: 토큰 여부 확인 후 로그인 뷰로 이동
+}

--- a/Boolti/Boolti/Support/Enviroment.swift
+++ b/Boolti/Boolti/Support/Enviroment.swift
@@ -1,0 +1,47 @@
+//
+//  Enviroment.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 1/20/24.
+//
+
+import Foundation
+
+enum Environment: String {
+    case debug = "debug"
+    case release = "release"
+    
+    enum Keys {
+        enum Plist {
+            static let baseURL = "BASE_URL"
+            static let kakaoNativeAppKey = "KAKAO_NATIVE_APP_KEY"
+        }
+    }
+    
+    static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else { fatalError() }
+        return dict
+    }()
+    
+    static let BASE_URL: String = {
+        guard let string = Environment.infoDictionary[Keys.Plist.baseURL] as? String else {
+            fatalError("Base URL not set in plist for this environment")
+        }
+        return string
+    }()
+    
+    static let KAKAO_NATIVE_APP_KEY: String = {
+        guard let string = Environment.infoDictionary[Keys.Plist.kakaoNativeAppKey] as? String else {
+            fatalError("KAKAO_NATIVE_APP_KEY not set in plist for this environment")
+        }
+        return string
+    }()
+}
+
+func env() -> Environment {
+    #if DEBUG
+    return .debug
+    #elseif RELEASE
+    return .release
+    #endif
+}


### PR DESCRIPTION
## 작업한 내용
- 이전 레포에서 용재가 올려준 코드를 바탕으로 네트워크 베이스 코드를 작성했어요.
  - 레포에 gitignore 이슈가 있어서 새로 레포를 생성했어요 ..

> App
- debug와 release 환경을 분리해뒀어요.
- Support 폴더에 총 3개의 xcconfig 파일이 들어갈 거예요. -> 디스코드로 공유할게요!
  - Shared.xcconfig
  - Debug.xcconfig
  - Release.xcconfig
  - UserDefaults를 사용하기 쉽게 `extension`, `wrapper`, `enum` 을 활용해서 만들었어요.
  - kakao app key를 넣어두었어요.

> Scene
- 용재가 작성한 DI Container 코드를 넣었어요!
- Home -> TabBar로 네이밍을 변경했어요.
- Root -> Splash -> TabBar로 넘어가는 부분을 확인했어요!
  - viewDidLoad에 backgroundColor를 지정해서 확인했어요.

> Network
- network provider에 MultiTarget을 사용하려고 했는데, Service쪽 코드가 애매해져서 일단 이렇게 진행할게요!
  - MultiTarget으로 바꿀 수 있는 방법을 더 고민해볼게요 🙆🏻‍♀️
- AuthInterceptor를 작성했어요.
  - 모든 경로의 request의 header에 token을 넣어요.
  - accessToken을 붙여 보낸 요청의 response가 401을 반환할 시 토큰 재발급을 요청해요.

## 관련 이슈
- Resolved: #1 
