### PR TITLE
Feature/#52 공연 상세 내용 전체보기 뷰 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -96,12 +96,15 @@
 		84B321A32B61543E007FD669 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 84B321A22B61543E007FD669 /* FirebaseMessaging */; };
 		84B321A52B61543E007FD669 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 84B321A42B61543E007FD669 /* FirebaseRemoteConfig */; };
 		84B321A72B61543E007FD669 /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 84B321A62B61543E007FD669 /* FirebaseRemoteConfigSwift */; };
+		84DF59DA2B722E5B000816DA /* UpdatePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59D92B722E5B000816DA /* UpdatePopupViewController.swift */; };
+		84DF59DC2B722EA0000816DA /* UpdatePopupDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59DB2B722EA0000816DA /* UpdatePopupDIContainer.swift */; };
+		84DF59E12B726E0A000816DA /* ConcertContentExpandDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59E02B726E0A000816DA /* ConcertContentExpandDIContainer.swift */; };
+		84DF59E32B726E21000816DA /* ConcertContentExpandViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59E22B726E21000816DA /* ConcertContentExpandViewController.swift */; };
+		84DF59E52B726E3F000816DA /* ConcertContentExpandViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59E42B726E3F000816DA /* ConcertContentExpandViewModel.swift */; };
 		84E5124B2B6E71FD002658D1 /* ConcertDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124A2B6E71FD002658D1 /* ConcertDetailDIContainer.swift */; };
 		84E5124D2B6E7736002658D1 /* ConcertDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124C2B6E7736002658D1 /* ConcertDetailViewController.swift */; };
 		84E5124F2B6E773F002658D1 /* ConcertDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124E2B6E773F002658D1 /* ConcertDetailViewModel.swift */; };
 		84E512532B6E9E0B002658D1 /* ConcertPosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E512522B6E9E0B002658D1 /* ConcertPosterView.swift */; };
-		84DF59DA2B722E5B000816DA /* UpdatePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59D92B722E5B000816DA /* UpdatePopupViewController.swift */; };
-		84DF59DC2B722EA0000816DA /* UpdatePopupDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59DB2B722EA0000816DA /* UpdatePopupDIContainer.swift */; };
 		84EC6A642B6CF973009AC6BB /* BooltiToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EC6A632B6CF973009AC6BB /* BooltiToastView.swift */; };
 		84FBBDF32B673877009462E9 /* ConcertInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBBDF22B673877009462E9 /* ConcertInfoView.swift */; };
 		84FBBDF72B67429D009462E9 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBBDF62B67429D009462E9 /* ImageCacheManager.swift */; };
@@ -252,6 +255,9 @@
 		849FBD502B5E920A006EB865 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		84DF59D92B722E5B000816DA /* UpdatePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePopupViewController.swift; sourceTree = "<group>"; };
 		84DF59DB2B722EA0000816DA /* UpdatePopupDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePopupDIContainer.swift; sourceTree = "<group>"; };
+		84DF59E02B726E0A000816DA /* ConcertContentExpandDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertContentExpandDIContainer.swift; sourceTree = "<group>"; };
+		84DF59E22B726E21000816DA /* ConcertContentExpandViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertContentExpandViewController.swift; sourceTree = "<group>"; };
+		84DF59E42B726E3F000816DA /* ConcertContentExpandViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertContentExpandViewModel.swift; sourceTree = "<group>"; };
 		84E5124A2B6E71FD002658D1 /* ConcertDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailDIContainer.swift; sourceTree = "<group>"; };
 		84E5124C2B6E7736002658D1 /* ConcertDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailViewController.swift; sourceTree = "<group>"; };
 		84E5124E2B6E773F002658D1 /* ConcertDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailViewModel.swift; sourceTree = "<group>"; };
@@ -688,6 +694,7 @@
 				8746AD1E2B6932970037A1B1 /* ConcertEnter */,
 				84E512482B6E702E002658D1 /* ConcertList */,
 				84E512492B6E71B6002658D1 /* ConcertDetail */,
+				84DF59DF2B726C34000816DA /* ConcertContentExpand */,
 			);
 			path = Concert;
 			sourceTree = "<group>";
@@ -768,6 +775,16 @@
 				84DF59D92B722E5B000816DA /* UpdatePopupViewController.swift */,
 			);
 			path = Update;
+			sourceTree = "<group>";
+		};
+		84DF59DF2B726C34000816DA /* ConcertContentExpand */ = {
+			isa = PBXGroup;
+			children = (
+				84DF59E02B726E0A000816DA /* ConcertContentExpandDIContainer.swift */,
+				84DF59E22B726E21000816DA /* ConcertContentExpandViewController.swift */,
+				84DF59E42B726E3F000816DA /* ConcertContentExpandViewModel.swift */,
+			);
+			path = ConcertContentExpand;
 			sourceTree = "<group>";
 		};
 		84E512482B6E702E002658D1 /* ConcertList */ = {
@@ -1207,6 +1224,8 @@
 				84781CC02B5BF98600D37921 /* MypageViewController.swift in Sources */,
 				84FBBE012B677187009462E9 /* BooltiTextField.swift in Sources */,
 				8753CA702B70E322002871C7 /* TicketEntryCodeViewModel.swift in Sources */,
+				84DF59E52B726E3F000816DA /* ConcertContentExpandViewModel.swift in Sources */,
+				84DF59E12B726E0A000816DA /* ConcertContentExpandDIContainer.swift in Sources */,
 				84781C7E2B5BEC0700D37921 /* LoginRequestDTO.swift in Sources */,
 				876E41572B5F972A006BEEB7 /* LoginResponseDTO.swift in Sources */,
 				84781CC52B5BF9DE00D37921 /* TicketListViewController.swift in Sources */,
@@ -1245,6 +1264,7 @@
 				84886E882B6FB166005D2329 /* UIColor+.swift in Sources */,
 				876E414D2B5F8CA8006BEEB7 /* BooltiLoadingIndicatorView.swift in Sources */,
 				84781CCE2B5C005600D37921 /* ConcertListViewController.swift in Sources */,
+				84DF59E32B726E21000816DA /* ConcertContentExpandViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiNavigationBar.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiNavigationBar.swift
@@ -14,6 +14,7 @@ enum NavigationType {
     case ticketingCompletion
     case concertDetail
     case ticketDetail
+    case concertContentExpand
 }
 
 final class BooltiNavigationBar: UIView {
@@ -49,6 +50,7 @@ final class BooltiNavigationBar: UIView {
         case .ticketingCompletion: self.configureTicketingCompletionUI()
         case .concertDetail: self.configureConcertDetailUI()
         case .ticketDetail: self.configureTicketDetailUI()
+        case .concertContentExpand: self.configureConcertContentExpandUI()
         }
     }
     
@@ -108,6 +110,14 @@ extension BooltiNavigationBar {
         self.configureTicketDetailConstraints()
     }
     
+    private func configureConcertContentExpandUI() {
+        self.titleLabel.text = "공연 내용"
+        self.backgroundColor = .grey95
+        
+        self.addSubviews([self.backButton, self.titleLabel])
+        self.configureConcertContentExpandConstraints()
+    }
+    
     private func configureTicketDetailConstraints() {
         self.backButton.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(20)
@@ -124,8 +134,7 @@ extension BooltiNavigationBar {
         }
         
         self.titleLabel.snp.makeConstraints { make in
-            make.left.equalTo(self.backButton).offset(20)
-            make.width.height.equalTo(24)
+            make.left.equalTo(self.backButton.snp.right).offset(4)
             make.bottom.equalToSuperview().inset(10)
         }
     }
@@ -169,7 +178,19 @@ extension BooltiNavigationBar {
             make.width.height.equalTo(24)
             make.bottom.equalToSuperview().inset(10)
         }
-
+    }
+    
+    private func configureConcertContentExpandConstraints() {
+        self.backButton.snp.makeConstraints { make in
+            make.left.equalToSuperview().inset(20)
+            make.width.height.equalTo(24)
+            make.bottom.equalToSuperview().inset(10)
+        }
+        
+        self.titleLabel.snp.makeConstraints { make in
+            make.left.equalTo(self.backButton.snp.right).offset(4)
+            make.bottom.equalToSuperview().inset(10)
+        }
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandDIContainer.swift
@@ -1,0 +1,30 @@
+//
+//  ConcertContentExpandDIContainer.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/6/24.
+//
+
+final class ConcertContentExpandDIContainer {
+
+//    private let concertAPIService: ConcertAPIService
+//
+//    init(concertAPIService: ConcertAPIService) {
+//        self.concertAPIService = concertAPIService
+//    }
+    
+    func createConcertContentExpandViewController(content: String) -> ConcertContentExpandViewController {
+        let viewModel = createConcertContentExpandViewModel(content: content)
+
+        let viewController = ConcertContentExpandViewController(
+            viewModel: viewModel
+        )
+
+        return viewController
+    }
+    
+    private func createConcertContentExpandViewModel(content: String) -> ConcertContentExpandViewModel {
+        return ConcertContentExpandViewModel(content: content)
+    }
+
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandViewController.swift
@@ -1,0 +1,93 @@
+//
+//  ConcertContentExpandViewController.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/6/24.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class ConcertContentExpandViewController: UIViewController {
+    
+    // MARK: Properties
+    
+    private let viewModel: ConcertContentExpandViewModel
+    private let disposeBag = DisposeBag()
+    
+    // MARK: UI Component
+    
+    private let navigationBar = BooltiNavigationBar(type: .concertContentExpand)
+    
+    private let contentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .pretendardR(16)
+        label.textColor = .grey30
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        
+        return label
+    }()
+    
+    // MARK: Init
+    
+    init(viewModel: ConcertContentExpandViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        
+        self.configureUI()
+        self.configureConstraints()
+        self.bindOutputs()
+        self.bindNavigationBar()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+}
+
+// MARK: - Methods
+
+extension ConcertContentExpandViewController {
+    
+    private func bindOutputs() {
+        self.viewModel.output.content
+            .bind(with: self) { owner, content in
+                owner.contentLabel.text = content
+                owner.contentLabel.setLineSpacing(lineSpacing: 6)
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func bindNavigationBar() {
+        self.navigationBar.didBackButtonTap()
+            .emit(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: self.disposeBag)
+    }
+}
+
+// MARK: - UI
+
+extension ConcertContentExpandViewController {
+    
+    private func configureUI() {
+        self.view.addSubviews([self.navigationBar, self.contentLabel])
+        
+        self.view.backgroundColor = .grey95
+    }
+    
+    private func configureConstraints() {
+        self.navigationBar.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
+        }
+        
+        self.contentLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.navigationBar.snp.bottom).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  ConcertContentExpandViewModel.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/6/24.
+//
+
+import Foundation
+import RxRelay
+import RxSwift
+
+final class ConcertContentExpandViewModel {
+    
+    // MARK: Properties
+    
+    private let disposeBag = DisposeBag()
+    
+    struct Output {
+        let content = BehaviorRelay<String>(value: "")
+    }
+    
+    let output: Output
+    
+    // MARK: Init
+    
+    init(content: String) {
+        self.output = Output()
+        
+        self.output.content.accept(content)
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Components/Views/ContentInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Components/Views/ContentInfoView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RxCocoa
 
 final class ContentInfoView: UIView {
     
@@ -73,6 +74,10 @@ extension ContentInfoView {
         self.snp.makeConstraints { make in
             make.height.equalTo(106 + min(self.contentLabel.getLabelHeight(), 246))
         }
+    }
+    
+    func didAddressExpandButtonTap() -> Signal<Void> {
+        return self.expandButton.rx.tap.asSignal()
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
@@ -5,9 +5,6 @@
 //  Created by Juhyeon Byun on 2/3/24.
 //
 
-import Foundation
-import UIKit
-
 final class ConcertDetailDIContainer {
 
 //    private let concertAPIService: ConcertAPIService
@@ -18,12 +15,24 @@ final class ConcertDetailDIContainer {
     
     func createConcertDetailViewController() -> ConcertDetailViewController {
         let viewModel = createConcertDetailViewModel()
+        
+        let concertContentExpandViewControllerFactory: (String) -> ConcertContentExpandViewController = { content in
+            let DIContainer = self.createConcertContentExpandDIContainer()
+
+            let viewController = DIContainer.createConcertContentExpandViewController(content: content)
+            return viewController
+        }
 
         let viewController = ConcertDetailViewController(
-            viewModel: viewModel
+            viewModel: viewModel, 
+            concertContentExpandViewControllerFactory: concertContentExpandViewControllerFactory
         )
 
         return viewController
+    }
+    
+    private func createConcertContentExpandDIContainer() -> ConcertContentExpandDIContainer {
+        return ConcertContentExpandDIContainer()
     }
     
     private func createConcertDetailViewModel() -> ConcertDetailViewModel {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -16,6 +16,8 @@ final class ConcertDetailViewController: BooltiViewController {
     private let viewModel: ConcertDetailViewModel
     private let disposeBag = DisposeBag()
     
+    private let concertContentExpandViewControllerFactory: (String) -> ConcertContentExpandViewController
+    
     // MARK: UI Component
     
     private let navigationView = BooltiNavigationBar(type: .concertDetail)
@@ -71,8 +73,11 @@ final class ConcertDetailViewController: BooltiViewController {
     
     // MARK: Init
     
-    init(viewModel: ConcertDetailViewModel) {
+    init(viewModel: ConcertDetailViewModel,
+         concertContentExpandViewControllerFactory: @escaping (String) -> ConcertContentExpandViewController) {
         self.viewModel = viewModel
+        self.concertContentExpandViewControllerFactory = concertContentExpandViewControllerFactory
+        
         super.init()
     }
 
@@ -91,6 +96,7 @@ final class ConcertDetailViewController: BooltiViewController {
         self.configureConstraints()
         self.configureToastView(isButtonExisted: true)
         self.bindPlaceInfoView()
+        self.bindContentInfoView()
         self.bindNavigationView()
         self.bindOutputs()
     }
@@ -140,6 +146,17 @@ extension ConcertDetailViewController {
             .emit(with: self) { owner, _ in
                 UIPasteboard.general.string = self.viewModel.output.concertDetail.value.streetAddress
                 owner.showToast(message: "공연장 주소가 복사되었어요")
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func bindContentInfoView() {
+        self.contentInfoView.didAddressExpandButtonTap()
+            .emit(with: self) { owner, _ in
+                let content = owner.viewModel.output.concertDetail.value.notice
+                let viewController = owner.concertContentExpandViewControllerFactory(content)
+                
+                owner.navigationController?.pushViewController(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)
     }


### PR DESCRIPTION
## 작업한 내용
- 공연 상세 내용에서 전체보기 버튼을 눌렀을 때 나오는 뷰를 구현했어요.

## 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2024-02-07 at 00 21 17](https://github.com/Nexters/Boolti-iOS/assets/58043306/c8599005-558b-4afb-b318-23d4cb341f1d)

## 관련 이슈
- Resolved: #52 
