### PR TITLE
feature/#120 Refresh 토큰 만료 시 앱 재시작 로직 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		87D2FABC2B6EBF650027FBE1 /* TicketDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FABB2B6EBF650027FBE1 /* TicketDetailView.swift */; };
 		87D2FABE2B6F89060027FBE1 /* TicketInquiryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FABD2B6F89060027FBE1 /* TicketInquiryView.swift */; };
 		87D2FAC02B7003970027FBE1 /* ReversalPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FABF2B7003970027FBE1 /* ReversalPolicyView.swift */; };
+		87F7DF452B82322E0068A6C9 /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F7DF442B82322E0068A6C9 /* Notification.Name+.swift */; };
 		87FB0D382B6BE7B900B42AF9 /* SwiftJWT in Frameworks */ = {isa = PBXBuildFile; productRef = 87FB0D372B6BE7B900B42AF9 /* SwiftJWT */; };
 		87FB0D3A2B6BE97F00B42AF9 /* IdentityTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FB0D392B6BE97F00B42AF9 /* IdentityTokenDTO.swift */; };
 /* End PBXBuildFile section */
@@ -534,6 +535,7 @@
 		87D2FABB2B6EBF650027FBE1 /* TicketDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailView.swift; sourceTree = "<group>"; };
 		87D2FABD2B6F89060027FBE1 /* TicketInquiryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketInquiryView.swift; sourceTree = "<group>"; };
 		87D2FABF2B7003970027FBE1 /* ReversalPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReversalPolicyView.swift; sourceTree = "<group>"; };
+		87F7DF442B82322E0068A6C9 /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+.swift"; sourceTree = "<group>"; };
 		87FB0D392B6BE97F00B42AF9 /* IdentityTokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityTokenDTO.swift; sourceTree = "<group>"; };
 		87FB0D3B2B6C09B500B42AF9 /* TicketItemEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketItemEntity.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -827,6 +829,7 @@
 				84625A152B63C33D00CC9077 /* UITableViewCell+.swift */,
 				840B39642B78DD6000E7F8C8 /* UICollectionViewCell+.swift */,
 				84FEF6162B68A6D100EBB64F /* UIResponder+.swift */,
+				87F7DF442B82322E0068A6C9 /* Notification.Name+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1870,6 +1873,7 @@
 				8726054F2B79FD49005CD0D4 /* TicketReservationDetailRequestDTO.swift in Sources */,
 				840B39612B78CE6300E7F8C8 /* ConcertListRequestDTO.swift in Sources */,
 				843918FC2B7A82DF00CC62AA /* ReportViewController.swift in Sources */,
+				87F7DF452B82322E0068A6C9 /* Notification.Name+.swift in Sources */,
 				84781CC02B5BF98600D37921 /* MypageViewController.swift in Sources */,
 				84FBBE012B677187009462E9 /* BooltiTextField.swift in Sources */,
 				84D1C3812B7938CB00527998 /* TicketingResponseDTO.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.Name+.swift
+//  Boolti
+//
+//  Created by Miro on 2/18/24.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let refreshTokenHasExpired = Notification.Name("refreshTokenHasExpired")
+}

--- a/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
@@ -25,6 +25,7 @@ final class AuthInterceptor: RequestInterceptor {
         
         debugPrint("🔥 요청한 AccessToken: \(UserDefaults.accessToken) 🔥")
         debugPrint("🔥 요청한 userId: \(UserDefaults.userId) 🔥")
+        NotificationCenter.default.post(name: Notification.Name.refreshTokenHasExpired, object: nil)
 
         completion(.success(urlRequest))
     }
@@ -60,6 +61,10 @@ final class AuthInterceptor: RequestInterceptor {
                 completion(.retry)
             }, onFailure: { error in
                 // 이러면 로그인 화면으로 간다!..
+                UserDefaults.accessToken = ""
+                UserDefaults.refreshToken = ""
+
+                NotificationCenter.default.post(name: Notification.Name.refreshTokenHasExpired, object: nil)
                 completion(.doNotRetry)
             })
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -45,9 +45,18 @@ class BooltiViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NotificationCenter.default.addObserver(self, selector: #selector(showNetworkAlert),
-                                               name: Notification.Name("ServerErrorNotification"),
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showNetworkAlert),
+            name: Notification.Name("ServerErrorNotification"),
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(navigateToRoot),
+            name: Notification.Name.refreshTokenHasExpired,
+            object: nil
+        )
     }
 
     deinit {
@@ -78,7 +87,32 @@ extension BooltiViewController {
         alertController.addAction(okAction)
         self.present(alertController, animated: true, completion: nil)
     }
-    
+
+    @objc func navigateToRoot() {
+
+        let alertController = UIAlertController(
+            title: "오류",
+            message: "로그인 세션이 만료되었습니다.\n앱을 다시 시작해주세요.",
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(title: "다시 시작하기", style: .default, handler: { _ in
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+            let scenedelegate = windowScene.delegate as? SceneDelegate
+
+            let rootDIContainer = RootDIContainer()
+            let rootViewController = rootDIContainer.createRootViewController()
+
+            scenedelegate?.window?.rootViewController = rootViewController
+            scenedelegate?.window?.makeKeyAndVisible()
+
+        })
+        alertController.addAction(okAction)
+
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true, completion: nil)
+        }
+    }
+
     func showToast(message: String) {
         self.toastView?.showToast.accept(message)
     }


### PR DESCRIPTION
## 작업한 내용
- AuthInterceptor를 통해서 Refresh 토큰 만료 시 앱 재시작 로직을 구현 했습니다.
  - NotificiationCenter 활용
  - 추후에 앱 재시작이 아닌 유저 다이렉션을 되돌리지 않는 방법으로 수정할 예정

## 스크린샷


## 관련 이슈
- Resolved: #
