### PR TITLE
Feature/#38 토스트 팝업 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		84B321A32B61543E007FD669 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 84B321A22B61543E007FD669 /* FirebaseMessaging */; };
 		84B321A52B61543E007FD669 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 84B321A42B61543E007FD669 /* FirebaseRemoteConfig */; };
 		84B321A72B61543E007FD669 /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 84B321A62B61543E007FD669 /* FirebaseRemoteConfigSwift */; };
+		84EC6A642B6CF973009AC6BB /* BooltiToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EC6A632B6CF973009AC6BB /* BooltiToastView.swift */; };
 		84FBBDF32B673877009462E9 /* ConcertInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBBDF22B673877009462E9 /* ConcertInfoView.swift */; };
 		84FBBDF72B67429D009462E9 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBBDF62B67429D009462E9 /* ImageCacheManager.swift */; };
 		84FBBDF92B67431D009462E9 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBBDF82B67431D009462E9 /* UIImageView+.swift */; };
@@ -221,6 +222,7 @@
 		84975BFD2B6123E500F903E7 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		84975BFE2B6123E500F903E7 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		849FBD502B5E920A006EB865 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		84EC6A632B6CF973009AC6BB /* BooltiToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiToastView.swift; sourceTree = "<group>"; };
 		84FBBDF22B673877009462E9 /* ConcertInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertInfoView.swift; sourceTree = "<group>"; };
 		84FBBDF62B67429D009462E9 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		84FBBDF82B67431D009462E9 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -846,6 +848,7 @@
 				84625A032B6382C300CC9077 /* BooltiBottomSheetViewController.swift */,
 				84625A172B63E05700CC9077 /* BooltiPaddingLabel.swift */,
 				84FBBE002B677187009462E9 /* BooltiTextField.swift */,
+				84EC6A632B6CF973009AC6BB /* BooltiToastView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1078,6 +1081,7 @@
 				84FEF6172B68A6D100EBB64F /* UIResponder+.swift in Sources */,
 				8757BAB02B60069B008503B5 /* OAuthResponse.swift in Sources */,
 				8766B5612B641581004F266A /* UsedTicket.swift in Sources */,
+				84EC6A642B6CF973009AC6BB /* BooltiToastView.swift in Sources */,
 				84625A162B63C33D00CC9077 /* UITableViewCell+.swift in Sources */,
 				84625A092B63A01100CC9077 /* TicketSelectionViewController.swift in Sources */,
 				8757BAAA2B5FDF29008503B5 /* KakaoOAuth.swift in Sources */,

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiToastView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiToastView.swift
@@ -1,0 +1,94 @@
+//
+//  BooltiToastView.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/2/24.
+//
+
+import UIKit
+import RxSwift
+import RxRelay
+
+final class BooltiToastView: UIView {
+    
+    // MARK: Properties
+    
+    private let disposeBag = DisposeBag()
+
+    let showToast = PublishRelay<String>()
+    
+    // MARK: UI Component
+    
+    let toastLabel: BooltiPaddingLabel = {
+        let label = BooltiPaddingLabel(padding: UIEdgeInsets(top: 12.0, left: 16.0, bottom: 12.0, right: 16.0))
+        label.textColor = .grey10
+        label.backgroundColor = .grey80
+        label.font = .body1
+        label.layer.cornerRadius = 4
+        label.layer.masksToBounds = true
+        return label
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        self.configureUI()
+        self.configureConstraints()
+        self.bindOutputs()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}
+
+// MARK: - Methods
+
+extension BooltiToastView {
+    
+    private func bindOutputs() {
+        self.showToast
+            .asDriver(onErrorJustReturn: "")
+            .drive(with: self) { owner, message in
+                self.toastLabel.text = message
+                self.isHidden = false
+                
+                Observable.just("")
+                    .delay(.seconds(2), scheduler: MainScheduler.instance)
+                    .asDriver(onErrorJustReturn: "")
+                    .drive(with: self) { owner, _ in
+                        UIView.animate(
+                            withDuration: 0.3,
+                            animations: {
+                                owner.alpha = 0.0
+                            },
+                            completion: { _ in
+                                owner.isHidden = true
+                                owner.alpha = 1.0
+                            })
+                    }
+                    .disposed(by: owner.disposeBag)
+            }
+            .disposed(by: self.disposeBag)
+    }
+}
+
+// MARK: - UI
+
+extension BooltiToastView {
+    
+    private func configureUI() {
+        self.addSubview(self.toastLabel)
+        self.isHidden = true
+    }
+    
+    private func configureConstraints() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(41)
+        }
+        
+        self.toastLabel.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiToastView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiToastView.swift
@@ -49,25 +49,21 @@ extension BooltiToastView {
     private func bindOutputs() {
         self.showToast
             .asDriver(onErrorJustReturn: "")
+            .throttle(.seconds(2))
             .drive(with: self) { owner, message in
                 self.toastLabel.text = message
-                self.isHidden = false
                 
-                Observable.just("")
-                    .delay(.seconds(2), scheduler: MainScheduler.instance)
-                    .asDriver(onErrorJustReturn: "")
-                    .drive(with: self) { owner, _ in
-                        UIView.animate(
-                            withDuration: 0.3,
-                            animations: {
-                                owner.alpha = 0.0
-                            },
-                            completion: { _ in
-                                owner.isHidden = true
-                                owner.alpha = 1.0
-                            })
-                    }
-                    .disposed(by: owner.disposeBag)
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 1,
+                    animations: {
+                        self.isHidden = false
+                        self.alpha = 0
+                    },
+                    completion: { _ in
+                        self.alpha = 1.0
+                        self.isHidden = true
+                    })
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -69,8 +69,10 @@ extension BooltiViewController {
         }
     }
     
-    func configureToastView() {
+    func configureToastView(isbuttonExisted: Bool) {
         self.toastView = BooltiToastView()
+        
+        let bottomOffset = isbuttonExisted ? 80 : 20
         
         guard let keyWindow = UIApplication.shared.connectedScenes
             .filter({ $0.activationState == .foregroundActive })
@@ -80,7 +82,7 @@ extension BooltiViewController {
         }
         keyWindow.addSubview(self.toastView ?? BooltiToastView())
         self.toastView?.snp.makeConstraints { make in
-            make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-20)
+            make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-bottomOffset)
             make.centerX.equalTo(keyWindow)
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -69,8 +69,10 @@ extension BooltiViewController {
         }
     }
     
-    func configureToastView() {
+    func configureToastView(isButtonExisted: Bool) {
         self.toastView = BooltiToastView()
+        
+        let bottomOffset = isButtonExisted ? 80 : 20
         
         guard let keyWindow = UIApplication.shared.connectedScenes
             .filter({ $0.activationState == .foregroundActive })
@@ -80,7 +82,7 @@ extension BooltiViewController {
         }
         keyWindow.addSubview(self.toastView ?? BooltiToastView())
         self.toastView?.snp.makeConstraints { make in
-            make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-20)
+            make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-bottomOffset)
             make.centerX.equalTo(keyWindow)
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -10,29 +10,28 @@ import RxSwift
 import RxCocoa
 
 class BooltiViewController: UIViewController {
+    
+    // MARK: UI Component
+    
+    private var toastView: BooltiToastView?
 
-    private let loadingIndicatorView = BooltiLoadingIndicatorView(style: .large)
-
+    private var loadingIndicatorView: BooltiLoadingIndicatorView?
+    
+    // MARK: Properties
+    
     var isLoading: Binder<Bool> {
         Binder(self) { [weak self] viewController, isLoading in
-            guard let self = self else { return }
+            guard let self = self, let loadingIndicatorView = self.loadingIndicatorView else { return }
             if isLoading {
-                viewController.view.bringSubviewToFront(self.loadingIndicatorView)
-                self.loadingIndicatorView.isLoading = true
+                viewController.view.bringSubviewToFront(loadingIndicatorView)
+                loadingIndicatorView.isLoading = true
             } else {
-                self.loadingIndicatorView.isLoading = false
+                loadingIndicatorView.isLoading = false
             }
         }
     }
     
-    private let toastView = BooltiToastView()
-    
-    var showToast: Binder<String> {
-        Binder(self) { [weak self] viewController, message in
-            guard let self = self else { return }
-            self.toastView.showToast.accept(message)
-        }
-    }
+    // MARK: Init
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -44,36 +43,49 @@ class BooltiViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.configureLoadingIndicatorView()
-        self.configureToast()
     }
 
     deinit {
         print(" 💀 \(String(describing: self)) deinit")
     }
+    
+    // MARK: Override
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+}
 
-    private func configureLoadingIndicatorView() {
-        self.view.addSubview(self.loadingIndicatorView)
-        self.loadingIndicatorView.snp.makeConstraints { make in
+// MARK: - Methods
+
+extension BooltiViewController {
+    
+    func configureLoadingIndicatorView() {
+        self.loadingIndicatorView = BooltiLoadingIndicatorView(style: .large)
+        
+        self.view.addSubview(self.loadingIndicatorView ?? BooltiLoadingIndicatorView(style: .large))
+        self.loadingIndicatorView?.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
     }
     
-    private func configureToast() {
+    func configureToastView() {
+        self.toastView = BooltiToastView()
+        
         guard let keyWindow = UIApplication.shared.connectedScenes
             .filter({ $0.activationState == .foregroundActive })
             .compactMap({ $0 as? UIWindowScene })
             .first?.windows.first else {
             return
         }
-        keyWindow.addSubview(self.toastView)
-        self.toastView.snp.makeConstraints { make in
+        keyWindow.addSubview(self.toastView ?? BooltiToastView())
+        self.toastView?.snp.makeConstraints { make in
             make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-20)
             make.centerX.equalTo(keyWindow)
         }
     }
-
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
+    
+    func showToast(message: String) {
+        self.toastView?.showToast.accept(message)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -24,6 +24,15 @@ class BooltiViewController: UIViewController {
             }
         }
     }
+    
+    private let toastView = BooltiToastView()
+    
+    var showToast: Binder<String> {
+        Binder(self) { [weak self] viewController, message in
+            guard let self = self else { return }
+            self.toastView.showToast.accept(message)
+        }
+    }
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -35,17 +44,32 @@ class BooltiViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.setupLoadingIndicatorView()
+        self.configureLoadingIndicatorView()
+        self.configureToast()
     }
 
     deinit {
         print(" 💀 \(String(describing: self)) deinit")
     }
 
-    private func setupLoadingIndicatorView() {
+    private func configureLoadingIndicatorView() {
         self.view.addSubview(self.loadingIndicatorView)
-        self.loadingIndicatorView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+        self.loadingIndicatorView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    private func configureToast() {
+        guard let keyWindow = UIApplication.shared.connectedScenes
+            .filter({ $0.activationState == .foregroundActive })
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first else {
+            return
+        }
+        keyWindow.addSubview(self.toastView)
+        self.toastView.snp.makeConstraints { make in
+            make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-20)
+            make.centerX.equalTo(keyWindow)
         }
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
@@ -58,7 +58,7 @@ final class TicketingCompletionViewController: BooltiViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.configureToastView()
+        self.configureToastView(isButtonExisted: false)
         self.bindOutput()
         self.configureUI()
         self.configureConstraints()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import RxSwift
 
-final class TicketingCompletionViewController: UIViewController {
+final class TicketingCompletionViewController: BooltiViewController {
     
     // MARK: Properties
     
@@ -46,7 +46,7 @@ final class TicketingCompletionViewController: UIViewController {
     
     init(viewModel: TicketingCompletionViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        super.init()
     }
     
     required init?(coder: NSCoder) {
@@ -83,7 +83,11 @@ extension TicketingCompletionViewController {
             .disposed(by: self.disposeBag)
         
         self.copyButton.rx.tap
-            .bind(to: self.viewModel.input.didCopyButtonTap)
+            .asDriver()
+            .drive(with: self) { owner, _ in
+                owner.viewModel.input.didCopyButtonTap.onNext(())
+                owner.showToast.onNext("계좌번호가 복사되었어요")
+            }
             .disposed(by: self.disposeBag)
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
@@ -58,6 +58,7 @@ final class TicketingCompletionViewController: BooltiViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.configureToastView()
         self.bindOutput()
         self.configureUI()
         self.configureConstraints()
@@ -86,7 +87,7 @@ extension TicketingCompletionViewController {
             .asDriver()
             .drive(with: self) { owner, _ in
                 owner.viewModel.input.didCopyButtonTap.onNext(())
-                owner.showToast.onNext("계좌번호가 복사되었어요")
+                owner.showToast(message: "계좌번호가 복사되었어요")
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingCompletion/TicketingCompletionViewController.swift
@@ -58,7 +58,7 @@ final class TicketingCompletionViewController: BooltiViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.configureToastView()
+        self.configureToastView(isbuttonExisted: false)
         self.bindOutput()
         self.configureUI()
         self.configureConstraints()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingDetail/Components/Views/PaymentMethodView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingDetail/Components/Views/PaymentMethodView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import RxSwift
+import RxCocoa
 
 final class PaymentMethodView: UIView {
     
@@ -64,7 +65,6 @@ final class PaymentMethodView: UIView {
         
         self.configureUI()
         self.configureConstraints()
-        self.bindInputs()
     }
     
     required init?(coder: NSCoder) {
@@ -76,11 +76,8 @@ final class PaymentMethodView: UIView {
 
 extension PaymentMethodView {
     
-    private func bindInputs() {
-        self.depositButton.rx.tap
-            .bind(with: self, onNext: { owner, _ in
-                debugPrint("계좌 이체 선택")
-            }).disposed(by: self.disposeBag)
+    func didDepositButtonTap() -> Signal<Void> {
+        return self.depositButton.rx.tap.asSignal()
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingDetail/TicketingDetailViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class TicketingDetailViewController: UIViewController {
+final class TicketingDetailViewController: BooltiViewController {
     
     // MARK: Properties
     
@@ -72,7 +72,7 @@ final class TicketingDetailViewController: UIViewController {
     ) {
         self.viewModel = viewModel
         self.ticketingCompletionViewControllerFactory = ticketingCompletionViewControllerFactory
-        super.init(nibName: nil, bundle: nil)
+        super.init()
     }
 
     
@@ -85,6 +85,7 @@ final class TicketingDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.configureToastView(isButtonExisted: true)
         self.configureUI()
         self.configureConstraints()
         self.configureGesture()
@@ -129,6 +130,13 @@ extension TicketingDetailViewController {
                 let viewController = self.ticketingCompletionViewControllerFactory(TicketingEntity(ticketHolder: TicketingEntity.userInfo(name: .init(), phoneNumber: .init()), depositor: nil, selectedTicket: [self.viewModel.output.selectedTicket.value], paymentMethod: "", invitationCode: "asdf"))
                 self.navigationController?.pushViewController(viewController, animated: true)
             })
+            .disposed(by: self.disposeBag)
+        
+        self.paymentMethodView.didDepositButtonTap()
+            .asDriver(onErrorJustReturn: ())
+            .drive(with: self) { owner, _ in
+                owner.showToast(message: "지금은 계좌 이체로만 결제할 수 있어요")
+            }
             .disposed(by: self.disposeBag)
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketingDetail/TicketingDetailViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class TicketingDetailViewController: UIViewController {
+final class TicketingDetailViewController: BooltiViewController {
     
     // MARK: Properties
     
@@ -72,7 +72,7 @@ final class TicketingDetailViewController: UIViewController {
     ) {
         self.viewModel = viewModel
         self.ticketingCompletionViewControllerFactory = ticketingCompletionViewControllerFactory
-        super.init(nibName: nil, bundle: nil)
+        super.init()
     }
 
     
@@ -85,6 +85,7 @@ final class TicketingDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.configureToastView(isbuttonExisted: true)
         self.configureUI()
         self.configureConstraints()
         self.configureGesture()
@@ -129,6 +130,13 @@ extension TicketingDetailViewController {
                 let viewController = self.ticketingCompletionViewControllerFactory(TicketingEntity(ticketHolder: TicketingEntity.userInfo(name: .init(), phoneNumber: .init()), depositor: nil, selectedTicket: [self.viewModel.output.selectedTicket.value], paymentMethod: "", invitationCode: "asdf"))
                 self.navigationController?.pushViewController(viewController, animated: true)
             })
+            .disposed(by: self.disposeBag)
+        
+        self.paymentMethodView.didDepositButtonTap()
+            .asDriver(onErrorJustReturn: ())
+            .drive(with: self) { owner, _ in
+                owner.showToast(message: "지금은 계좌 이체로만 결제할 수 있어요")
+            }
             .disposed(by: self.disposeBag)
     }
     


### PR DESCRIPTION
## 작업한 내용
- ToastView를 만들었어요.
  - uiview안에 label이 있는 형태가 아닌 label에 padding을 넣은 형태로 만들었어요! BooltiPaddingLabel을 재활용 했습니다!
- BooltiViewController 안에 ToastView를 만드는 함수를 만들었어요.
  - 화면이 닫힐 때 토스트는 그대로 띄워져있도록 window에서 띄우도록 했어요.
  - 2초 후 hidden처리 될 때 흐려지도록 애니메이션을 넣었어요.
  - ToastView가 필요없는 뷰에서는 만들어지지 않도록 `configureToastView()` 함수를 만들었어요.
  - 뷰에 버튼 존재 여부에 따라 높이를 조절해요.
    ```swift
    private var toastView: BooltiToastView?

    func configureToastView(isButtonExisted: Bool) {
        self.toastView = BooltiToastView()
        
        let bottomOffset = isButtonExisted ? 80 : 20
        
        guard let keyWindow = UIApplication.shared.connectedScenes
            .filter({ $0.activationState == .foregroundActive })
            .compactMap({ $0 as? UIWindowScene })
            .first?.windows.first else {
            return
        }
        keyWindow.addSubview(self.toastView ?? BooltiToastView())
        self.toastView?.snp.makeConstraints { make in
            make.bottom.equalTo(keyWindow.safeAreaLayoutGuide).offset(-bottomOffset)
            make.centerX.equalTo(keyWindow)
        }
    }
    ```
  - 필요한 ViewController에서 (BooltiViewController 상속받아야함) viewDidLoad에 `configureToastView()`를 호출하면 필요할 때 토스트 뷰를 사용할 수 있어요.
    ```swift
        func showToast(message: String) {
            self.toastView?.showToast.accept(message)
        }
    ```
- 이와 비슷하게 loadingIndicator도 필요할 때만 viewDidLoad에 `configureLoadingIndicatorView()`를 호출하면 돼요!

## 스크린샷
![RPReplay_Final1706877568](https://github.com/Nexters/Boolti-iOS/assets/58043306/96c6e240-c0ce-4af9-a383-e558f144bd02)

## 관련 이슈
- Resolved: #38 
