### PR TITLE
FIX/#114 점선 그리는 로직 변경

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
@@ -287,17 +287,13 @@ final class TicketDetailView: UIView {
 
     private func configureSeperateLine() {
 
-        guard !self.isSeperatedLineConfigured else { return }
-        self.isSeperatedLineConfigured = true
-
-        let path = UIBezierPath()
+        let path = CGMutablePath()
 
         path.move(to: CGPoint(x: 20, y: 475))
         path.addLine(to: CGPoint(x: self.bounds.width-20, y: 475))
-        path.close()
 
         let shapeLayer = CAShapeLayer()
-        shapeLayer.path = path.cgPath
+        shapeLayer.path = path
         shapeLayer.lineWidth = 2
         shapeLayer.lineDashPattern = [5, 5]
         shapeLayer.strokeColor = UIColor.init(white: 1, alpha: 0.3).cgColor

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -212,18 +212,17 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
     }
 
         private func configureSeperateLine() {
-            let path = UIBezierPath()
+            let path = CGMutablePath()
             let height = self.bounds.height * 0.813
             let width = self.bounds.width * 0.053
 
             path.move(to: CGPoint(x: width, y: height))
             path.addLine(to: CGPoint(x: self.bounds.width * 0.947, y: height))
-            path.close()
 
             let shapeLayer = CAShapeLayer()
-            shapeLayer.path = path.cgPath
+            shapeLayer.path = path
             shapeLayer.lineWidth = 2
-            shapeLayer.lineDashPattern = [7, 7]
+            shapeLayer.lineDashPattern = [5, 5]
             shapeLayer.strokeColor = UIColor.init(white: 1, alpha: 0.3).cgColor
             self.layer.addSublayer(shapeLayer)
         }


### PR DESCRIPTION
## 작업한 내용
- UIBeizerPath를 CGMutablePath로 변경했어요.
- 기존의 UIBeizerPath는 기기 별로(스크린 사이즈 별로) 점선의 간격이 달랐는데, CGMutablePath는 기기 별로 점선의 간격이 같았기에 CGMutablePath로 구현했어요.
- 찾아보니까 UIBeizerPath의 경우에는 UIKit에서 제공해주는 객체지향적인 인터페이스를 메인으로 하고, CGMutablePath는 Core Graphics를 활용해서 C 언어 기반의 API를 활용한다는데... 왜 서로 다르게 구현이 되는 지는 조금 더 공부를 해봐야될 거 같아요..

## 스크린샷
- 스크린 샷은 실제로 기기로 보는 게 좋을 거 같아요!

## 관련 이슈
- Resolved: #114 
