### PR TITLE
Feat/#7 navigation

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		84781C6D2B5BEA3800D37921 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */; };
 		84781C702B5BEAB800D37921 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C6F2B5BEAB800D37921 /* UserDefaults+.swift */; };
 		84781C722B5BEAC800D37921 /* RxMoya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C712B5BEAC800D37921 /* RxMoya+.swift */; };
-		84781C752B5BEB5600D37921 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C742B5BEB5600D37921 /* UserDefaultsManager.swift */; };
+		84781C752B5BEB5600D37921 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C742B5BEB5600D37921 /* UserDefault.swift */; };
 		84781C772B5BEB8500D37921 /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C762B5BEB8500D37921 /* UserDefaultsKey.swift */; };
 		84781C7E2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C7D2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift */; };
 		84781C802B5BEC1400D37921 /* KakaoLoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781C7F2B5BEC1400D37921 /* KakaoLoginResponseDTO.swift */; };
@@ -38,10 +38,10 @@
 		84781CA62B5BF6F500D37921 /* SplashDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA52B5BF6F500D37921 /* SplashDIContainer.swift */; };
 		84781CA82B5BF71900D37921 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA72B5BF71900D37921 /* SplashViewController.swift */; };
 		84781CAA2B5BF72200D37921 /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CA92B5BF72200D37921 /* SplashViewModel.swift */; };
-		84781CAD2B5BF7A200D37921 /* TabBarDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CAC2B5BF7A200D37921 /* TabBarDIContainer.swift */; };
+		84781CAD2B5BF7A200D37921 /* HomeTabBarDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CAC2B5BF7A200D37921 /* HomeTabBarDIContainer.swift */; };
 		84781CAF2B5BF7CA00D37921 /* HomeTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CAE2B5BF7CA00D37921 /* HomeTab.swift */; };
-		84781CB12B5BF85400D37921 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CB02B5BF85400D37921 /* TabBarController.swift */; };
-		84781CBA2B5BF90C00D37921 /* TabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CB92B5BF90C00D37921 /* TabBarViewModel.swift */; };
+		84781CB12B5BF85400D37921 /* HomeTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CB02B5BF85400D37921 /* HomeTabBarController.swift */; };
+		84781CBA2B5BF90C00D37921 /* HomeTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CB92B5BF90C00D37921 /* HomeTabBarViewModel.swift */; };
 		84781CBE2B5BF95100D37921 /* MyPageDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CBD2B5BF95100D37921 /* MyPageDIContainer.swift */; };
 		84781CC02B5BF98600D37921 /* MypageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CBF2B5BF98600D37921 /* MypageViewController.swift */; };
 		84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CC12B5BF9A700D37921 /* MyPageViewModel.swift */; };
@@ -51,12 +51,14 @@
 		84781CCC2B5C003700D37921 /* ConcertDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCB2B5C003700D37921 /* ConcertDIContainer.swift */; };
 		84781CCE2B5C005600D37921 /* ConcertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCD2B5C005600D37921 /* ConcertViewController.swift */; };
 		84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCF2B5C006500D37921 /* ConcertViewModel.swift */; };
-		84781CD42B5C06EC00D37921 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CD32B5C06EC00D37921 /* AuthService.swift */; };
+		84781CD42B5C06EC00D37921 /* AuthAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CD32B5C06EC00D37921 /* AuthAPIService.swift */; };
 		87101EF32B5DF685004BD418 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF02B5DF685004BD418 /* Debug.xcconfig */; };
 		87101EF42B5DF685004BD418 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF12B5DF685004BD418 /* Release.xcconfig */; };
 		87101EF52B5DF685004BD418 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF22B5DF685004BD418 /* Shared.xcconfig */; };
 		87101EF72B5DF8FE004BD418 /* RootDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EF62B5DF8FE004BD418 /* RootDestination.swift */; };
 		87101EFA2B5DF9A3004BD418 /* RxAppState in Frameworks */ = {isa = PBXBuildFile; productRef = 87101EF92B5DF9A3004BD418 /* RxAppState */; };
+		87101EFC2B5DFC60004BD418 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EFB2B5DFC60004BD418 /* NetworkProvider.swift */; };
+		87101EFE2B5DFCD2004BD418 /* AuthAPIServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EFD2B5DFCD2004BD418 /* AuthAPIServiceType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,7 +74,7 @@
 		84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		84781C6F2B5BEAB800D37921 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		84781C712B5BEAC800D37921 /* RxMoya+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxMoya+.swift"; sourceTree = "<group>"; };
-		84781C742B5BEB5600D37921 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		84781C742B5BEB5600D37921 /* UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefault.swift; sourceTree = "<group>"; };
 		84781C762B5BEB8500D37921 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		84781C7D2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginRequestDTO.swift; sourceTree = "<group>"; };
 		84781C7F2B5BEC1400D37921 /* KakaoLoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginResponseDTO.swift; sourceTree = "<group>"; };
@@ -86,10 +88,10 @@
 		84781CA52B5BF6F500D37921 /* SplashDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashDIContainer.swift; sourceTree = "<group>"; };
 		84781CA72B5BF71900D37921 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		84781CA92B5BF72200D37921 /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
-		84781CAC2B5BF7A200D37921 /* TabBarDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDIContainer.swift; sourceTree = "<group>"; };
+		84781CAC2B5BF7A200D37921 /* HomeTabBarDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabBarDIContainer.swift; sourceTree = "<group>"; };
 		84781CAE2B5BF7CA00D37921 /* HomeTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTab.swift; sourceTree = "<group>"; };
-		84781CB02B5BF85400D37921 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
-		84781CB92B5BF90C00D37921 /* TabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewModel.swift; sourceTree = "<group>"; };
+		84781CB02B5BF85400D37921 /* HomeTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabBarController.swift; sourceTree = "<group>"; };
+		84781CB92B5BF90C00D37921 /* HomeTabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabBarViewModel.swift; sourceTree = "<group>"; };
 		84781CBD2B5BF95100D37921 /* MyPageDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDIContainer.swift; sourceTree = "<group>"; };
 		84781CBF2B5BF98600D37921 /* MypageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewController.swift; sourceTree = "<group>"; };
 		84781CC12B5BF9A700D37921 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
@@ -99,11 +101,13 @@
 		84781CCB2B5C003700D37921 /* ConcertDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDIContainer.swift; sourceTree = "<group>"; };
 		84781CCD2B5C005600D37921 /* ConcertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertViewController.swift; sourceTree = "<group>"; };
 		84781CCF2B5C006500D37921 /* ConcertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertViewModel.swift; sourceTree = "<group>"; };
-		84781CD32B5C06EC00D37921 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		84781CD32B5C06EC00D37921 /* AuthAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIService.swift; sourceTree = "<group>"; };
 		87101EF02B5DF685004BD418 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = "../../../../Boolti-File/Debug.xcconfig"; sourceTree = "<group>"; };
 		87101EF12B5DF685004BD418 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = "../../../../Boolti-File/Release.xcconfig"; sourceTree = "<group>"; };
 		87101EF22B5DF685004BD418 /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = "../../../../Boolti-File/Shared.xcconfig"; sourceTree = "<group>"; };
 		87101EF62B5DF8FE004BD418 /* RootDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootDestination.swift; sourceTree = "<group>"; };
+		87101EFB2B5DFC60004BD418 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
+		87101EFD2B5DFCD2004BD418 /* AuthAPIServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIServiceType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -219,6 +223,7 @@
 				84781BED2B5BE3B600D37921 /* NetworkError.swift */,
 				84781BEF2B5BE3C000D37921 /* Networking.swift */,
 				84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */,
+				87101EFB2B5DFC60004BD418 /* NetworkProvider.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -235,7 +240,7 @@
 		84781C782B5BEBB800D37921 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				84781C742B5BEB5600D37921 /* UserDefaultsManager.swift */,
+				84781C742B5BEB5600D37921 /* UserDefault.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -330,9 +335,9 @@
 			isa = PBXGroup;
 			children = (
 				84781CAE2B5BF7CA00D37921 /* HomeTab.swift */,
-				84781CAC2B5BF7A200D37921 /* TabBarDIContainer.swift */,
-				84781CB02B5BF85400D37921 /* TabBarController.swift */,
-				84781CB92B5BF90C00D37921 /* TabBarViewModel.swift */,
+				84781CAC2B5BF7A200D37921 /* HomeTabBarDIContainer.swift */,
+				84781CB02B5BF85400D37921 /* HomeTabBarController.swift */,
+				84781CB92B5BF90C00D37921 /* HomeTabBarViewModel.swift */,
 			);
 			path = TabBar;
 			sourceTree = "<group>";
@@ -370,7 +375,8 @@
 		84781CD12B5C064100D37921 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				84781CD32B5C06EC00D37921 /* AuthService.swift */,
+				84781CD32B5C06EC00D37921 /* AuthAPIService.swift */,
+				87101EFD2B5DFCD2004BD418 /* AuthAPIServiceType.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -467,8 +473,8 @@
 				87101EF72B5DF8FE004BD418 /* RootDestination.swift in Sources */,
 				84781CC92B5BFA1C00D37921 /* TicketViewModel.swift in Sources */,
 				84781CCC2B5C003700D37921 /* ConcertDIContainer.swift in Sources */,
-				84781CB12B5BF85400D37921 /* TabBarController.swift in Sources */,
-				84781CD42B5C06EC00D37921 /* AuthService.swift in Sources */,
+				84781CB12B5BF85400D37921 /* HomeTabBarController.swift in Sources */,
+				84781CD42B5C06EC00D37921 /* AuthAPIService.swift in Sources */,
 				84781CAF2B5BF7CA00D37921 /* HomeTab.swift in Sources */,
 				84781C702B5BEAB800D37921 /* UserDefaults+.swift in Sources */,
 				84781C892B5BEDAA00D37921 /* AuthAPI.swift in Sources */,
@@ -484,14 +490,16 @@
 				84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */,
 				84781BEE2B5BE3B600D37921 /* NetworkError.swift in Sources */,
 				84781CA82B5BF71900D37921 /* SplashViewController.swift in Sources */,
+				87101EFE2B5DFCD2004BD418 /* AuthAPIServiceType.swift in Sources */,
 				84781C822B5BEC3900D37921 /* BaseResponseDTO.swift in Sources */,
-				84781CAD2B5BF7A200D37921 /* TabBarDIContainer.swift in Sources */,
-				84781C752B5BEB5600D37921 /* UserDefaultsManager.swift in Sources */,
+				84781CAD2B5BF7A200D37921 /* HomeTabBarDIContainer.swift in Sources */,
+				84781C752B5BEB5600D37921 /* UserDefault.swift in Sources */,
 				84781CAA2B5BF72200D37921 /* SplashViewModel.swift in Sources */,
 				84781C6D2B5BEA3800D37921 /* AuthInterceptor.swift in Sources */,
 				84781CBE2B5BF95100D37921 /* MyPageDIContainer.swift in Sources */,
 				84781BCF2B5BDAFC00D37921 /* SceneDelegate.swift in Sources */,
-				84781CBA2B5BF90C00D37921 /* TabBarViewModel.swift in Sources */,
+				87101EFC2B5DFC60004BD418 /* NetworkProvider.swift in Sources */,
+				84781CBA2B5BF90C00D37921 /* HomeTabBarViewModel.swift in Sources */,
 				84781CC72B5BF9F700D37921 /* TicketDIContainer.swift in Sources */,
 				84781CC02B5BF98600D37921 /* MypageViewController.swift in Sources */,
 				84781C7E2B5BEC0700D37921 /* KakaoLoginRequestDTO.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		87101EF32B5DF685004BD418 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF02B5DF685004BD418 /* Debug.xcconfig */; };
 		87101EF42B5DF685004BD418 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF12B5DF685004BD418 /* Release.xcconfig */; };
 		87101EF52B5DF685004BD418 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF22B5DF685004BD418 /* Shared.xcconfig */; };
+		87101EF72B5DF8FE004BD418 /* RootDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EF62B5DF8FE004BD418 /* RootDestination.swift */; };
+		87101EFA2B5DF9A3004BD418 /* RxAppState in Frameworks */ = {isa = PBXBuildFile; productRef = 87101EF92B5DF9A3004BD418 /* RxAppState */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -101,6 +103,7 @@
 		87101EF02B5DF685004BD418 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = "../../../../Boolti-File/Debug.xcconfig"; sourceTree = "<group>"; };
 		87101EF12B5DF685004BD418 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = "../../../../Boolti-File/Release.xcconfig"; sourceTree = "<group>"; };
 		87101EF22B5DF685004BD418 /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = "../../../../Boolti-File/Shared.xcconfig"; sourceTree = "<group>"; };
+		87101EF62B5DF8FE004BD418 /* RootDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootDestination.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +117,7 @@
 				84781C642B5BE9C100D37921 /* Moya in Frameworks */,
 				84781C952B5BF15A00D37921 /* RxKakaoSDKAuth in Frameworks */,
 				84781C992B5BF15A00D37921 /* RxKakaoSDKUser in Frameworks */,
+				87101EFA2B5DF9A3004BD418 /* RxAppState in Frameworks */,
 				84781C662B5BE9C100D37921 /* ReactiveMoya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -307,6 +311,7 @@
 				84781C9E2B5BF6A000D37921 /* RootNavigationDelegate.swift */,
 				84781CA02B5BF6AB00D37921 /* RootViewController.swift */,
 				84781CA22B5BF6BF00D37921 /* RootViewModel.swift */,
+				87101EF62B5DF8FE004BD418 /* RootDestination.swift */,
 			);
 			path = Root;
 			sourceTree = "<group>";
@@ -394,6 +399,7 @@
 				84781C942B5BF15A00D37921 /* RxKakaoSDKAuth */,
 				84781C962B5BF15A00D37921 /* RxKakaoSDKCommon */,
 				84781C982B5BF15A00D37921 /* RxKakaoSDKUser */,
+				87101EF92B5DF9A3004BD418 /* RxAppState */,
 			);
 			productName = Boolti;
 			productReference = 84781BC92B5BDAFC00D37921 /* Boolti.app */;
@@ -427,6 +433,7 @@
 				84781C622B5BE9C000D37921 /* XCRemoteSwiftPackageReference "Moya" */,
 				84781C692B5BEA0000D37921 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */,
+				87101EF82B5DF9A3004BD418 /* XCRemoteSwiftPackageReference "RxAppState" */,
 			);
 			productRefGroup = 84781BCA2B5BDAFC00D37921 /* Products */;
 			projectDirPath = "";
@@ -457,6 +464,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				87101EF72B5DF8FE004BD418 /* RootDestination.swift in Sources */,
 				84781CC92B5BFA1C00D37921 /* TicketViewModel.swift in Sources */,
 				84781CCC2B5C003700D37921 /* ConcertDIContainer.swift in Sources */,
 				84781CB12B5BF85400D37921 /* TabBarController.swift in Sources */,
@@ -745,6 +753,14 @@
 				kind = branch;
 			};
 		};
+		87101EF82B5DF9A3004BD418 /* XCRemoteSwiftPackageReference "RxAppState" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pixeldock/RxAppState.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.7.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -782,6 +798,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 84781C932B5BF15A00D37921 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
 			productName = RxKakaoSDKUser;
+		};
+		87101EF92B5DF9A3004BD418 /* RxAppState */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 87101EF82B5DF9A3004BD418 /* XCRemoteSwiftPackageReference "RxAppState" */;
+			productName = RxAppState;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -52,6 +52,9 @@
 		84781CCE2B5C005600D37921 /* ConcertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCD2B5C005600D37921 /* ConcertViewController.swift */; };
 		84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CCF2B5C006500D37921 /* ConcertViewModel.swift */; };
 		84781CD42B5C06EC00D37921 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84781CD32B5C06EC00D37921 /* AuthService.swift */; };
+		87101EF32B5DF685004BD418 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF02B5DF685004BD418 /* Debug.xcconfig */; };
+		87101EF42B5DF685004BD418 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF12B5DF685004BD418 /* Release.xcconfig */; };
+		87101EF52B5DF685004BD418 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 87101EF22B5DF685004BD418 /* Shared.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -61,10 +64,7 @@
 		84781BD52B5BDAFD00D37921 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		84781BD82B5BDAFD00D37921 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		84781BDA2B5BDAFD00D37921 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		84781BE52B5BE06400D37921 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		84781BE62B5BE0BB00D37921 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		84781BE72B5BE17400D37921 /* Enviroment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enviroment.swift; sourceTree = "<group>"; };
-		84781BE92B5BE19900D37921 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		84781BED2B5BE3B600D37921 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		84781BEF2B5BE3C000D37921 /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		84781C6C2B5BEA3800D37921 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
@@ -98,6 +98,9 @@
 		84781CCD2B5C005600D37921 /* ConcertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertViewController.swift; sourceTree = "<group>"; };
 		84781CCF2B5C006500D37921 /* ConcertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertViewModel.swift; sourceTree = "<group>"; };
 		84781CD32B5C06EC00D37921 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		87101EF02B5DF685004BD418 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = "../../../../Boolti-File/Debug.xcconfig"; sourceTree = "<group>"; };
+		87101EF12B5DF685004BD418 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = "../../../../Boolti-File/Release.xcconfig"; sourceTree = "<group>"; };
+		87101EF22B5DF685004BD418 /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = "../../../../Boolti-File/Shared.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,9 +190,9 @@
 		84781BE42B5BE03600D37921 /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				84781BE62B5BE0BB00D37921 /* Shared.xcconfig */,
-				84781BE52B5BE06400D37921 /* Debug.xcconfig */,
-				84781BE92B5BE19900D37921 /* Release.xcconfig */,
+				87101EF02B5DF685004BD418 /* Debug.xcconfig */,
+				87101EF12B5DF685004BD418 /* Release.xcconfig */,
+				87101EF22B5DF685004BD418 /* Shared.xcconfig */,
 				84781BE72B5BE17400D37921 /* Enviroment.swift */,
 			);
 			path = Support;
@@ -439,8 +442,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				87101EF42B5DF685004BD418 /* Release.xcconfig in Resources */,
+				87101EF52B5DF685004BD418 /* Shared.xcconfig in Resources */,
 				84781BD92B5BDAFD00D37921 /* LaunchScreen.storyboard in Resources */,
 				84781BD62B5BDAFD00D37921 /* Assets.xcassets in Resources */,
+				87101EF32B5DF685004BD418 /* Debug.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,7 +512,6 @@
 /* Begin XCBuildConfiguration section */
 		84781BDB2B5BDAFD00D37921 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 84781BE52B5BE06400D37921 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -570,7 +575,6 @@
 		};
 		84781BDC2B5BDAFD00D37921 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 84781BE92B5BE19900D37921 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -627,7 +631,6 @@
 		};
 		84781BDE2B5BDAFD00D37921 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 84781BE52B5BE06400D37921 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -662,7 +665,6 @@
 		};
 		84781BDF2B5BDAFD00D37921 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 84781BE92B5BE19900D37921 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "rxappstate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pixeldock/RxAppState.git",
+      "state" : {
+        "revision" : "733bfbd56661ff67b947eee28bfda0e62ae42cc6",
+        "version" : "1.7.2"
+      }
+    },
+    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift",

--- a/Boolti/Boolti/Sources/Global/Utils/UserDefault.swift
+++ b/Boolti/Boolti/Sources/Global/Utils/UserDefault.swift
@@ -1,5 +1,5 @@
 //
-//  UserDefaultsManager.swift
+//  UserDefault.swift
 //  Boolti
 //
 //  Created by Juhyeon Byun on 1/20/24.

--- a/Boolti/Boolti/Sources/Network/Foundation/NetworkProvider.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/NetworkProvider.swift
@@ -1,0 +1,42 @@
+//
+//  NetworkProvider.swift
+//  Boolti
+//
+//  Created by Miro on 1/22/24.
+//
+
+import Foundation
+import RxSwift
+import RxMoya
+import Moya
+
+final class NetworkProvider: Networking {
+
+    private let provider: MoyaProvider<MultiTarget>
+
+    init(plugins: [PluginType] = []) {
+        let session = Session(interceptor: AuthInterceptor())
+        session.sessionConfiguration.timeoutIntervalForRequest = 10
+
+        self.provider = MoyaProvider<MultiTarget>(session: session, plugins: plugins)
+    }
+
+    func request(_ api: BaseAPI) -> Single<Response> {
+        let requestString = "\(api.path)"
+        let endpoint = MultiTarget.target(api)
+
+        return provider.rx.request(endpoint)
+            .filterSuccessfulStatusCodes()
+            .do(
+                onSuccess: { response in
+                    print("SUCCESS: \(requestString) (\(response.statusCode))")
+                },
+                onError: { _ in
+                    print("ERROR: \(requestString)")
+                },
+                onSubscribed: {
+                    print("REQUEST: \(requestString)")
+                }
+            )
+    }
+}

--- a/Boolti/Boolti/Sources/Network/Foundation/Networking.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/Networking.swift
@@ -6,40 +6,8 @@
 //
 
 import RxSwift
-import RxMoya
 import Moya
 
 protocol Networking {
     func request(_ api: BaseAPI) -> Single<Response>
-}
-
-final class NetworkProvider: Networking {
-    
-    private let provider: MoyaProvider<MultiTarget>
-    
-    init(plugins: [PluginType] = []) {
-        let session = Session(interceptor: AuthInterceptor())
-        session.sessionConfiguration.timeoutIntervalForRequest = 10
-
-        self.provider = MoyaProvider<MultiTarget>(session: session, plugins: plugins)
-    }
-
-    func request(_ api: BaseAPI) -> Single<Response> {
-        let requestString = "\(api.path)"
-        let endpoint = MultiTarget.target(api)
-
-        return provider.rx.request(endpoint)
-            .filterSuccessfulStatusCodes()
-            .do(
-                onSuccess: { response in
-                    print("SUCCESS: \(requestString) (\(response.statusCode))")
-                },
-                onError: { _ in
-                    print("ERROR: \(requestString)")
-                },
-                onSubscribed: {
-                    print("REQUEST: \(requestString)")
-                }
-            )
-    }
 }

--- a/Boolti/Boolti/Sources/Network/Services/AuthAPIService.swift
+++ b/Boolti/Boolti/Sources/Network/Services/AuthAPIService.swift
@@ -11,11 +11,7 @@ import Moya
 import RxCocoa
 import RxSwift
 
-protocol AuthAPIServiceType {
-    func login(accessToken: String) -> Single<KakaoLoginResponseDTO>
-}
-
-final class AuthService: AuthAPIServiceType {
+final class AuthAPIService: AuthAPIServiceType {
     
     private typealias API = AuthAPI
     private let provider: NetworkProvider

--- a/Boolti/Boolti/Sources/Network/Services/AuthAPIServiceType.swift
+++ b/Boolti/Boolti/Sources/Network/Services/AuthAPIServiceType.swift
@@ -1,0 +1,14 @@
+//
+//  AuthAPIServiceType.swift
+//  Boolti
+//
+//  Created by Miro on 1/22/24.
+//
+
+import Foundation
+import Moya
+import RxSwift
+
+protocol AuthAPIServiceType {
+    func login(accessToken: String) -> Single<KakaoLoginResponseDTO>
+}

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class RootDIContainer {
 
-    private let rootViewModel: RootViewModel
+    let rootViewModel: RootViewModel
     private let networkProvider: NetworkProvider
 
     init() {

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -23,15 +23,15 @@ final class RootDIContainer {
             return DIContainer.createSplashViewController()
         }
 
-        let tabBarControllerFactory: () -> HomeTabBarController = {
-            let DIContainer = self.createTabBarDIContainer()
-            return DIContainer.createTabBarController()
+        let homeTabBarControllerFactory: () -> HomeTabBarController = {
+            let DIContainer = self.createHomeTabBarDIContainer()
+            return DIContainer.createHomeTabBarController()
         }
 
         return RootViewController(
             viewModel: rootViewModel,
             splashViewControllerFactory: splashViewControllerFactory,
-            tabBarControllerFactory: tabBarControllerFactory
+            hometabBarControllerFactory: homeTabBarControllerFactory
         )
     }
 
@@ -39,7 +39,7 @@ final class RootDIContainer {
         return SplashDIContainer(rootDIContainer: self, networkProvider: networkProvider)
     }
 
-    private func createTabBarDIContainer() -> HomeTabBarDIContainer {
+    private func createHomeTabBarDIContainer() -> HomeTabBarDIContainer {
         return HomeTabBarDIContainer(rootDIContainer: self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -23,7 +23,7 @@ final class RootDIContainer {
             return DIContainer.createSplashViewController()
         }
 
-        let tabBarControllerFactory: () -> TabBarController = {
+        let tabBarControllerFactory: () -> HomeTabBarController = {
             let DIContainer = self.createTabBarDIContainer()
             return DIContainer.createTabBarController()
         }
@@ -39,7 +39,7 @@ final class RootDIContainer {
         return SplashDIContainer(rootDIContainer: self, networkProvider: networkProvider)
     }
 
-    private func createTabBarDIContainer() -> TabBarDIContainer {
-        return TabBarDIContainer(rootDIContainer: self)
+    private func createTabBarDIContainer() -> HomeTabBarDIContainer {
+        return HomeTabBarDIContainer(rootDIContainer: self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDestination.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDestination.swift
@@ -1,0 +1,13 @@
+//
+//  RootDestination.swift
+//  Boolti
+//
+//  Created by Miro on 1/22/24.
+//
+
+import Foundation
+
+enum RootDestination {
+    case splash
+    case homeTab
+}

--- a/Boolti/Boolti/Sources/UILayer/Root/RootNavigationDelegate.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootNavigationDelegate.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol SplashViewViewModelDelegate {
-    func splashViewViewModel(_ didSplashViewControllerDismissed: SplashViewModel)
+protocol SplashViewModelDelegate {
+    func splashViewModel(_ didSplashViewControllerDismissed: SplashViewModel)
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootNavigationDelegate.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootNavigationDelegate.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol SplashViewControllerDelegate {
-    func splashViewController(_ didSplashViewDismissed: SplashViewModel)
+protocol SplashViewViewModelDelegate {
+    func splashViewViewModel(_ didSplashViewControllerDismissed: SplashViewModel)
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -16,12 +16,12 @@ final class RootViewController: UIViewController {
     private let disposeBag = DisposeBag()
 
     private let splashViewControllerFactory: () -> SplashViewController
-    private let tabBarControllerFactory: () -> TabBarController
+    private let tabBarControllerFactory: () -> HomeTabBarController
 
     init(
         viewModel: RootViewModel,
         splashViewControllerFactory: @escaping () -> SplashViewController,
-        tabBarControllerFactory: @escaping () -> TabBarController
+        tabBarControllerFactory: @escaping () -> HomeTabBarController
     ) {
         self.viewModel = viewModel
         self.splashViewControllerFactory = splashViewControllerFactory

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -6,13 +6,18 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
+import RxAppState
 
 final class RootViewController: UIViewController {
 
     private let viewModel: RootViewModel
+    private let disposeBag = DisposeBag()
+
     private let splashViewControllerFactory: () -> SplashViewController
     private let tabBarControllerFactory: () -> TabBarController
-    
+
     init(
         viewModel: RootViewModel,
         splashViewControllerFactory: @escaping () -> SplashViewController,
@@ -28,43 +33,41 @@ final class RootViewController: UIViewController {
         fatalError()
     }
 
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        self.bind()
+
         // TODO: 화면 넘어가는 거 확인용. 나중에 지워야함!
         self.view.backgroundColor = .red
-        
-        let splashDuration: DispatchTimeInterval = .seconds(2)
+    }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + splashDuration) { [weak self] in
-            let splashViewController = self?.splashViewControllerFactory() ?? UIViewController()
-            self?.navigationController?.pushViewController(splashViewController, animated: true)
-            
-//            let tabBarController = self?.tabBarControllerFactory() ?? UITabBarController()
-//            tabBarController.modalTransitionStyle = .crossDissolve
-//            tabBarController.modalPresentationStyle = .overFullScreen
-//            self?.present(tabBarController, animated: true)
+    private func bind() {
+        self.rx.viewDidAppear
+            .take(1)
+            .flatMapFirst { _ in self.viewModel.navigation }
+            .subscribe(onNext: { [weak self] destination in
+                let viewController = self?.createViewController(destination) ?? UIViewController()
+                switch destination {
+                case .splash:
+                    viewController.modalPresentationStyle = .fullScreen
+                    self?.present(viewController, animated: true, completion: nil)
+                case .homeTab:
+                    if let presentedViewController = self?.presentedViewController {
+                        presentedViewController.dismiss(animated: false, completion: { [weak self] in
+                            viewController.modalTransitionStyle = .crossDissolve
+                            viewController.modalPresentationStyle = .overFullScreen
+                            self?.present(viewController, animated: true, completion: nil)
+                        })
+                    }
+                }
+            })
+            .disposed(by: self.disposeBag)
+    }
+
+    private func createViewController(_ next: RootDestination) -> UIViewController {
+        switch next {
+        case .splash: return splashViewControllerFactory()
+        case .homeTab: return tabBarControllerFactory()
         }
     }
-
-}
-
-extension RootViewController: SplashViewControllerDelegate {
-
-    func splashViewController(_ didSplashViewDismissed: SplashViewModel) {
-    }
-    // TODO: Delegate을 활용해서 Splash View -> RootView -> TabBar로 넘어가는 로직 구현할 예정!
-
-        // HomeTab으로 navigate하기!..
-//        if let presentedViewController = self.presentedViewController {
-//            presentedViewController.dismiss(animated: false, completion: { [weak self] in
-//                viewController.modalPresentationStyle = .fullScreen
-//                self?.present(viewController, animated: animated, completion: nil)
-//            })
-//        } else {
-//            viewController.modalPresentationStyle = .fullScreen
-//            self.present(viewController, animated: animated, completion: nil)
-//        }
-//    }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -16,16 +16,16 @@ final class RootViewController: UIViewController {
     private let disposeBag = DisposeBag()
 
     private let splashViewControllerFactory: () -> SplashViewController
-    private let tabBarControllerFactory: () -> HomeTabBarController
+    private let homeTabBarControllerFactory: () -> HomeTabBarController
 
     init(
         viewModel: RootViewModel,
         splashViewControllerFactory: @escaping () -> SplashViewController,
-        tabBarControllerFactory: @escaping () -> HomeTabBarController
+        hometabBarControllerFactory: @escaping () -> HomeTabBarController
     ) {
         self.viewModel = viewModel
         self.splashViewControllerFactory = splashViewControllerFactory
-        self.tabBarControllerFactory = tabBarControllerFactory
+        self.homeTabBarControllerFactory = hometabBarControllerFactory
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -67,7 +67,7 @@ final class RootViewController: UIViewController {
     private func createViewController(_ next: RootDestination) -> UIViewController {
         switch next {
         case .splash: return splashViewControllerFactory()
-        case .homeTab: return tabBarControllerFactory()
+        case .homeTab: return homeTabBarControllerFactory()
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
@@ -14,9 +14,9 @@ final class RootViewModel {
     let navigation = BehaviorRelay<RootDestination>(value: .splash)
 }
 
-extension RootViewModel: SplashViewViewModelDelegate {
+extension RootViewModel: SplashViewModelDelegate {
 
-    func splashViewViewModel(_ didSplashViewControllerDismissed: SplashViewModel) {
+    func splashViewModel(_ didSplashViewControllerDismissed: SplashViewModel) {
         self.navigation.accept(.homeTab)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
@@ -6,7 +6,18 @@
 //
 
 import Foundation
+import RxSwift
+import RxRelay
 
 final class RootViewModel {
 
+    let navigation = BehaviorRelay<RootDestination>(value: .splash)
+
+}
+
+extension RootViewModel: SplashViewViewModelDelegate {
+
+    func splashViewViewModel(_ didSplashViewControllerDismissed: SplashViewModel) {
+        self.navigation.accept(.homeTab)
+    }
 }

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
@@ -10,9 +10,8 @@ import RxSwift
 import RxRelay
 
 final class RootViewModel {
-
+    
     let navigation = BehaviorRelay<RootDestination>(value: .splash)
-
 }
 
 extension RootViewModel: SplashViewViewModelDelegate {

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
@@ -24,7 +24,7 @@ final class SplashDIContainer {
 
     private func createSplashViewModel() -> SplashViewModel {
         // TODO: 네트워크 의존성 주입하는 방법임!! 나중에 지워야함!
-        let viewModel = SplashViewModel(authAPIService: AuthService(provider: self.networkProvider), delegate: self.rootDIContainer.rootViewModel)
+        let viewModel = SplashViewModel(authAPIService: AuthAPIService(provider: self.networkProvider), delegate: self.rootDIContainer.rootViewModel)
 
         return viewModel
     }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
@@ -24,7 +24,7 @@ final class SplashDIContainer {
 
     private func createSplashViewModel() -> SplashViewModel {
         // TODO: 네트워크 의존성 주입하는 방법임!! 나중에 지워야함!
-        let viewModel = SplashViewModel(networkService: AuthService(provider: networkProvider))
+        let viewModel = SplashViewModel(authAPIService: AuthService(provider: networkProvider))
 
         return viewModel
     }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
@@ -24,7 +24,7 @@ final class SplashDIContainer {
 
     private func createSplashViewModel() -> SplashViewModel {
         // TODO: 네트워크 의존성 주입하는 방법임!! 나중에 지워야함!
-        let viewModel = SplashViewModel(authAPIService: AuthService(provider: networkProvider))
+        let viewModel = SplashViewModel(authAPIService: AuthService(provider: self.networkProvider), delegate: self.rootDIContainer.rootViewModel)
 
         return viewModel
     }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewController.swift
@@ -36,10 +36,8 @@ final class SplashViewController: UIViewController {
 
         let splashDuration: DispatchTimeInterval = .seconds(2)
 
-        // TODO: Delegate을 활용해서 Splash View -> RootView -> TabBar로 넘어가는 로직 구현할 예정!
         DispatchQueue.main.asyncAfter(deadline: .now() + splashDuration) { [weak self] in
-            // ViewModel의 메소드를 실행시킨다.
-
+            self?.viewModel.navigateToHomeTab()
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -9,9 +9,9 @@ import Foundation
 
 final class SplashViewModel {
     
-    private let networkService: AuthService
+    private let authAPIservice: AuthAPIServiceType
 
-    init(networkService: AuthService) {
-        self.networkService = networkService
+    init(authAPIService: AuthAPIServiceType) {
+        self.authAPIservice = authAPIService
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -10,14 +10,14 @@ import Foundation
 final class SplashViewModel {
     
     private let authAPIservice: AuthAPIServiceType
-    private let delegate: SplashViewViewModelDelegate
+    private let navigationDelegate: SplashViewViewModelDelegate
 
     init(authAPIService: AuthAPIServiceType, delegate: SplashViewViewModelDelegate) {
         self.authAPIservice = authAPIService
-        self.delegate = delegate
+        self.navigationDelegate = delegate
     }
 
     func navigateToHomeTab() {
-        delegate.splashViewViewModel(self)
+        navigationDelegate.splashViewViewModel(self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -10,8 +10,14 @@ import Foundation
 final class SplashViewModel {
     
     private let authAPIservice: AuthAPIServiceType
+    private let delegate: SplashViewViewModelDelegate
 
-    init(authAPIService: AuthAPIServiceType) {
+    init(authAPIService: AuthAPIServiceType, delegate: SplashViewViewModelDelegate) {
         self.authAPIservice = authAPIService
+        self.delegate = delegate
+    }
+
+    func navigateToHomeTab() {
+        delegate.splashViewViewModel(self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -10,14 +10,14 @@ import Foundation
 final class SplashViewModel {
     
     private let authAPIservice: AuthAPIServiceType
-    private let navigationDelegate: SplashViewViewModelDelegate
+    private let navigationDelegate: SplashViewModelDelegate
 
-    init(authAPIService: AuthAPIServiceType, delegate: SplashViewViewModelDelegate) {
+    init(authAPIService: AuthAPIServiceType, delegate: SplashViewModelDelegate) {
         self.authAPIservice = authAPIService
         self.navigationDelegate = delegate
     }
 
     func navigateToHomeTab() {
-        navigationDelegate.splashViewViewModel(self)
+        navigationDelegate.splashViewModel(self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -8,14 +8,14 @@
 import UIKit
 import RxSwift
 
-final class TabBarController: UITabBarController {
+final class HomeTabBarController: UITabBarController {
 
-    private let viewModel: TabBarViewModel
+    private let viewModel: HomeTabBarViewModel
     private let viewControllerFactory: (HomeTab) -> UIViewController
     private let disposeBag = DisposeBag()
 
     init(
-        viewModel: TabBarViewModel,
+        viewModel: HomeTabBarViewModel,
         viewControllerFactory: @escaping (HomeTab) -> UIViewController
     ) {
         self.viewModel = viewModel

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -1,5 +1,5 @@
 //
-//  TabBarController.swift
+//  HomeTabBarController.swift
 //  Boolti
 //
 //  Created by Miro on 1/20/24.

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
@@ -1,5 +1,5 @@
 //
-//  TabBarDIContainer.swift
+//  HomeTabBarDIContainer.swift
 //  Boolti
 //
 //  Created by Miro on 1/20/24.
@@ -17,14 +17,14 @@ final class HomeTabBarDIContainer {
         self.rootDIContainer = rootDIContainer
     }
 
-    func createTabBarController() -> HomeTabBarController {
+    func createHomeTabBarController() -> HomeTabBarController {
         return HomeTabBarController(
-        viewModel: createTabBarViewModel(),
+        viewModel: createHomeTabBarViewModel(),
         viewControllerFactory: createViewController(of:)
         )
     }
 
-    private func createTabBarViewModel() -> HomeTabBarViewModel {
+    private func createHomeTabBarViewModel() -> HomeTabBarViewModel {
         return HomeTabBarViewModel()
     }
 

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class TabBarDIContainer {
+final class HomeTabBarDIContainer {
 
     // TODO: 아래의 의존성은 다시 설정할 예정
 
@@ -17,15 +17,15 @@ final class TabBarDIContainer {
         self.rootDIContainer = rootDIContainer
     }
 
-    func createTabBarController() -> TabBarController {
-        return TabBarController(
+    func createTabBarController() -> HomeTabBarController {
+        return HomeTabBarController(
         viewModel: createTabBarViewModel(),
         viewControllerFactory: createViewController(of:)
         )
     }
 
-    private func createTabBarViewModel() -> TabBarViewModel {
-        return TabBarViewModel()
+    private func createTabBarViewModel() -> HomeTabBarViewModel {
+        return HomeTabBarViewModel()
     }
 
 

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxRelay
 
-final class TabBarViewModel {
+final class HomeTabBarViewModel {
 
     let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
     let currentTab = PublishRelay<HomeTab>()


### PR DESCRIPTION
## 작업한 내용
- RootVC에서 갈 수 있는 Splash와 HomeTab 사이의 navigation 로직을 구현했어요.
  - Splash에서 작업이 끝나면 HomeTab으로 이동하는 것을 Delegate을 활용해서 구현했어요.
  - 아직 SplashVC에서 어떤 네트워크 로직을 짜야할 지 모르겠어서, 일단 2초 뒤에 navigate되게 구현했어요.
- 그 외에 파일 정리 및 네이밍 변경을 했어요.
  - 기존의 protocol과 채택한 타입이 하나의 파일에 있었는데, 따로 다른 파일로 변경을 해주었어요.
  - 그리고 기존의 TabBar라는 네이밍을 HomeTabBar로 네이밍 변경을 했어요. (참고 사진 속 내용을 통해서 변경해주었어요.)
  + a

## 스크린샷

![Simulator Screen Recording - iPhone 15 - 2024-01-22 at 10 45 06](https://github.com/Nexters/Boolti-iOS/assets/85781941/94a39270-523c-4e9d-aea8-658a732f1e79)

## 관련 이슈
- Resolved: #7 

## 참고 내용
(Swift API Guidelines의 naming part)
<img width="785" alt="image" src="https://github.com/Nexters/Boolti-iOS/assets/85781941/9abf5df5-838d-4c4b-b402-b41278c614a8">
