### PR TITLE
Fix/#104 공연 내용 전체보기 textView로 변경 (스크롤 가능)

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		84DF59E12B726E0A000816DA /* ConcertContentExpandDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59E02B726E0A000816DA /* ConcertContentExpandDIContainer.swift */; };
 		84DF59E32B726E21000816DA /* ConcertContentExpandViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59E22B726E21000816DA /* ConcertContentExpandViewController.swift */; };
 		84DF59E52B726E3F000816DA /* ConcertContentExpandViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DF59E42B726E3F000816DA /* ConcertContentExpandViewModel.swift */; };
+		84E48AC12B7E224600F8BFD0 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E48AC02B7E224600F8BFD0 /* UITextView+.swift */; };
 		84E5124B2B6E71FD002658D1 /* ConcertDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124A2B6E71FD002658D1 /* ConcertDetailDIContainer.swift */; };
 		84E5124D2B6E7736002658D1 /* ConcertDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124C2B6E7736002658D1 /* ConcertDetailViewController.swift */; };
 		84E5124F2B6E773F002658D1 /* ConcertDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124E2B6E773F002658D1 /* ConcertDetailViewModel.swift */; };
@@ -404,6 +405,7 @@
 		84DF59E02B726E0A000816DA /* ConcertContentExpandDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertContentExpandDIContainer.swift; sourceTree = "<group>"; };
 		84DF59E22B726E21000816DA /* ConcertContentExpandViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertContentExpandViewController.swift; sourceTree = "<group>"; };
 		84DF59E42B726E3F000816DA /* ConcertContentExpandViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertContentExpandViewModel.swift; sourceTree = "<group>"; };
+		84E48AC02B7E224600F8BFD0 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
 		84E5124A2B6E71FD002658D1 /* ConcertDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailDIContainer.swift; sourceTree = "<group>"; };
 		84E5124C2B6E7736002658D1 /* ConcertDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailViewController.swift; sourceTree = "<group>"; };
 		84E5124E2B6E773F002658D1 /* ConcertDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailViewModel.swift; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 				84886E872B6FB166005D2329 /* UIColor+.swift */,
 				841D77D72B73D2A20068B1C5 /* String+.swift */,
 				841D77E02B7464250068B1C5 /* UIImageView+.swift */,
+				84E48AC02B7E224600F8BFD0 /* UITextView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1965,6 +1968,7 @@
 				8710D9582B74FAC800309FBF /* LogoutDIContainer.swift in Sources */,
 				840B395B2B7679EC00E7F8C8 /* SearchBarCollectionViewCell.swift in Sources */,
 				848CBF062B6547FA00239303 /* TicketingDetailViewController.swift in Sources */,
+				84E48AC12B7E224600F8BFD0 /* UITextView+.swift in Sources */,
 				84886E882B6FB166005D2329 /* UIColor+.swift in Sources */,
 				876E414D2B5F8CA8006BEEB7 /* BooltiLoadingIndicatorView.swift in Sources */,
 				84781CCE2B5C005600D37921 /* ConcertListViewController.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Extensions/UITextView+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UITextView+.swift
@@ -18,9 +18,11 @@ extension UITextView {
             style.lineSpacing = lineSpacing
             style.lineBreakStrategy = .hangulWordPriority
 
-            mutableAttributedText.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSMakeRange(0, mutableAttributedText.length))
-            mutableAttributedText.addAttribute(NSAttributedString.Key.font, value: font, range: NSMakeRange(0, mutableAttributedText.length))
-            mutableAttributedText.addAttribute(NSAttributedString.Key.foregroundColor, value: textColor, range: NSMakeRange(0, mutableAttributedText.length))
+            mutableAttributedText
+                .addAttributes([.paragraphStyle: style,
+                                                 .font: font,
+                                                 .foregroundColor: textColor],
+                               range: NSMakeRange(0, mutableAttributedText.length))
 
             self.attributedText = mutableAttributedText
         }

--- a/Boolti/Boolti/Sources/Global/Extensions/UITextView+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UITextView+.swift
@@ -1,0 +1,28 @@
+//
+//  UITextView+.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/15/24.
+//
+
+import UIKit
+
+extension UITextView {
+
+    /// 행간 조정 메서드
+    func setLineSpacing(lineSpacing: CGFloat) {
+        if let attributedText = self.attributedText, let font = self.font, let textColor = self.textColor {
+            let mutableAttributedText = NSMutableAttributedString(attributedString: attributedText)
+
+            let style = NSMutableParagraphStyle()
+            style.lineSpacing = lineSpacing
+            style.lineBreakStrategy = .hangulWordPriority
+
+            mutableAttributedText.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSMakeRange(0, mutableAttributedText.length))
+            mutableAttributedText.addAttribute(NSAttributedString.Key.font, value: font, range: NSMakeRange(0, mutableAttributedText.length))
+            mutableAttributedText.addAttribute(NSAttributedString.Key.foregroundColor, value: textColor, range: NSMakeRange(0, mutableAttributedText.length))
+
+            self.attributedText = mutableAttributedText
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertContentExpand/ConcertContentExpandViewController.swift
@@ -21,14 +21,13 @@ final class ConcertContentExpandViewController: UIViewController {
     
     private let navigationBar = BooltiNavigationBar(type: .concertContentExpand)
     
-    private let contentLabel: UILabel = {
-        let label = UILabel()
-        label.font = .pretendardR(16)
-        label.textColor = .grey30
-        label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
-        
-        return label
+    private let contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.font = .pretendardR(16)
+        textView.textColor = .grey30
+        return textView
     }()
     
     // MARK: Init
@@ -55,8 +54,8 @@ extension ConcertContentExpandViewController {
     private func bindOutputs() {
         self.viewModel.output.content
             .bind(with: self) { owner, content in
-                owner.contentLabel.text = content
-                owner.contentLabel.setLineSpacing(lineSpacing: 6)
+                owner.contentTextView.text = content
+                owner.contentTextView.setLineSpacing(lineSpacing: 6)
             }
             .disposed(by: self.disposeBag)
     }
@@ -75,7 +74,7 @@ extension ConcertContentExpandViewController {
 extension ConcertContentExpandViewController {
     
     private func configureUI() {
-        self.view.addSubviews([self.navigationBar, self.contentLabel])
+        self.view.addSubviews([self.navigationBar, self.contentTextView])
         
         self.view.backgroundColor = .grey95
     }
@@ -86,9 +85,10 @@ extension ConcertContentExpandViewController {
             make.horizontalEdges.equalToSuperview()
         }
         
-        self.contentLabel.snp.makeConstraints { make in
+        self.contentTextView.snp.makeConstraints { make in
             make.top.equalTo(self.navigationBar.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide)
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/Cell/TicketReservationsTableViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/Cell/TicketReservationsTableViewCell.swift
@@ -102,7 +102,7 @@ class TicketReservationsTableViewCell: UITableViewCell {
     }
 
     private func configureUI() {
-        self.backgroundColor = .black100
+        self.backgroundColor = .grey95
         self.contentView.backgroundColor = .grey90
 
         self.contentView.addSubviews([

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsViewController.swift
@@ -67,7 +67,7 @@ final class TicketReservationsViewController: BooltiViewController {
     }
 
     private func configureUI() {
-        self.view.backgroundColor = .black100
+        self.view.backgroundColor = .grey95
         self.navigationController?.navigationBar.isHidden = true
 
         self.view.addSubviews([


### PR DESCRIPTION
## 작업한 내용
- 공연내용 전체보기 시 내용이 길 때 스크롤이 안되는 오류를 해결했어요.

## 스크린샷
![RPReplay_Final1708004273](https://github.com/Nexters/Boolti-iOS/assets/58043306/539be785-65e9-45da-a025-2f0ffcb5d88d)

## 관련 이슈
- Resolved: #104 
