### PR TITLE
Feature/#76 홈 입금 확인 중 기존 api 연결 및 화면 이동

### DIFF
--- a/Boolti/Boolti/Sources/Entities/Concert/ConcertEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Concert/ConcertEntity.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ConcertEntity {
+struct ConcertEntity: Equatable {
     let id: Int
     let name: String
     let dateTime: Date

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListDIContainer.swift
@@ -13,11 +13,14 @@ final class ConcertListDIContainer {
 
     private let authRepository: AuthRepository
     private let concertRepository: ConcertRepository
+    private let ticketReservationRepository: TicketReservationRepository
 
     init(authRepository: AuthRepository,
-         concertRepository: ConcertRepository) {
+         concertRepository: ConcertRepository,
+         ticketReservationRepository: TicketReservationRepository) {
         self.authRepository = authRepository
         self.concertRepository = concertRepository
+        self.ticketReservationRepository = ticketReservationRepository
     }
     
     func createConcertListViewController() -> UIViewController {
@@ -29,10 +32,18 @@ final class ConcertListDIContainer {
             let viewController = DIContainer.createConcertDetailViewController(concertId: concertId)
             return viewController
         }
+        
+        let ticketReservationsViewControllerFactory = {
+            let DIContainer = self.createTicketReservationsDIContainer()
+            let viewController = DIContainer.createTicketReservationsViewController()
+
+            return viewController
+        }
 
         let viewController = ConcertListViewController(
             viewModel: viewModel,
-            concertDetailViewControllerFactory: concertDetailViewControllerFactory
+            concertDetailViewControllerFactory: concertDetailViewControllerFactory,
+            ticketReservationsViewControllerFactory: ticketReservationsViewControllerFactory
         )
 
         let navigationController = UINavigationController(rootViewController: viewController)
@@ -41,7 +52,12 @@ final class ConcertListDIContainer {
     }
     
     private func createConcertListViewModel() -> ConcertListViewModel {
-        return ConcertListViewModel(concertRepository: self.concertRepository)
+        return ConcertListViewModel(concertRepository: self.concertRepository,
+                                    ticketReservationRepository: self.ticketReservationRepository)
+    }
+    
+    private func createTicketReservationsDIContainer() -> TicketReservationsDIContainer {
+        return TicketReservationsDIContainer(networkService: self.authRepository.networkService)
     }
     
     private func createConcertDetailDIContainer() -> ConcertDetailDIContainer {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -18,6 +18,7 @@ final class ConcertListViewController: UIViewController {
     private let viewModel: ConcertListViewModel
     private let disposeBag = DisposeBag()
     private let concertDetailViewControllerFactory: (ConcertId) -> ConcertDetailViewController
+    private let ticketReservationsViewControllerFactory: () -> TicketReservationsViewController
     
     // MARK: UI Component
     
@@ -33,10 +34,12 @@ final class ConcertListViewController: UIViewController {
     
     init(
         viewModel: ConcertListViewModel,
-        concertDetailViewControllerFactory: @escaping (ConcertId) -> ConcertDetailViewController
+        concertDetailViewControllerFactory: @escaping (ConcertId) -> ConcertDetailViewController,
+        ticketReservationsViewControllerFactory: @escaping () -> TicketReservationsViewController
     ) {
         self.viewModel = viewModel
         self.concertDetailViewControllerFactory = concertDetailViewControllerFactory
+        self.ticketReservationsViewControllerFactory = ticketReservationsViewControllerFactory
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -70,10 +73,19 @@ final class ConcertListViewController: UIViewController {
 extension ConcertListViewController {
     
     private func bindOutputs() {
-        self.viewModel.output.concerts
-            .asDriver()
+        self.viewModel.output.checkingTicketCount
+            .skip(1)
+            .asDriver(onErrorJustReturn: 0)
             .drive(with: self) { owner, concerts in
-                owner.mainCollectionView.reloadData()
+                owner.mainCollectionView.reloadSections([0], animationStyle: .automatic)
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.viewModel.output.concerts
+            .skip(1)
+            .asDriver(onErrorJustReturn: [])
+            .drive(with: self) { owner, concerts in
+                owner.mainCollectionView.reloadSections([3], animationStyle: .automatic)
             }
             .disposed(by: self.disposeBag)
     }
@@ -95,7 +107,8 @@ extension ConcertListViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section == 0 {
-            debugPrint("예매 내역으로 이동")
+            let viewController = ticketReservationsViewControllerFactory()
+            self.navigationController?.pushViewController(viewController, animated: true)
         }
         else if indexPath.section == 3 {
             let viewController = concertDetailViewControllerFactory(self.viewModel.output.concerts.value[indexPath.row].id)
@@ -118,6 +131,8 @@ extension ConcertListViewController: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         switch section {
+        case 0:
+            return self.viewModel.output.checkingTicketCount.value
         case 3:
             return viewModel.output.concerts.value.count
         default:
@@ -129,7 +144,6 @@ extension ConcertListViewController: UICollectionViewDataSource {
         switch indexPath.section {
         case 0:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CheckingTicketCollectionViewCell.className, for: indexPath) as? CheckingTicketCollectionViewCell else { return UICollectionViewCell() }
-            cell.isHidden = self.viewModel.output.checkingTicketCount.value == 0
             return cell
         case 1:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ConcertListMainTitleCollectionViewCell.className, for: indexPath) as? ConcertListMainTitleCollectionViewCell else { return UICollectionViewCell() }
@@ -160,7 +174,7 @@ extension ConcertListViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         switch indexPath.section {
         case 0:
-            return CGSize(width: self.mainCollectionView.frame.width - 40, height:  CGFloat(self.viewModel.output.checkingTicketCount.value) * 51 + 1)
+            return CGSize(width: self.mainCollectionView.frame.width - 40, height: 52)
         case 1:
             return CGSize(width: self.mainCollectionView.frame.width - 40, height: 96)
         case 2:

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -75,14 +75,16 @@ extension ConcertListViewController {
     private func bindOutputs() {
         self.viewModel.output.checkingTicketCount
             .skip(1)
+            .distinctUntilChanged()
             .asDriver(onErrorJustReturn: 0)
             .drive(with: self) { owner, concerts in
-                owner.mainCollectionView.reloadSections([0], animationStyle: .automatic)
+                owner.mainCollectionView.reloadSections([0, 1], animationStyle: .automatic)
             }
             .disposed(by: self.disposeBag)
         
         self.viewModel.output.concerts
             .skip(1)
+            .distinctUntilChanged()
             .asDriver(onErrorJustReturn: [])
             .drive(with: self) { owner, concerts in
                 owner.mainCollectionView.reloadSections([3], animationStyle: .automatic)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsDIContainer.swift
@@ -18,7 +18,7 @@ final class TicketReservationsDIContainer {
     }
 
     func createTicketReservationsViewController() -> TicketReservationsViewController {
-        let ticketReservationsViewControllerFactory: (ReservationID) -> TicketReservationDetailViewController = { reservationID in
+        let ticketReservationDetailViewControllerFactory: (ReservationID) -> TicketReservationDetailViewController = { reservationID in
             let DIContainer = self.createTicketReservationDetailDIContainer()
 
             let viewController = DIContainer.createTicketReservationDetailViewController(reservationID: reservationID)
@@ -26,7 +26,9 @@ final class TicketReservationsDIContainer {
             return viewController
         }
 
-        return TicketReservationsViewController(ticketReservationDetailViewControllerFactory: ticketReservationsViewControllerFactory, viewModel: self.createTicketResercationsViewModel())
+        return TicketReservationsViewController(
+            ticketReservationDetailViewControllerFactory: ticketReservationDetailViewControllerFactory,
+            viewModel: self.createTicketResercationsViewModel())
     }
 
     private func createTicketResercationsViewModel() -> TicketReservationsViewModel {

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarDIContainer.swift
@@ -49,7 +49,8 @@ final class HomeTabBarDIContainer {
     private func createConcertListDIContainer() -> ConcertListDIContainer {
         return ConcertListDIContainer(
             authRepository: AuthRepository(networkService: rootDIContainer.networkProvider),
-            concertRepository: ConcertRepository(networkService: rootDIContainer.networkProvider)
+            concertRepository: ConcertRepository(networkService: rootDIContainer.networkProvider),
+            ticketReservationRepository: TicketReservationRepository(networkService: rootDIContainer.networkProvider)
         )
     }
 


### PR DESCRIPTION
## 작업한 내용
- 홈에 있는 입금 확인 중 view hidden 로직을 수정했어요 (원래 cell height을 변경했었는데, section item 개수로 변경했습니다!)
- collectionview reload를 section별로 하도록 수정했어요! (검색창은 reload 필요가 없음..!)

## 스크린샷
![RPReplay_Final1707807601](https://github.com/Nexters/Boolti-iOS/assets/58043306/011ca101-6758-4467-a4de-3af7885b311b)

## 관련 이슈
- Resolved: #76 
