### PR TITLE
Feature/#61 EntryCode UI 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		87101EFA2B5DF9A3004BD418 /* RxAppState in Frameworks */ = {isa = PBXBuildFile; productRef = 87101EF92B5DF9A3004BD418 /* RxAppState */; };
 		87101EFC2B5DFC60004BD418 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EFB2B5DFC60004BD418 /* NetworkProvider.swift */; };
 		87101EFE2B5DFCD2004BD418 /* AuthAPIServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EFD2B5DFCD2004BD418 /* AuthAPIServiceType.swift */; };
+		8721400A2B749A5D007C3BC1 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 872140092B749A5D007C3BC1 /* RxKeyboard */; };
 		8724C4BF2B6221A500484BFC /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8724C4BE2B6221A500484BFC /* UIView+.swift */; };
 		8746ACFF2B65F9AF0037A1B1 /* TicketListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746ACFE2B65F9AF0037A1B1 /* TicketListCollectionViewCell.swift */; };
 		8746AD012B67F7610037A1B1 /* TicketMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746AD002B67F7610037A1B1 /* TicketMainView.swift */; };
@@ -362,6 +363,7 @@
 				849FBD4C2B5E8BE9006EB865 /* FirebaseRemoteConfig in Frameworks */,
 				849FBD462B5E8BE9006EB865 /* FirebaseAnalyticsSwift in Frameworks */,
 				84781C642B5BE9C100D37921 /* Moya in Frameworks */,
+				8721400A2B749A5D007C3BC1 /* RxKeyboard in Frameworks */,
 				84781C952B5BF15A00D37921 /* RxKakaoSDKAuth in Frameworks */,
 				84B321A32B61543E007FD669 /* FirebaseMessaging in Frameworks */,
 				84781C992B5BF15A00D37921 /* RxKakaoSDKUser in Frameworks */,
@@ -1069,6 +1071,7 @@
 				8766B5582B641266004F266A /* Differentiator */,
 				8766B55A2B641266004F266A /* RxDataSources */,
 				87FB0D372B6BE7B900B42AF9 /* SwiftJWT */,
+				872140092B749A5D007C3BC1 /* RxKeyboard */,
 			);
 			productName = Boolti;
 			productReference = 84781BC92B5BDAFC00D37921 /* Boolti.app */;
@@ -1106,6 +1109,7 @@
 				849FBD402B5E8BE9006EB865 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				8766B5572B641266004F266A /* XCRemoteSwiftPackageReference "RxDataSources" */,
 				87FB0D362B6BE7B900B42AF9 /* XCRemoteSwiftPackageReference "Swift-JWT" */,
+				872140082B749A5D007C3BC1 /* XCRemoteSwiftPackageReference "RxKeyboard" */,
 			);
 			productRefGroup = 84781BCA2B5BDAFC00D37921 /* Products */;
 			projectDirPath = "";
@@ -1569,6 +1573,14 @@
 				minimumVersion = 1.7.2;
 			};
 		};
+		872140082B749A5D007C3BC1 /* XCRemoteSwiftPackageReference "RxKeyboard" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RxSwiftCommunity/RxKeyboard.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.1;
+			};
+		};
 		8766B5572B641266004F266A /* XCRemoteSwiftPackageReference "RxDataSources" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RxSwiftCommunity/RxDataSources.git";
@@ -1702,6 +1714,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 87101EF82B5DF9A3004BD418 /* XCRemoteSwiftPackageReference "RxAppState" */;
 			productName = RxAppState;
+		};
+		872140092B749A5D007C3BC1 /* RxKeyboard */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 872140082B749A5D007C3BC1 /* XCRemoteSwiftPackageReference "RxKeyboard" */;
+			productName = RxKeyboard;
 		};
 		8766B5582B641266004F266A /* Differentiator */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		8757BAB02B60069B008503B5 /* OAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757BAAF2B60069B008503B5 /* OAuthResponse.swift */; };
 		8757BAB62B6009B5008503B5 /* SignUpRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757BAB52B6009B5008503B5 /* SignUpRequestDTO.swift */; };
 		8757BAB82B600B1B008503B5 /* SignUpResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757BAB72B600B1B008503B5 /* SignUpResponseDTO.swift */; };
+		876667542B73A82300DDB2B5 /* EntryCodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876667532B73A82300DDB2B5 /* EntryCodeInputView.swift */; };
 		8766B5592B641266004F266A /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = 8766B5582B641266004F266A /* Differentiator */; };
 		8766B55B2B641266004F266A /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = 8766B55A2B641266004F266A /* RxDataSources */; };
 		8769BF962B625DB200DA9A67 /* TermsAgreementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8769BF952B625DB200DA9A67 /* TermsAgreementViewController.swift */; };
@@ -315,6 +316,7 @@
 		8757BAB52B6009B5008503B5 /* SignUpRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestDTO.swift; sourceTree = "<group>"; };
 		8757BAB72B600B1B008503B5 /* SignUpResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpResponseDTO.swift; sourceTree = "<group>"; };
 		876577142B613F8D00BC6805 /* Boolti.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Boolti.entitlements; sourceTree = "<group>"; };
+		876667532B73A82300DDB2B5 /* EntryCodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCodeInputView.swift; sourceTree = "<group>"; };
 		8769BF952B625DB200DA9A67 /* TermsAgreementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAgreementViewController.swift; sourceTree = "<group>"; };
 		8769BF972B625DBF00DA9A67 /* TermsAgreementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAgreementViewModel.swift; sourceTree = "<group>"; };
 		8769BF992B625DC900DA9A67 /* TermsAgreementDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAgreementDIContainer.swift; sourceTree = "<group>"; };
@@ -427,7 +429,6 @@
 				84FEF6182B68ACDD00EBB64F /* TicketingEntity.swift */,
 				842183722B71D75D00A52E1C /* ConcertDetailEntity.swift */,
 				87FB0D3B2B6C09B500B42AF9 /* TicketItemEntity.swift */,
-
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -922,6 +923,7 @@
 				8753CA6B2B70E17B002871C7 /* TicketEntryCodeViewController.swift */,
 				8753CA6D2B70E30D002871C7 /* TicketEntryCodeDIContainer.swift */,
 				8753CA6F2B70E322002871C7 /* TicketEntryCodeViewModel.swift */,
+				876667532B73A82300DDB2B5 /* EntryCodeInputView.swift */,
 			);
 			path = TicketEntryCode;
 			sourceTree = "<group>";
@@ -1222,7 +1224,7 @@
 				84781CBA2B5BF90C00D37921 /* HomeTabBarViewModel.swift in Sources */,
 				84781CC72B5BF9F700D37921 /* TicketListDIContainer.swift in Sources */,
 				842183732B71D75D00A52E1C /* ConcertDetailEntity.swift in Sources */,
-				87FB0D3C2B6C09B500B42AF9 /* TicketItem.swift in Sources */,
+				87FB0D3C2B6C09B500B42AF9 /* TicketItemEntity.swift in Sources */,
 				87FB0D3C2B6C09B500B42AF9 /* TicketItemEntity.swift in Sources */,
 				8769BF9A2B625DC900DA9A67 /* TermsAgreementDIContainer.swift in Sources */,
 				8746AD202B6932B30037A1B1 /* ConcertEnterView.swift in Sources */,
@@ -1254,12 +1256,13 @@
 				84625A182B63E05700CC9077 /* BooltiPaddingLabel.swift in Sources */,
 				87FB0D3A2B6BE97F00B42AF9 /* IdentityTokenDTO.swift in Sources */,
 				84781BE82B5BE17400D37921 /* Enviroment.swift in Sources */,
-				84781C872B5BED9A00D37921 /* BaseAPI.swift in Sources */,
+				84781C872B5BED9A00D37921 /* ServiceAPI.swift in Sources */,
 				84DF59DC2B722EA0000816DA /* UpdatePopupDIContainer.swift in Sources */,
 				84781C872B5BED9A00D37921 /* ServiceAPI.swift in Sources */,
 				84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */,
 				8746AD012B67F7610037A1B1 /* TicketMainView.swift in Sources */,
 				84625A0B2B63B2AE00CC9077 /* TicketSelectionViewModel.swift in Sources */,
+				876667542B73A82300DDB2B5 /* EntryCodeInputView.swift in Sources */,
 				84FEF6172B68A6D100EBB64F /* UIResponder+.swift in Sources */,
 				87D2FABC2B6EBF650027FBE1 /* TicketDetailView.swift in Sources */,
 				8757BAB02B60069B008503B5 /* OAuthResponse.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -235,6 +235,15 @@
       }
     },
     {
+      "identity" : "rxkeyboard",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxKeyboard.git",
+      "state" : {
+        "revision" : "63f6377975c962a1d89f012a6f1e5bebb2c502b7",
+        "version" : "2.0.1"
+      }
+    },
+    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift",

--- a/Boolti/Boolti/Sources/Entities/TicketDetailItemEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/TicketDetailItemEntity.swift
@@ -20,5 +20,5 @@ struct TicketDetailItemEntity {
     let ticketID: Int
     let hostName: String
     let hostPhoneNumber: String
-    let usedTime: String
+    let usedTime: String?
 }

--- a/Boolti/Boolti/Sources/Entities/TicketItemEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/TicketItemEntity.swift
@@ -18,5 +18,7 @@ struct TicketItemEntity: Hashable {
     let location: String
     let qrCode: UIImage
     let ticketID: Int
-    let usedTime: String
+    let usedTime: String?
 }
+
+

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Response/TicketDetailResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Response/TicketDetailResponseDTO.swift
@@ -20,7 +20,7 @@ struct TicketDetailResponseDTO: Decodable {
     let ticketName: String
     let notice: String
     let entryCode: String
-    let usedAt: String
+    let usedAt: String?
     let hostName: String
     let hostPhoneNumber: String
 }

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Response/TicketListItemResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Response/TicketListItemResponseDTO.swift
@@ -17,7 +17,7 @@ struct TicketListItemResponseDTO: Decodable {
     let ticketType: String
     let ticketName: String
     let entryCode: String
-    let usedAt: String
+    let usedAt: String?
 }
 
 extension TicketListItemResponseDTO {

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiTextField.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiTextField.swift
@@ -10,14 +10,12 @@ import UIKit
 final class BooltiTextField: UITextField {
 
     // MARK: Init
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        configureUI()
-        configureConstraints()
+    init(backgroundColor: UIColor = .grey85) {
+        super.init(frame: .zero)
+        self.configureUI(backgroundColor: backgroundColor)
+        self.configureConstraints()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
@@ -27,10 +25,10 @@ final class BooltiTextField: UITextField {
 
 extension BooltiTextField {
     
-    func setPlaceHolderText(placeholder: String) {
+    func setPlaceHolderText(placeholder: String, foregroundColor: UIColor = UIColor.grey70) {
         self.placeholder = placeholder
         self.attributedPlaceholder = NSAttributedString(string: placeholder,
-                                                        attributes: [.foregroundColor: UIColor.grey70,
+                                                        attributes: [.foregroundColor: foregroundColor,
                                                                      .font: UIFont.body3])
     }
 }
@@ -39,12 +37,12 @@ extension BooltiTextField {
 
 extension BooltiTextField {
     
-    private func configureUI() {
+    private func configureUI(backgroundColor: UIColor = .grey85) {
         self.layer.cornerRadius = 4
         self.font = .body3
         self.textColor = .grey15
-        self.backgroundColor = .grey85
-        
+        self.backgroundColor = backgroundColor
+
         self.addLeftPadding()
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -65,11 +65,7 @@ class TicketDetailViewController: BooltiViewController {
     override func viewWillAppear(_ animated: Bool) {
         self.tabBarController?.tabBar.isHidden = true
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        self.tabBarController?.tabBar.isHidden = true
-    }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -150,8 +150,7 @@ class TicketDetailViewController: BooltiViewController {
         self.entryCodeButton.rx.tap
             .bind(with: self) { owner, _ in
                 let viewController = owner.ticketEntryCodeControllerFactory()
-                owner.modalPresentationStyle = .overFullScreen
-
+                viewController.modalPresentationStyle = .overFullScreen
                 owner.present(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -150,7 +150,8 @@ class TicketDetailViewController: BooltiViewController {
         self.entryCodeButton.rx.tap
             .bind(with: self) { owner, _ in
                 let viewController = owner.ticketEntryCodeControllerFactory()
-                viewController.modalPresentationStyle = .overFullScreen
+                owner.modalPresentationStyle = .overFullScreen
+
                 owner.present(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxRelay
 import RxCocoa
 
-class EntryCodeInputView: UIView {
+final class EntryCodeInputView: UIView {
 
     private let disposeBag = DisposeBag()
 
@@ -177,12 +177,4 @@ class EntryCodeInputView: UIView {
         }
         self.layoutIfNeeded()
     }
-
-    //    func disableCheckButton() {
-    //        self.checkButton.isEnabled = false
-    //    }
-    //
-    //    func enableCheckButton() {
-    //        self.checkButton.isEnabled = true
-    //    }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
@@ -18,6 +18,7 @@ class EntryCodeInputView: UIView {
     var textFieldText = PublishRelay<String>()
     var enableCheckButton = PublishRelay<Bool>()
     var didCheckButtonTap = PublishRelay<Void>()
+    var didCloseButtonTap = PublishRelay<Void>()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -146,6 +147,10 @@ class EntryCodeInputView: UIView {
 
         self.checkButton.rx.tap
             .bind(to: self.didCheckButtonTap)
+            .disposed(by: self.disposeBag)
+
+        self.closeButton.rx.tap
+            .bind(to: self.didCloseButtonTap)
             .disposed(by: self.disposeBag)
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
@@ -7,7 +7,16 @@
 
 import UIKit
 
+import RxSwift
+import RxRelay
+import RxCocoa
+
 class EntryCodeInputView: UIView {
+
+    private let disposeBag = DisposeBag()
+
+    var textFieldText = PublishSubject<String>()
+    var enableCheckButton = PublishSubject<Bool>()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -22,9 +31,10 @@ class EntryCodeInputView: UIView {
         let label = UILabel()
         label.text = "입장 코드는 마이 > QR 스캔 > \n 해당 공연 스캐너에서 확인 가능해요"
         label.numberOfLines = 0
-        label.textAlignment = .center
         label.textColor = .grey50
         label.font = .body1
+        label.setLineSpacing(lineSpacing: 3)
+        label.textAlignment = .center
 
         return label
     }()
@@ -51,6 +61,7 @@ class EntryCodeInputView: UIView {
         super.init(frame: .zero)
         self.configureUI()
         self.configureConstraints()
+        self.bindUIComponents()
     }
 
     required init?(coder: NSCoder) {
@@ -60,6 +71,7 @@ class EntryCodeInputView: UIView {
     private func configureUI() {
         self.backgroundColor = .grey85
         self.layer.cornerRadius = 8
+        self.checkButton.isEnabled = false
 
         self.addSubviews([
             self.closeButton,
@@ -100,4 +112,27 @@ class EntryCodeInputView: UIView {
             make.horizontalEdges.equalTo(self.entryCodeInputTextField)
         }
     }
+
+    private func bindUIComponents() {
+        self.entryCodeInputTextField.rx.text
+            .orEmpty
+            .distinctUntilChanged()
+            .bind(to: self.textFieldText)
+            .disposed(by: self.disposeBag)
+
+        self.enableCheckButton
+            .distinctUntilChanged()
+            .bind(with: self, onNext: { owner, enableCheckButton in
+                self.checkButton.isEnabled = enableCheckButton
+            })
+            .disposed(by: self.disposeBag)
+    }
+
+//    func disableCheckButton() {
+//        self.checkButton.isEnabled = false
+//    }
+//
+//    func enableCheckButton() {
+//        self.checkButton.isEnabled = true
+//    }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
@@ -149,21 +149,35 @@ class EntryCodeInputView: UIView {
             .disposed(by: self.disposeBag)
     }
 
-    func showErrorComments() {
-        self.errorCommentLabel.isHidden = false
-        self.entryCodeInputTextField.layer.borderColor = UIColor.error.cgColor
-        self.entryCodeInputTextField.layer.borderWidth = 1
-
-        self.snp.updateConstraints { make in
-            make.height.equalTo(316)
+    var isInvalidEntryCodeTyped: Bool = true {
+        didSet {
+            self.setErrorCommentUI()
         }
     }
 
-//    func disableCheckButton() {
-//        self.checkButton.isEnabled = false
-//    }
-//
-//    func enableCheckButton() {
-//        self.checkButton.isEnabled = true
-//    }
+    private func setErrorCommentUI() {
+        self.errorCommentLabel.isHidden.toggle()
+        if self.isInvalidEntryCodeTyped {
+            self.entryCodeInputTextField.layer.borderColor = nil
+            self.entryCodeInputTextField.layer.borderWidth = 0
+            self.snp.updateConstraints { make in
+                make.height.equalTo(286)
+            }
+        } else {
+            self.entryCodeInputTextField.layer.borderColor = UIColor.error.cgColor
+            self.entryCodeInputTextField.layer.borderWidth = 1
+            self.snp.updateConstraints { make in
+                make.height.equalTo(316)
+            }
+        }
+        self.layoutIfNeeded()
+    }
+
+    //    func disableCheckButton() {
+    //        self.checkButton.isEnabled = false
+    //    }
+    //
+    //    func enableCheckButton() {
+    //        self.checkButton.isEnabled = true
+    //    }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
@@ -15,8 +15,9 @@ class EntryCodeInputView: UIView {
 
     private let disposeBag = DisposeBag()
 
-    var textFieldText = PublishSubject<String>()
-    var enableCheckButton = PublishSubject<Bool>()
+    var textFieldText = PublishRelay<String>()
+    var enableCheckButton = PublishRelay<Bool>()
+    var didCheckButtonTap = PublishRelay<Void>()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -51,6 +52,16 @@ class EntryCodeInputView: UIView {
         return button
     }()
 
+    private let errorCommentLabel: UILabel = {
+        let label = UILabel()
+        label.text = "올바른 입장 코드를 입력해 주세요."
+        label.font = .body1
+        label.textColor = .error
+        label.isHidden = true
+
+        return label
+    }()
+
     private let closeButton: UIButton = {
         let button = UIButton()
         button.setImage(.closeButton.withTintColor(.grey50), for: .normal)
@@ -78,6 +89,7 @@ class EntryCodeInputView: UIView {
             self.titleLabel,
             self.descriptionLabel,
             self.entryCodeInputTextField,
+            self.errorCommentLabel,
             self.checkButton
         ])
     }
@@ -107,8 +119,13 @@ class EntryCodeInputView: UIView {
             make.horizontalEdges.equalToSuperview().inset(20)
         }
 
+        self.errorCommentLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.entryCodeInputTextField.snp.bottom).offset(8)
+            make.horizontalEdges.equalTo(self.entryCodeInputTextField)
+        }
+
         self.checkButton.snp.makeConstraints { make in
-            make.top.equalTo(self.entryCodeInputTextField.snp.bottom).offset(28)
+            make.bottom.equalToSuperview().inset(20)
             make.horizontalEdges.equalTo(self.entryCodeInputTextField)
         }
     }
@@ -126,6 +143,20 @@ class EntryCodeInputView: UIView {
                 self.checkButton.isEnabled = enableCheckButton
             })
             .disposed(by: self.disposeBag)
+
+        self.checkButton.rx.tap
+            .bind(to: self.didCheckButtonTap)
+            .disposed(by: self.disposeBag)
+    }
+
+    func showErrorComments() {
+        self.errorCommentLabel.isHidden = false
+        self.entryCodeInputTextField.layer.borderColor = UIColor.error.cgColor
+        self.entryCodeInputTextField.layer.borderWidth = 1
+
+        self.snp.updateConstraints { make in
+            make.height.equalTo(316)
+        }
     }
 
 //    func disableCheckButton() {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/EntryCodeInputView.swift
@@ -1,0 +1,103 @@
+//
+//  EntryCodeInputView.swift
+//  Boolti
+//
+//  Created by Miro on 2/7/24.
+//
+
+import UIKit
+
+class EntryCodeInputView: UIView {
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "입장 코드로 입장 확인"
+        label.font = .subhead2
+        label.textColor = .grey15
+
+        return label
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "입장 코드는 마이 > QR 스캔 > \n 해당 공연 스캐너에서 확인 가능해요"
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.textColor = .grey50
+        label.font = .body1
+
+        return label
+    }()
+
+    private let entryCodeInputTextField: BooltiTextField = {
+        let textField = BooltiTextField(backgroundColor: .grey80)
+        textField.setPlaceHolderText(placeholder: "입장 코드를 입력해 주세요.", foregroundColor: .grey60)
+
+        return textField
+    }()
+
+    private let checkButton: BooltiButton = {
+        let button = BooltiButton(title: "확인")
+        return button
+    }()
+
+    private let closeButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.closeButton.withTintColor(.grey50), for: .normal)
+        return button
+    }()
+
+    init() {
+        super.init(frame: .zero)
+        self.configureUI()
+        self.configureConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureUI() {
+        self.backgroundColor = .grey85
+        self.layer.cornerRadius = 8
+
+        self.addSubviews([
+            self.closeButton,
+            self.titleLabel,
+            self.descriptionLabel,
+            self.entryCodeInputTextField,
+            self.checkButton
+        ])
+    }
+
+    private func configureConstraints() {
+        self.snp.makeConstraints { make in
+            make.width.equalTo(311)
+            make.height.equalTo(286)
+        }
+
+        self.closeButton.snp.makeConstraints { make in
+            make.top.right.equalToSuperview().inset(12)
+        }
+
+        self.titleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(48)
+        }
+
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(4)
+        }
+
+        self.entryCodeInputTextField.snp.makeConstraints { make in
+            make.top.equalTo(self.descriptionLabel.snp.bottom).offset(24)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+
+        self.checkButton.snp.makeConstraints { make in
+            make.top.equalTo(self.entryCodeInputTextField.snp.bottom).offset(28)
+            make.horizontalEdges.equalTo(self.entryCodeInputTextField)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -7,21 +7,26 @@
 
 import UIKit
 
-class TicketEntryCodeViewController: UIViewController {
+import RxSwift
+import RxCocoa
+
+class TicketEntryCodeViewController: BooltiViewController {
 
     private let viewModel: TicketEntryCodeViewModel
 
-    private let entryCodeInputView = EntryCodeInputView()
+    private let disposeBag = DisposeBag()
 
+    private let entryCodeInputView = EntryCodeInputView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
+        self.bindUIComponents()
     }
 
     init(viewModel: TicketEntryCodeViewModel) {
         self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        super.init()
     }
     
     required init?(coder: NSCoder) {
@@ -35,5 +40,31 @@ class TicketEntryCodeViewController: UIViewController {
         self.entryCodeInputView.snp.makeConstraints { make in
             make.center.equalToSuperview()
         }
+    }
+
+    private func bindUIComponents() {
+//        self.entryCodeInputView.textFieldText
+//            .asDriver(onErrorJustReturn: "")
+//            .drive(with: self) { owner, text in
+//                print(text)
+//                if text == "" {
+//                    owner.entryCodeInputView.disableCheckButton()
+//                } else {
+//                    owner.entryCodeInputView.enableCheckButton()
+//                }
+//            }
+//            .disposed(by: self.disposeBag)
+
+        self.entryCodeInputView.textFieldText
+            .asDriver(onErrorJustReturn: "")
+            .drive(with: self) { owner, text in
+                print(text)
+                if text == "" {
+                    owner.entryCodeInputView.enableCheckButton.onNext(false)
+                } else {
+                    owner.entryCodeInputView.enableCheckButton.onNext(true)
+                }
+            }
+            .disposed(by: self.disposeBag)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -22,6 +22,7 @@ class TicketEntryCodeViewController: BooltiViewController {
         super.viewDidLoad()
         self.configureUI()
         self.bindUIComponents()
+        self.bindViewModel()
     }
 
     init(viewModel: TicketEntryCodeViewModel) {
@@ -42,27 +43,56 @@ class TicketEntryCodeViewController: BooltiViewController {
         }
     }
 
+    private func bindViewModel() {
+        self.bindInputs()
+        self.bindOutputs()
+    }
+
+    private func bindInputs() {
+
+        self.entryCodeInputView.didCheckButtonTap
+            .do(onNext: { [weak self] _ in
+                self?.view.endEditing(true)
+            })
+            .bind(to: self.viewModel.input.didCheckButtonTapEvent)
+            .disposed(by: self.disposeBag)
+    }
+
+    private func bindOutputs() {
+        self.viewModel.output.isValidEntryCode
+            .asDriver(onErrorJustReturn: false)
+            .drive(with: self) { owner, isValid in
+                if isValid {
+                    // dismiss하고 토스트 이미지 띄우기
+                } else {
+                    print("뭔데...")
+                    // 올바른 입장 코드를 입력해 주세요.
+                    owner.entryCodeInputView.showErrorComments()
+                }
+            }
+    }
+
     private func bindUIComponents() {
-//        self.entryCodeInputView.textFieldText
-//            .asDriver(onErrorJustReturn: "")
-//            .drive(with: self) { owner, text in
-//                print(text)
-//                if text == "" {
-//                    owner.entryCodeInputView.disableCheckButton()
-//                } else {
-//                    owner.entryCodeInputView.enableCheckButton()
-//                }
-//            }
-//            .disposed(by: self.disposeBag)
+
+        //        self.entryCodeInputView.textFieldText
+        //            .asDriver(onErrorJustReturn: "")
+        //            .drive(with: self) { owner, text in
+        //                print(text)
+        //                if text == "" {
+        //                    owner.entryCodeInputView.disableCheckButton()
+        //                } else {
+        //                    owner.entryCodeInputView.enableCheckButton()
+        //                }
+        //            }
+        //            .disposed(by: self.disposeBag)
 
         self.entryCodeInputView.textFieldText
             .asDriver(onErrorJustReturn: "")
             .drive(with: self) { owner, text in
-                print(text)
                 if text == "" {
-                    owner.entryCodeInputView.enableCheckButton.onNext(false)
+                    owner.entryCodeInputView.enableCheckButton.accept(false)
                 } else {
-                    owner.entryCodeInputView.enableCheckButton.onNext(true)
+                    owner.entryCodeInputView.enableCheckButton.accept(true)
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -11,10 +11,12 @@ class TicketEntryCodeViewController: UIViewController {
 
     private let viewModel: TicketEntryCodeViewModel
 
+    private let entryCodeInputView = EntryCodeInputView()
+
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .black100.withAlphaComponent(0.85)
+        self.configureUI()
     }
 
     init(viewModel: TicketEntryCodeViewModel) {
@@ -24,5 +26,14 @@ class TicketEntryCodeViewController: UIViewController {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureUI() {
+        self.view.backgroundColor = .black100.withAlphaComponent(0.85)
+        self.view.addSubview(self.entryCodeInputView)
+
+        self.entryCodeInputView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -30,7 +30,7 @@ class TicketEntryCodeViewController: BooltiViewController {
         self.viewModel = viewModel
         super.init()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -96,26 +96,10 @@ class TicketEntryCodeViewController: BooltiViewController {
             }
             .disposed(by: self.disposeBag)
 
-        //        self.entryCodeInputView.textFieldText
-        //            .asDriver(onErrorJustReturn: "")
-        //            .drive(with: self) { owner, text in
-        //                print(text)
-        //                if text == "" {
-        //                    owner.entryCodeInputView.disableCheckButton()
-        //                } else {
-        //                    owner.entryCodeInputView.enableCheckButton()
-        //                }
-        //            }
-        //            .disposed(by: self.disposeBag)
-
         self.entryCodeInputView.textFieldText
             .asDriver(onErrorJustReturn: "")
             .drive(with: self) { owner, text in
-                if text == "" {
-                    owner.entryCodeInputView.enableCheckButton.accept(false)
-                } else {
-                    owner.entryCodeInputView.enableCheckButton.accept(true)
-                }
+                owner.entryCodeInputView.enableCheckButton.accept(!text.isEmpty)
 
                 guard !owner.entryCodeInputView.isInvalidEntryCodeTyped else { return }
                 owner.entryCodeInputView.isInvalidEntryCodeTyped = true

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -88,7 +88,6 @@ class TicketEntryCodeViewController: BooltiViewController {
         RxKeyboard.instance.visibleHeight
             .skip(1)
             .drive(with: self) { owner, keyBoardHeight in
-                print(keyBoardHeight)
                 if keyBoardHeight == 0 {
                     owner.view.frame.origin.y = 0
                 } else {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import RxSwift
 import RxCocoa
+import RxKeyboard
 
 class TicketEntryCodeViewController: BooltiViewController {
 
@@ -44,6 +45,7 @@ class TicketEntryCodeViewController: BooltiViewController {
     }
 
     private func bindViewModel() {
+
         self.bindInputs()
         self.bindOutputs()
     }
@@ -59,6 +61,7 @@ class TicketEntryCodeViewController: BooltiViewController {
     }
 
     private func bindOutputs() {
+
         self.viewModel.output.isValidEntryCode
             .asDriver(onErrorJustReturn: false)
             .drive(with: self) { owner, isValid in
@@ -81,6 +84,18 @@ class TicketEntryCodeViewController: BooltiViewController {
     }
 
     private func bindUIComponents() {
+
+        RxKeyboard.instance.visibleHeight
+            .skip(1)
+            .drive(with: self) { owner, keyBoardHeight in
+                print(keyBoardHeight)
+                if keyBoardHeight == 0 {
+                    owner.view.frame.origin.y = 0
+                } else {
+                    owner.view.frame.origin.y -= 50
+                }
+            }
+            .disposed(by: self.disposeBag)
 
         //        self.entryCodeInputView.textFieldText
         //            .asDriver(onErrorJustReturn: "")
@@ -105,6 +120,15 @@ class TicketEntryCodeViewController: BooltiViewController {
 
                 guard !owner.entryCodeInputView.isInvalidEntryCodeTyped else { return }
                 owner.entryCodeInputView.isInvalidEntryCodeTyped = true
+            }
+            .disposed(by: self.disposeBag)
+
+
+        self.entryCodeInputView.didCloseButtonTap
+            .take(1)
+            .asDriver(onErrorJustReturn: ())
+            .drive(with: self) { owner, _ in
+                owner.dismiss(animated: true)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -64,12 +64,20 @@ class TicketEntryCodeViewController: BooltiViewController {
             .drive(with: self) { owner, isValid in
                 if isValid {
                     // dismiss하고 토스트 이미지 띄우기
+                    guard let homeTabBarController = owner.presentingViewController as? HomeTabBarController else { return }
+                    guard let rootviewController = homeTabBarController.children[1] as? UINavigationController else { return }
+                    guard let ticketDetailViewController = rootviewController.viewControllers.filter({ $0 is TicketDetailViewController
+                    })[0] as? TicketDetailViewController else { return }
+
+                    owner.dismiss(animated: true) {
+                        ticketDetailViewController.showToast(message: "입장을 확인했어요")
+                    }
                 } else {
-                    print("뭔데...")
                     // 올바른 입장 코드를 입력해 주세요.
-                    owner.entryCodeInputView.showErrorComments()
+                    owner.entryCodeInputView.isInvalidEntryCodeTyped = false
                 }
             }
+            .disposed(by: self.disposeBag)
     }
 
     private func bindUIComponents() {
@@ -94,6 +102,9 @@ class TicketEntryCodeViewController: BooltiViewController {
                 } else {
                     owner.entryCodeInputView.enableCheckButton.accept(true)
                 }
+
+                guard !owner.entryCodeInputView.isInvalidEntryCodeTyped else { return }
+                owner.entryCodeInputView.isInvalidEntryCodeTyped = true
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewModel.swift
@@ -45,8 +45,9 @@ class TicketEntryCodeViewModel {
             }
             .disposed(by: self.disposeBag)
     }
-
+    
+    // API 올라오면 붙힐 예정!
     private func validateEntryCode() -> Single<Bool> {
-        return Single.just(true)
+        return Single.just(false)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewModel.swift
@@ -41,13 +41,12 @@ class TicketEntryCodeViewModel {
         self.input.didCheckButtonTapEvent
             .flatMap { self.validateEntryCode() }
             .subscribe(with: self) { owner, isValid in
-                print("🔥🔥🔥🔥🔥")
                 owner.output.isValidEntryCode.accept(isValid)
             }
             .disposed(by: self.disposeBag)
     }
 
     private func validateEntryCode() -> Single<Bool> {
-        return Single.just(false)
+        return Single.just(true)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewModel.swift
@@ -7,11 +7,47 @@
 
 import Foundation
 
+import RxSwift
+import RxMoya
+import RxRelay
+
 class TicketEntryCodeViewModel {
-    
+
+    struct Input {
+        var didCheckButtonTapEvent = PublishSubject<Void>()
+    }
+
+    struct Output {
+        let isValidEntryCode = PublishRelay<Bool>()
+    }
+
+    let input: Input
+    let output: Output
+
+    private let disposeBag = DisposeBag()
+
     private let networkService: NetworkProviderType
 
     init(networkService: NetworkProviderType) {
         self.networkService = networkService
+
+        self.input = Input()
+        self.output = Output()
+
+        self.bindInputs()
+    }
+
+    private func bindInputs() {
+        self.input.didCheckButtonTapEvent
+            .flatMap { self.validateEntryCode() }
+            .subscribe(with: self) { owner, isValid in
+                print("🔥🔥🔥🔥🔥")
+                owner.output.isValidEntryCode.accept(isValid)
+            }
+            .disposed(by: self.disposeBag)
+    }
+
+    private func validateEntryCode() -> Single<Bool> {
+        return Single.just(false)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewModel.swift
@@ -103,6 +103,7 @@ final class TicketListViewModel {
     }
 
     private func fetchTicketList() -> Single<[TicketItemEntity]> {
+        print(UserDefaults.accessToken)
         // MARK: 의존성 networkService로 바꿔주기!..
         let networkProvider = self.authAPIService.networkService
         let ticketListAPI = TicketAPI.list


### PR DESCRIPTION
## 작업한 내용
- EntryCode UI를 구현했어요.(아직 API가 나오질 않아서 UI만 구현했어요)
- BooltiTextField가 재사용되는데, 기존의 BootlTextField와 다른 점이 있어서 파라미터로 받을 수 있게 수정해주었어요.
- RxKeyboard를 활용해서 Keyboard가 뷰를 가리는 문제를 해결했어요.
- 글자가 채워져야지 버튼을 활성화시키는 로직을 구현했어요.
근데, 이걸 구현하는 과정에서 두 가지 고민이 생겼어요.
1. 매번 TextField의 text 값을 확인해서 text가 채워져있으면 checkButton을 활성화 함수 실행, 채워있지 않으면 checkButton 비활성 함수 실행 (코드 내 주석처리된 부분)
2. 1번의 로직을 한번 PublishRelay로 감싸서, 불필요하게 호출되는 함수 처리를 방지하기.

1번의 경우에는 불필요하게 함수가 호출되어 View에 적용되는데, 2번의 경우에는 distinctUntilChanged로 해당 함수가 적용되는 것을 막아요.
그 대신 2번의 경우에는 rx를 처리를 하니까, 불필요하게 rx가 많이 사용된다는 느낌이 들었어요.

뭔가 코드를 짤 때, 불필요하게 Rx를 많이 쓰면 안될 거 같다는 생각을 하는데, 2번은 너무 Rx를 남용하는 거 아닌가라는 생각도 들기도 해요..🥲
(VC와 View간의 관계에서 rx가 너무 많이 사용되는 거 같아서...)

사실 이 모든 게 View의 프러퍼티의 은닉화를 위해서 하는 건데, 이걸 위해서 rx를 덕지덕지 붙히는 게 맞나 생각이 들기도 해요!(저번에 주현이랑 이야기했던 것 처럼) 왜냐하면 하나하나씩 rx로 연결하면 공수가 너무 많이 드는 거 같아서요.

이 부분에 대한 주현이의 의견이 궁금해요오!!

## 스크린샷

https://github.com/Nexters/Boolti-iOS/assets/85781941/26d82332-14dc-4fd1-a99f-3099d2271e20



## 관련 이슈
- Resolved: #61 
