### PR TITLE
Feature/#63 예매하기 -> 티켓 선택 화면 연결, 티켓 선택 api 연결

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		841D77DF2B7463020068B1C5 /* TicketListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746ACFE2B65F9AF0037A1B1 /* TicketListCollectionViewCell.swift */; };
 		841D77E12B7464250068B1C5 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841D77E02B7464250068B1C5 /* UIImageView+.swift */; };
 		842183732B71D75D00A52E1C /* ConcertDetailEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842183722B71D75D00A52E1C /* ConcertDetailEntity.swift */; };
+		8453D7FC2B7539270048F103 /* SalesTicketResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8453D7FB2B7539270048F103 /* SalesTicketResponseDTO.swift */; };
+		8453D7FE2B7539770048F103 /* SalesTicketRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8453D7FD2B7539770048F103 /* SalesTicketRequestDTO.swift */; };
 		84625A042B6382C300CC9077 /* BooltiBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84625A032B6382C300CC9077 /* BooltiBottomSheetViewController.swift */; };
 		84625A092B63A01100CC9077 /* TicketSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84625A082B63A01100CC9077 /* TicketSelectionViewController.swift */; };
 		84625A0B2B63B2AE00CC9077 /* TicketSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84625A0A2B63B2AE00CC9077 /* TicketSelectionViewModel.swift */; };
@@ -203,6 +205,8 @@
 		841D77D72B73D2A20068B1C5 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		841D77E02B7464250068B1C5 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		842183722B71D75D00A52E1C /* ConcertDetailEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailEntity.swift; sourceTree = "<group>"; };
+		8453D7FB2B7539270048F103 /* SalesTicketResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesTicketResponseDTO.swift; sourceTree = "<group>"; };
+		8453D7FD2B7539770048F103 /* SalesTicketRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesTicketRequestDTO.swift; sourceTree = "<group>"; };
 		84625A032B6382C300CC9077 /* BooltiBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiBottomSheetViewController.swift; sourceTree = "<group>"; };
 		84625A082B63A01100CC9077 /* TicketSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketSelectionViewController.swift; sourceTree = "<group>"; };
 		84625A0A2B63B2AE00CC9077 /* TicketSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketSelectionViewModel.swift; sourceTree = "<group>"; };
@@ -813,6 +817,7 @@
 			isa = PBXGroup;
 			children = (
 				84DC6F662B728858001F9576 /* ConcertDetailRequestDTO.swift */,
+				8453D7FD2B7539770048F103 /* SalesTicketRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -821,6 +826,7 @@
 			isa = PBXGroup;
 			children = (
 				84C6E0022B7320280023BAE6 /* ConcertDetailResponseDTO.swift */,
+				8453D7FB2B7539270048F103 /* SalesTicketResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1239,6 +1245,7 @@
 				84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */,
 				876E414F2B5F915E006BEEB7 /* BooltiViewController.swift in Sources */,
 				847AA70E2B62B55500E5B55C /* BooltiNavigationBar.swift in Sources */,
+				8453D7FC2B7539270048F103 /* SalesTicketResponseDTO.swift in Sources */,
 				84896A4F2B6A723900CB3E33 /* Date+.swift in Sources */,
 				84781BEE2B5BE3B600D37921 /* NetworkError.swift in Sources */,
 				8724C4BF2B6221A500484BFC /* UIView+.swift in Sources */,
@@ -1320,6 +1327,7 @@
 				8753CA6C2B70E17B002871C7 /* TicketEntryCodeViewController.swift in Sources */,
 				84EC6A642B6CF973009AC6BB /* BooltiToastView.swift in Sources */,
 				84625A162B63C33D00CC9077 /* UITableViewCell+.swift in Sources */,
+				8453D7FE2B7539770048F103 /* SalesTicketRequestDTO.swift in Sources */,
 				84625A092B63A01100CC9077 /* TicketSelectionViewController.swift in Sources */,
 				8757BAAA2B5FDF29008503B5 /* KakaoOAuth.swift in Sources */,
 				84E5124F2B6E773F002658D1 /* ConcertDetailViewModel.swift in Sources */,

--- a/Boolti/Boolti/Sources/Entities/SalesTicketEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/SalesTicketEntity.swift
@@ -10,7 +10,7 @@ import Foundation
 struct SalesTicketEntity {
     // 일단 여러 티켓 살 수 없음을 가정해서 매수는 1개로 고정
     let id: Int
-    let showId: Int
+    let concertId: Int
     let ticketType: TicketType
     let ticketName: String
     let price: Int

--- a/Boolti/Boolti/Sources/Entities/SalesTicketEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/SalesTicketEntity.swift
@@ -16,8 +16,8 @@ struct SalesTicketEntity {
     let price: Int
     let quantity: Int
     
-    enum TicketType {
-        case sales
-        case invite
+    enum TicketType: String {
+        case sales = "SALE"
+        case invite = "INVITE"
     }
 }

--- a/Boolti/Boolti/Sources/Network/APIs/ConcertAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/ConcertAPI.swift
@@ -12,6 +12,7 @@ import Moya
 enum ConcertAPI {
 
     case detail(requestDTO: ConcertDetailRequestDTO)
+    case salesTicket(requestDTO: SalesTicketRequestDTO)
 }
 
 extension ConcertAPI: ServiceAPI {
@@ -20,6 +21,8 @@ extension ConcertAPI: ServiceAPI {
         switch self {
         case .detail(let DTO):
             return "/papi/v1/show/\(DTO.id)"
+        case .salesTicket(let DTO):
+            return "/api/v1/sales-ticket-type/\(DTO.showId)"
         }
     }
     

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Request/SalesTicketRequestDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Request/SalesTicketRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  SalesTicketRequestDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/9/24.
+//
+
+import Foundation
+
+struct SalesTicketRequestDTO {
+    
+    let showId: Int
+}

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertDetailResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertDetailResponseDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ConcertDetailResponseDTO: Codable {
+struct ConcertDetailResponseDTO: Decodable {
     
     let id: Int
     let groupId: Int
@@ -28,7 +28,7 @@ struct ConcertDetailResponseDTO: Codable {
     let hostName: String
     let hostPhoneNumber: String
     
-    struct ShowImg: Codable {
+    struct ShowImg: Decodable {
         let id: Int
         let showId: Int
         let path: String

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Response/SalesTicketResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Response/SalesTicketResponseDTO.swift
@@ -1,0 +1,44 @@
+//
+//  SalesTicketResponseDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/9/24.
+//
+
+import Foundation
+
+struct SalesTicketResponseDTOElement: Decodable {
+    let id: Int
+    let showId: Int
+    let ticketType: String
+    let ticketName: String
+    let price: Int
+    let quantity: Int
+}
+
+typealias SalesTicketResponseDTO = [SalesTicketResponseDTOElement]
+
+extension SalesTicketResponseDTO {
+    
+    func convertToSalesTicketEntities() -> [SalesTicketEntity] {
+        return self.map { ticket in
+            var ticketType: SalesTicketEntity.TicketType = .invite
+            
+            switch ticket.ticketType {
+            case TicketType.invitation.rawValue:
+                ticketType = .invite
+            case TicketType.sale.rawValue:
+                ticketType = .sales
+            default:
+                break
+            }
+            
+            return SalesTicketEntity(id: ticket.id,
+                                     showId: ticket.showId,
+                                     ticketType: ticketType,
+                                     ticketName: ticket.ticketName,
+                                     price: ticket.price,
+                                     quantity: ticket.quantity)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Response/SalesTicketResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Response/SalesTicketResponseDTO.swift
@@ -34,7 +34,7 @@ extension SalesTicketResponseDTO {
             }
             
             return SalesTicketEntity(id: ticket.id,
-                                     showId: ticket.showId,
+                                     concertId: ticket.showId,
                                      ticketType: ticketType,
                                      ticketName: ticket.ticketName,
                                      price: ticket.price,

--- a/Boolti/Boolti/Sources/Network/Repositories/ConcertRepository.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/ConcertRepository.swift
@@ -24,4 +24,13 @@ final class ConcertRepository: ConcertRepositoryType {
             .map(ConcertDetailResponseDTO.self)
             .map { $0.convertToConcertDetailEntity() }
     }
+    
+    func salesTicket(concertId: Int) -> Single<[SalesTicketEntity]> {
+        let salesTicketRequestDTO = SalesTicketRequestDTO(showId: concertId)
+        let api = ConcertAPI.salesTicket(requestDTO: salesTicketRequestDTO)
+        
+        return networkService.request(api)
+            .map(SalesTicketResponseDTO.self)
+            .map { $0.convertToSalesTicketEntities() }
+    }
 }

--- a/Boolti/Boolti/Sources/Network/Repositories/Protocol/ConcertRepositoryType.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Protocol/ConcertRepositoryType.swift
@@ -11,4 +11,5 @@ protocol ConcertRepositoryType {
 
     var networkService: NetworkProviderType { get }
     func concertDetail(concertId: Int) -> Single<ConcertDetailEntity>
+    func salesTicket(concertId: Int) -> Single<[SalesTicketEntity]>
 }

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiBottomSheetViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiBottomSheetViewController.swift
@@ -15,7 +15,7 @@ enum BottomSheetContentType {
     case selectedTicket
 }
 
-class BooltiBottomSheetViewController: UIViewController {
+class BooltiBottomSheetViewController: BooltiViewController {
     
     // MARK: Properties
     
@@ -67,6 +67,7 @@ extension BooltiBottomSheetViewController {
     private func configureUI() {
         self.view.backgroundColor = .grey85
         self.navigationController?.navigationBar.isHidden = true
+        self.sheetPresentationController?.detents = [.medium()]
         
         self.view.addSubviews([titleView, contentView])
         self.titleView.addSubview(titleLabel)

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiNavigationBar.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiNavigationBar.swift
@@ -77,8 +77,11 @@ extension BooltiNavigationBar {
 extension BooltiNavigationBar {
     
     private func configureDefaultConstraints() {
-        self.snp.makeConstraints { make in
-            make.height.equalTo(88)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            let statusBarHeight = windowScene.statusBarManager?.statusBarFrame.height ?? 44
+            self.snp.makeConstraints { make in
+                make.height.equalTo(statusBarHeight + 44)
+            }
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandDIContainer.swift
@@ -6,12 +6,6 @@
 //
 
 final class ConcertContentExpandDIContainer {
-
-//    private let concertAPIService: ConcertAPIService
-//
-//    init(concertAPIService: ConcertAPIService) {
-//        self.concertAPIService = concertAPIService
-//    }
     
     func createConcertContentExpandViewController(content: String) -> ConcertContentExpandViewController {
         let viewModel = createConcertContentExpandViewModel(content: content)

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
@@ -7,32 +7,71 @@
 
 final class ConcertDetailDIContainer {
 
+    // MARK: Properties
+    
+    typealias Content = String
+    typealias ConcertId = Int
+    
+    private let authRepository: AuthRepository
     private let concertRepository: ConcertRepository
 
-    init(concertRepository: ConcertRepository) {
+    // MARK: Init
+    
+    init(authRepository: AuthRepository,
+         concertRepository: ConcertRepository) {
+        self.authRepository = authRepository
         self.concertRepository = concertRepository
     }
+    
+    // MARK: - Methods
     
     func createConcertDetailViewController() -> ConcertDetailViewController {
         let viewModel = createConcertDetailViewModel()
         
-        let concertContentExpandViewControllerFactory: (String) -> ConcertContentExpandViewController = { content in
+        let loginViewControllerFactory: () -> LoginViewController = {
+            let DIContainer = self.createLoginViewDIContainer()
+            
+            let viewController = DIContainer.createLoginViewController()
+            return viewController
+        }
+        
+        let concertContentExpandViewControllerFactory: (Content) -> ConcertContentExpandViewController = { content in
             let DIContainer = self.createConcertContentExpandDIContainer()
 
             let viewController = DIContainer.createConcertContentExpandViewController(content: content)
             return viewController
         }
+        
+        let ticketSelectionViewControllerFactory: (ConcertId) -> TicketSelectionViewController = { concertId in
+            let DIContainer = self.createTicketSelectionDIContainer()
+
+            let viewController = DIContainer.createTicketSelectionViewController(concertId: concertId)
+            return viewController
+        }
 
         let viewController = ConcertDetailViewController(
             viewModel: viewModel, 
-            concertContentExpandViewControllerFactory: concertContentExpandViewControllerFactory
+            loginViewControllerFactory: loginViewControllerFactory,
+            concertContentExpandViewControllerFactory: concertContentExpandViewControllerFactory,
+            ticketSelectionViewControllerFactory: ticketSelectionViewControllerFactory
         )
 
         return viewController
     }
     
+    private func createLoginViewDIContainer() -> LoginViewDIContainer {
+        return LoginViewDIContainer(
+            authRepository: self.authRepository,
+            socialLoginAPIService: OAuthRepository()
+        )
+    }
+    
     private func createConcertContentExpandDIContainer() -> ConcertContentExpandDIContainer {
         return ConcertContentExpandDIContainer()
+    }
+    
+    private func createTicketSelectionDIContainer() -> TicketSelectionDIContainer {
+        return TicketSelectionDIContainer(concertRepository: self.concertRepository)
     }
     
     private func createConcertDetailViewModel() -> ConcertDetailViewModel {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -103,15 +103,10 @@ final class ConcertDetailViewController: BooltiViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.backgroundColor = .grey95
-        
         self.configureUI()
         self.configureConstraints()
         self.configureToastView(isButtonExisted: true)
-        self.bindLoginEnterView()
-        self.bindPlaceInfoView()
-        self.bindContentInfoView()
-        self.bindNavigationBar()
+        self.bindUIComponents()
         self.bindInputs()
         self.bindOutputs()
     }
@@ -187,6 +182,13 @@ extension ConcertDetailViewController {
                 }
             }
             .disposed(by: self.disposeBag)
+    }
+    
+    private func bindUIComponents() {
+        self.bindLoginEnterView()
+        self.bindPlaceInfoView()
+        self.bindContentInfoView()
+        self.bindNavigationBar()
     }
     
     private func bindLoginEnterView() {
@@ -270,6 +272,8 @@ extension ConcertDetailViewController {
                                self.buttonBackgroundView,
                                self.ticketingButton,
                                self.loginEnterView])
+        
+        self.view.backgroundColor = .grey95
     }
     
     private func configureConstraints() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -14,15 +14,22 @@ import Kingfisher
 final class ConcertDetailViewController: BooltiViewController {
     
     // MARK: Properties
+
+    typealias Content = String
+    typealias ConcertId = Int
     
     private let viewModel: ConcertDetailViewModel
     private let disposeBag = DisposeBag()
     
-    private let concertContentExpandViewControllerFactory: (String) -> ConcertContentExpandViewController
+    private let loginViewControllerFactory: () -> LoginViewController
+    private let concertContentExpandViewControllerFactory: (Content) -> ConcertContentExpandViewController
+    private let ticketSelectionViewControllerFactory: (ConcertId) -> TicketSelectionViewController
     
     // MARK: UI Component
     
     private let navigationView = BooltiNavigationBar(type: .concertDetail)
+
+    private let loginEnterView = LoginEnterView()
 
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -76,9 +83,13 @@ final class ConcertDetailViewController: BooltiViewController {
     // MARK: Init
     
     init(viewModel: ConcertDetailViewModel,
-         concertContentExpandViewControllerFactory: @escaping (String) -> ConcertContentExpandViewController) {
+         loginViewControllerFactory: @escaping () -> LoginViewController,
+         concertContentExpandViewControllerFactory: @escaping (Content) -> ConcertContentExpandViewController,
+         ticketSelectionViewControllerFactory: @escaping (ConcertId) -> TicketSelectionViewController) {
         self.viewModel = viewModel
+        self.loginViewControllerFactory = loginViewControllerFactory
         self.concertContentExpandViewControllerFactory = concertContentExpandViewControllerFactory
+        self.ticketSelectionViewControllerFactory = ticketSelectionViewControllerFactory
         
         super.init()
     }
@@ -97,9 +108,11 @@ final class ConcertDetailViewController: BooltiViewController {
         self.configureUI()
         self.configureConstraints()
         self.configureToastView(isButtonExisted: true)
+        self.bindLoginEnterView()
         self.bindPlaceInfoView()
         self.bindContentInfoView()
-        self.bindNavigationView()
+        self.bindNavigationBar()
+        self.bindInputs()
         self.bindOutputs()
     }
     
@@ -111,6 +124,12 @@ final class ConcertDetailViewController: BooltiViewController {
 // MARK: - Methods
 
 extension ConcertDetailViewController {
+    
+    private func bindInputs() {
+        self.ticketingButton.rx.tap
+            .bind(to: self.viewModel.input.didTicketingButtonTap)
+            .disposed(by: self.disposeBag)
+    }
     
     private func bindOutputs() {
         self.viewModel.output.concertDetail
@@ -141,6 +160,41 @@ extension ConcertDetailViewController {
                 }
             }
             .disposed(by: self.disposeBag)
+        
+        self.viewModel.output.showLoginEnterView
+            .asDriver(onErrorJustReturn: false)
+            .drive(with: self) { owner, show in
+                owner.loginEnterView.isHidden = !show
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.viewModel.output.navigate
+            .asDriver(onErrorJustReturn: .login)
+            .drive(with: self) { owner, destination in
+                switch destination {
+                case .login:
+                    let viewController = owner.loginViewControllerFactory()
+                    viewController.modalPresentationStyle = .overFullScreen
+                    owner.present(viewController, animated: true) {
+                        owner.loginEnterView.isHidden = true
+                    }
+                case .contentExpand(let content):
+                    let viewController = owner.concertContentExpandViewControllerFactory(content)
+                    owner.navigationController?.pushViewController(viewController, animated: true)
+                case .ticketSelection(let concertId):
+                    let viewController = owner.ticketSelectionViewControllerFactory(concertId)
+                    owner.present(viewController, animated: true)
+                }
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func bindLoginEnterView() {
+        self.loginEnterView.loginButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.viewModel.output.navigate.accept(.login)
+            }
+            .disposed(by: self.disposeBag)
     }
     
     private func bindPlaceInfoView() {
@@ -155,15 +209,12 @@ extension ConcertDetailViewController {
     private func bindContentInfoView() {
         self.contentInfoView.didAddressExpandButtonTap()
             .emit(with: self) { owner, _ in
-                guard let content = owner.viewModel.output.concertDetailEntity?.notice else { return }
-                let viewController = owner.concertContentExpandViewControllerFactory(content)
-                
-                owner.navigationController?.pushViewController(viewController, animated: true)
+                owner.viewModel.input.didExpandButtonTap.accept(())
             }
             .disposed(by: self.disposeBag)
     }
     
-    private func bindNavigationView() {
+    private func bindNavigationBar() {
         self.navigationView.didBackButtonTap()
             .emit(with: self) { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
@@ -217,13 +268,18 @@ extension ConcertDetailViewController {
         self.view.addSubviews([self.navigationView,
                                self.scrollView,
                                self.buttonBackgroundView,
-                               self.ticketingButton])
+                               self.ticketingButton,
+                               self.loginEnterView])
     }
     
     private func configureConstraints() {
         self.navigationView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.horizontalEdges.equalToSuperview()
+        }
+        
+        self.loginEnterView.snp.makeConstraints { make in
+            make.edges.equalTo(self.view.safeAreaLayoutGuide)
         }
         
         self.scrollView.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
@@ -113,8 +113,9 @@ extension ConcertDetailViewModel {
 extension ConcertDetailViewModel {
  
     private func fetchConcertDetail(concertId: Int) {
-        self.concertRepository.concertDetail(concertId: concertId).asObservable()
+        self.concertRepository.concertDetail(concertId: concertId)
             .do { self.output.concertDetailEntity = $0 }
+            .asObservable()
             .bind(to: self.output.concertDetail)
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
@@ -56,7 +56,7 @@ final class ConcertDetailViewModel {
         
         self.bindInputs()
         self.bindOutputs()
-        self.fetchConcertDetail(concertId: 1)
+        self.fetchConcertDetail(concertId: 3)
     }
 }
 
@@ -67,7 +67,8 @@ extension ConcertDetailViewModel {
     private func bindInputs() {
         self.input.didExpandButtonTap
             .bind(with: self) { owner, _ in
-                owner.output.navigate.accept(.contentExpand(content: "담배 노노요"))
+                guard let notice = owner.output.concertDetailEntity?.notice else { return }
+                owner.output.navigate.accept(.contentExpand(content: notice))
             }
             .disposed(by: self.disposeBag)
         
@@ -76,7 +77,8 @@ extension ConcertDetailViewModel {
                 if UserDefaults.accessToken.isEmpty {
                     owner.output.showLoginEnterView.accept(true)
                 } else {
-                    owner.output.navigate.accept(.ticketSelection(concertId: 1))
+                    guard let concertId = owner.output.concertDetailEntity?.id else { return }
+                    owner.output.navigate.accept(.ticketSelection(concertId: concertId))
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
@@ -10,6 +10,12 @@ import Foundation
 import RxRelay
 import RxSwift
 
+enum ConcertDetailDestination {
+    case login
+    case contentExpand(content: String)
+    case ticketSelection(concertId: Int)
+}
+
 final class ConcertDetailViewModel {
     
     // MARK: Properties
@@ -24,12 +30,20 @@ final class ConcertDetailViewModel {
     private let disposeBag = DisposeBag()
     private let concertRepository: ConcertRepositoryType
     
+    struct Input {
+        let didTicketingButtonTap = PublishRelay<Void>()
+        let didExpandButtonTap = PublishRelay<Void>()
+    }
+    
     struct Output {
+        let navigate = PublishRelay<ConcertDetailDestination>()
+        let showLoginEnterView = BehaviorRelay<Bool>(value: false)
         let concertDetail = PublishRelay<ConcertDetailEntity>()
         var concertDetailEntity: ConcertDetailEntity?
         let buttonState = BehaviorRelay<ConcertTicketingState>(value: .endSale)
     }
     
+    let input: Input
     var output: Output
     
     // MARK: Init
@@ -37,8 +51,10 @@ final class ConcertDetailViewModel {
     // TODO: DIContainer에서 concertId 주입받기
     init(concertRepository: ConcertRepository) {
         self.concertRepository = concertRepository
+        self.input = Input()
         self.output = Output()
         
+        self.bindInputs()
         self.bindOutputs()
         self.fetchConcertDetail(concertId: 1)
     }
@@ -47,6 +63,24 @@ final class ConcertDetailViewModel {
 // MARK: - Methods
 
 extension ConcertDetailViewModel {
+    
+    private func bindInputs() {
+        self.input.didExpandButtonTap
+            .bind(with: self) { owner, _ in
+                owner.output.navigate.accept(.contentExpand(content: "담배 노노요"))
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.input.didTicketingButtonTap
+            .bind(with: self) { owner, _ in
+                if UserDefaults.accessToken.isEmpty {
+                    owner.output.showLoginEnterView.accept(true)
+                } else {
+                    owner.output.navigate.accept(.ticketSelection(concertId: 1))
+                }
+            }
+            .disposed(by: self.disposeBag)
+    }
     
     private func bindOutputs() {
         self.output.concertDetail
@@ -70,11 +104,17 @@ extension ConcertDetailViewModel {
             })
             .disposed(by: self.disposeBag)
     }
+}
 
+// MARK: - Network
+
+extension ConcertDetailViewModel {
+ 
     private func fetchConcertDetail(concertId: Int) {
         self.concertRepository.concertDetail(concertId: concertId).asObservable()
             .do { self.output.concertDetailEntity = $0 }
             .bind(to: self.output.concertDetail)
             .disposed(by: self.disposeBag)
     }
+
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListDIContainer.swift
@@ -9,9 +9,12 @@ import UIKit
 
 final class ConcertListDIContainer {
 
+    private let authRepository: AuthRepository
     private let concertRepository: ConcertRepository
 
-    init(concertRepository: ConcertRepository) {
+    init(authRepository: AuthRepository,
+         concertRepository: ConcertRepository) {
+        self.authRepository = authRepository
         self.concertRepository = concertRepository
     }
     
@@ -40,7 +43,7 @@ final class ConcertListDIContainer {
     }
     
     private func createConcertDetailDIContainer() -> ConcertDetailDIContainer {
-        return ConcertDetailDIContainer(concertRepository: self.concertRepository)
+        return ConcertDetailDIContainer(authRepository: self.authRepository, concertRepository: self.concertRepository)
     }
 
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionDIContainer.swift
@@ -9,14 +9,14 @@ import UIKit
 
 final class TicketSelectionDIContainer {
 
-//    private let ticketAPIService: TicketAPIService
-//
-//    init(ticketAPIService: TicketAPIService) {
-//        self.ticketAPIService = ticketAPIService
-//    }
+    private let concertRepository: ConcertRepository
 
-    func createTicketSelectionViewController() -> UIViewController {
-        let viewModel = createTicketSelectionViewModel()
+    init(concertRepository: ConcertRepository) {
+        self.concertRepository = concertRepository
+    }
+
+    func createTicketSelectionViewController(concertId: Int) -> TicketSelectionViewController {
+        let viewModel = createTicketSelectionViewModel(concertId: concertId)
         
         let ticketingDetailViewControllerFactory: (SalesTicketEntity) -> TicketingDetailViewController = { selectedTicket in
             let DIContainer = self.createTicketingDetailViewDIContainer()
@@ -26,7 +26,8 @@ final class TicketSelectionDIContainer {
         }
         
         let viewController = TicketSelectionViewController(
-            viewModel: viewModel, ticketingDetailViewControllerFactory: ticketingDetailViewControllerFactory
+            viewModel: viewModel,
+            ticketingDetailViewControllerFactory: ticketingDetailViewControllerFactory
         )
         
         return viewController
@@ -36,8 +37,9 @@ final class TicketSelectionDIContainer {
         return TicketingDetailDIContainer()
     }
 
-    private func createTicketSelectionViewModel() -> TicketSelectionViewModel {
-        return TicketSelectionViewModel()
+    private func createTicketSelectionViewModel(concertId: Int) -> TicketSelectionViewModel {
+        return TicketSelectionViewModel(concertRepository: self.concertRepository,
+                                        concertId: concertId)
     }
 
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionViewController.swift
@@ -122,7 +122,7 @@ extension TicketSelectionViewController {
         case .ticketTypeList:
             self.ticketTypeView.isHidden = false
             self.selectedTicketView.isHidden = true
-            self.setDetent(contentHeight: CGFloat(self.viewModel.output.salesTicketEntity?.count ?? 0) * self.ticketTypeView.cellHeight + 50, contentType: .ticketTypeList)
+            self.setDetent(contentHeight: CGFloat(self.viewModel.output.salesTicketEntity?.count ?? 0) * self.ticketTypeView.cellHeight, contentType: .ticketTypeList)
         case .selectedTicket:
             self.ticketTypeView.isHidden = true
             self.selectedTicketView.isHidden = false

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionViewController.swift
@@ -29,7 +29,8 @@ final class TicketSelectionViewController: BooltiBottomSheetViewController {
          ticketingDetailViewControllerFactory: @escaping (SalesTicketEntity) -> TicketingDetailViewController) {
         self.viewModel = viewModel
         self.ticketingDetailViewControllerFactory = ticketingDetailViewControllerFactory
-        super.init(nibName: nil, bundle: nil)
+        
+        super.init()
     }
     
     required init?(coder: NSCoder) {
@@ -37,14 +38,21 @@ final class TicketSelectionViewController: BooltiBottomSheetViewController {
     }
     
     // MARK: Life Cycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.configureUI()
         self.configureConstraints()
+        self.configureLoadingIndicatorView()
         self.bindInputs()
         self.bindOutputs()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.viewModel.fetchSalesTicket() {
+            self.showContentView(.ticketTypeList)
+        }
     }
 }
 
@@ -68,16 +76,8 @@ extension TicketSelectionViewController {
                 owner.pushTicketingDetailViewController()
             }
             .disposed(by: self.disposeBag)
-    }
-    
-    private func bindOutputs() {
-        self.viewModel.output.tickets
-            .bind(to: ticketTypeView.tableView.rx.items(cellIdentifier: TicketTypeTableViewCell.className, cellType: TicketTypeTableViewCell.self)) { index, item, cell in
-                cell.selectionStyle = .none
-                cell.setData(entity: item)
-            }.disposed(by: self.disposeBag)
         
-        self.viewModel.output.selectedTickets
+        self.viewModel.input.selectedTickets
             .bind(to: selectedTicketView.tableView.rx.items(cellIdentifier: SelectedTicketTableViewCell.className, cellType: SelectedTicketTableViewCell.self)) { index, item, cell in
                 cell.selectionStyle = .none
                 cell.setData(entity: item)
@@ -88,6 +88,18 @@ extension TicketSelectionViewController {
                         owner.viewModel.input.didDeleteButtonTap.onNext(item.id)
                     })
                     .disposed(by: cell.disposeBag)
+            }.disposed(by: self.disposeBag)
+    }
+    
+    private func bindOutputs() {
+        self.viewModel.output.isLoading
+            .bind(to: self.isLoading)
+            .disposed(by: self.disposeBag)
+        
+        self.viewModel.output.salesTickets
+            .bind(to: ticketTypeView.tableView.rx.items(cellIdentifier: TicketTypeTableViewCell.className, cellType: TicketTypeTableViewCell.self)) { index, item, cell in
+                cell.selectionStyle = .none
+                cell.setData(entity: item)
             }.disposed(by: self.disposeBag)
         
         self.viewModel.output.totalPrice
@@ -110,18 +122,18 @@ extension TicketSelectionViewController {
         case .ticketTypeList:
             self.ticketTypeView.isHidden = false
             self.selectedTicketView.isHidden = true
-            self.setDetent(contentHeight: CGFloat(self.viewModel.output.tickets.value.count) * self.ticketTypeView.cellHeight, contentType: .ticketTypeList)
+            self.setDetent(contentHeight: CGFloat(self.viewModel.output.salesTicketEntity?.count ?? 0) * self.ticketTypeView.cellHeight + 50, contentType: .ticketTypeList)
         case .selectedTicket:
             self.ticketTypeView.isHidden = true
             self.selectedTicketView.isHidden = false
-            self.setDetent(contentHeight: CGFloat(self.viewModel.output.selectedTickets.value.count) * self.selectedTicketView.cellHeight + 122, contentType: .selectedTicket)
+            self.setDetent(contentHeight: CGFloat(self.viewModel.input.selectedTickets.value.count) * self.selectedTicketView.cellHeight + 122, contentType: .selectedTicket)
         }
     }
     
     private func pushTicketingDetailViewController() {
         
         // 1차 MVP - 티켓 한 개 선택
-        guard let selectedTicket = self.viewModel.output.selectedTickets.value.first else { return }
+        guard let selectedTicket = self.viewModel.input.selectedTickets.value.first else { return }
         let viewController = self.ticketingDetailViewControllerFactory(selectedTicket)
         
         guard let presentingViewController = self.presentingViewController as? HomeTabBarController else { return }
@@ -140,7 +152,6 @@ extension TicketSelectionViewController {
         self.setTitle("티켓 선택")
         
         self.contentView.addSubviews([self.ticketTypeView, self.selectedTicketView])
-        self.showContentView(.ticketTypeList)
     }
     
     private func configureConstraints() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketSelection/TicketSelectionViewModel.swift
@@ -14,8 +14,7 @@ final class TicketSelectionViewModel {
     
     // MARK: Properties
     
-//    private let ticketAPIService: TicketAPIServiceType
-    
+    private let concertRepository: ConcertRepository
     private let disposeBag = DisposeBag()
     
     struct Input {
@@ -37,11 +36,15 @@ final class TicketSelectionViewModel {
     let input: Input
     let output: Output
     
+    private let concertId: Int
+    
     // MARK: Init
 
-//    init(ticketAPIService: TicketAPIService) {
-//        self.ticketAPIService = ticketAPIService
-    init() {
+    init(concertRepository: ConcertRepository,
+         concertId: Int) {
+        self.concertRepository = concertRepository
+        self.concertId = concertId
+        
         self.input = Input()
         self.output = Output()
         

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Components/Views/TicketInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Components/Views/TicketInfoView.swift
@@ -49,7 +49,7 @@ final class TicketInfoView: UIView {
         self.configureUI()
         self.configureConstraints()
         
-        self.setData(entity: .init(id: 1, showId: 1, ticketType: .sales, ticketName: "일반 티켓 A", price: 5000, quantity: 100))
+        self.setData(entity: .init(id: 1, concertId: 1, ticketType: .sales, ticketName: "일반 티켓 A", price: 5000, quantity: 100))
     }
     
     required init?(coder: NSCoder) {

--- a/Boolti/Boolti/Sources/UILayer/Login/LoginEnter/LoginEnterView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/LoginEnter/LoginEnterView.swift
@@ -51,6 +51,8 @@ class LoginEnterView: UIView {
 
     private func configureUI() {
 
+        self.backgroundColor = .grey95
+
         self.addSubviews([
             self.backgroundImageView,
             self.headerTitleLabel,

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
@@ -48,6 +48,7 @@ final class HomeTabBarDIContainer {
 
     private func createConcertListDIContainer() -> ConcertListDIContainer {
         return ConcertListDIContainer(
+            authRepository: AuthRepository(networkService: rootDIContainer.networkProvider),
             concertRepository: ConcertRepository(networkService: rootDIContainer.networkProvider)
         )
     }


### PR DESCRIPTION
## 작업한 내용
> 네비게이션 바
- se2에서 상태바 높이가 짧아서 네비게이션 높이를 88 -> 상태바 높이 + 44로 변경해두었어요.

> 티켓 예매 화면 연결
- 공연 상세 -> 티켓 예매 화면 플로우를 연결했어요
  - accessToken이 없으면 로그인 화면을 띄우고, 있으면 티켓 리스트가 보입니다!

> 공연 판매 티켓 리스트 api 연결
- api.. 연결했습니다.
- isLoading을 추가하려고 했더니 bottomSheet에는 인디케이터가 없어서 bottomSheet가 BooltiViewController를 상속 받게 변경했어요

## 스크린샷
![RPReplay_Final1707482010](https://github.com/Nexters/Boolti-iOS/assets/58043306/60508ba1-9b69-41f4-aa78-19d618e3e3b6)

## 관련 이슈
- Resolved: #63 
