### PR TITLE
Chore/#131 예매 마감 시간 지나면 환불 요청 버튼 제거

### DIFF
--- a/Boolti/Boolti/Sources/Entities/Ticket/TicketReservationDetailEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Ticket/TicketReservationDetailEntity.swift
@@ -39,4 +39,5 @@ struct TicketReservationDetailEntity {
     let purchaserPhoneNumber: String
     let depositorName: String
     let depositorPhoneNumber: String
+    let salesEndTime: String
 }

--- a/Boolti/Boolti/Sources/Network/DTO/Reservation/Response/TicketReservationDetailResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Reservation/Response/TicketReservationDetailResponseDTO.swift
@@ -53,7 +53,8 @@ extension TicketReservationDetailResponseDTO {
             purchaseName: self.reservationName,
             purchaserPhoneNumber: self.reservationPhoneNumber,
             depositorName: self.depositorName ?? "",
-            depositorPhoneNumber: self.depositorPhoneNumber ?? ""
+            depositorPhoneNumber: self.depositorPhoneNumber ?? "",
+            salesEndTime: self.salesEndTime
         )
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -275,7 +275,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.totalPaymentAmountView.setData("\(entity.totalPaymentAmount)원")
         self.paymentStatusView.setData(entity.reservationStatus.description)
 
-        self.configureRefundButton(with: entity.reservationStatus)
+        self.configureRefundButton(with: entity)
 
         // 티켓 정보
         self.ticketTypeView.setData(entity.ticketType.rawValue)
@@ -315,12 +315,15 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.depositorPhoneNumberView.setData(entity.depositorPhoneNumber)
     }
 
-    private func configureRefundButton(with reservationStatus: ReservationStatus) {
-        switch reservationStatus {
+    private func configureRefundButton(with entity: TicketReservationDetailEntity) {
+        switch entity.reservationStatus {
         case .reservationCompleted:
-            self.requestRefundButton.isHidden = false
-            return
-        case .waitingForRefund, .refundCompleted, .cancelled, .waitingForDeposit:
+            if Date() <= entity.salesEndTime.formatToDate() {
+                self.requestRefundButton.isHidden = false
+            } else {
+                self.requestRefundButton.isHidden = true
+            }
+        default:
             self.requestRefundButton.isHidden = true
         }
     }


### PR DESCRIPTION
## 작업한 내용
- 계좌이체, 발권 완료된 상태의 예매 내역 상세에서 예매 마감 시간이 지나면 환불 요청 버튼을 제거했어요

## 스크린샷
![RPReplay_Final1708577084](https://github.com/Nexters/Boolti-iOS/assets/58043306/caed1c23-63b8-4f8d-998e-d865fdc9db6b)

## 관련 이슈
- Resolved: #131 
