### PR TITLE
Fix/#132 공연 리스트 셀 간격 수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -591,10 +591,10 @@
 		840B39532B7667B100E7F8C8 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */,
-				840B395A2B7679EC00E7F8C8 /* SearchBarCollectionViewCell.swift */,
 				840B395C2B768B0800E7F8C8 /* CheckingTicketCollectionViewCell.swift */,
+				840B395A2B7679EC00E7F8C8 /* SearchBarCollectionViewCell.swift */,
 				840B395E2B76966E00E7F8C8 /* ConcertListMainTitleCollectionViewCell.swift */,
+				840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";

--- a/Boolti/Boolti/Sources/Global/Extensions/UILabel+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UILabel+.swift
@@ -27,6 +27,9 @@ extension UILabel {
             style.maximumLineHeight = lineHeight
             style.minimumLineHeight = lineHeight
             
+            style.lineBreakMode = .byTruncatingTail
+            style.lineBreakStrategy = .hangulWordPriority
+            
             let attributes: [NSAttributedString.Key: Any] = [
             .paragraphStyle: style,
             .baselineOffset: (lineHeight - font.lineHeight) / 2
@@ -69,7 +72,6 @@ extension UILabel {
             style.maximumLineHeight = lineHeight
             style.minimumLineHeight = lineHeight
             
-            style.lineBreakMode = .byWordWrapping
             style.lineBreakStrategy = .hangulWordPriority
             style.headIndent = 10
             attributedString.addAttribute(.paragraphStyle, value: style, range: NSMakeRange(0, attributedString.length))

--- a/Boolti/Boolti/Sources/Global/Extensions/UILabel+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UILabel+.swift
@@ -41,27 +41,6 @@ extension UILabel {
         }
     }
     
-    // TODO: 아래 메서드 수정 예정 (행간 조절 말고, lineHeight 사용)
-    
-    /// 행간 조정 메서드
-    func setLineSpacing(lineSpacing: CGFloat) {
-        if let text = self.text {
-            let style = NSMutableParagraphStyle()
-            
-            style.lineSpacing = lineSpacing
-            style.lineBreakMode = .byTruncatingTail
-            style.lineBreakStrategy = .hangulWordPriority
-            
-            let attributes: [NSAttributedString.Key: Any] = [
-            .paragraphStyle: style
-            ]
-
-            let attributeString = NSMutableAttributedString(string: text,
-                                                            attributes: attributes)
-            self.attributedText = attributeString
-        }
-    }
-    
     /// 행간 + headIndent 조정 메서드 (정책에서 쓰임)
     func setHeadIndent() {
         if let existingAttributedString = self.attributedText {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
@@ -42,7 +42,6 @@ final class ConcertPosterView: UIView {
         label.font = .point3
         label.textColor = .grey05
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ContentInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ContentInfoView.swift
@@ -38,7 +38,6 @@ final class ContentInfoView: UIView {
         label.textColor = .grey30
         label.font = .body3
         label.numberOfLines = 0
-        label.lineBreakMode = .byTruncatingTail
         
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/DatetimeInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/DatetimeInfoView.swift
@@ -25,7 +25,6 @@ final class DatetimeInfoView: UIView {
         label.textColor = .grey30
         label.font = .body3
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/PlaceInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/PlaceInfoView.swift
@@ -57,7 +57,6 @@ final class PlaceInfoView: UIView {
         label.textColor = .grey30
         label.font = .body3
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/ConcertCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/ConcertCollectionViewCell.swift
@@ -85,8 +85,7 @@ final class ConcertCollectionViewCell: UICollectionViewCell {
         let label = BooltiUILabel()
         label.font = .point1
         label.textColor = .grey05
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -182,14 +182,14 @@ extension ConcertListViewController: UICollectionViewDelegateFlowLayout {
         case 2:
             return CGSize(width: self.mainCollectionView.frame.width - 40, height: 80)
         default:
-            return CGSize(width: (self.mainCollectionView.frame.width - 40) / 2 - 7.5, height: 313)
+            return CGSize(width: (self.mainCollectionView.frame.width - 40) / 2 - 7.5, height: 313 * self.view.frame.height / 812)
         }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         switch section {
         case 3:
-            return UIEdgeInsets(top: 12, left: 0, bottom: 20, right: 0)
+            return UIEdgeInsets(top: 12, left: 0, bottom: 0, right: 0)
         default:
             return .zero
         }
@@ -207,7 +207,7 @@ extension ConcertListViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         switch section {
         case 3:
-            return 28
+            return 20
         default:
             return 0
         }

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/DepositSummaryView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/DepositSummaryView.swift
@@ -11,21 +11,20 @@ final class DepositSummaryView: UIView {
     
     // MARK: UI Component
     
-    private let datePriceLabel: UILabel = {
-        let label = UILabel()
+    private let datePriceLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.numberOfLines = 2
         label.font = .point4
         label.textColor = .grey05
         return label
     }()
     
-    private let infoLabel: UILabel = {
-        let label = UILabel()
+    private let infoLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.numberOfLines = 2
-        label.text = "입금 마감일까지 입금이 확인되지 않는 경우\n주문이 자동 취소됩니다."
         label.font = .body1
         label.textColor = .grey50
-        label.setLineSpacing(lineSpacing: 6)
+        label.text = "입금 마감일까지 입금이 확인되지 않는 경우\n주문이 자동 취소됩니다."
         return label
     }()
     
@@ -60,7 +59,6 @@ extension DepositSummaryView {
         let formattedDate = date.format(.simple)
         let formattedPrice = "\(price.formattedCurrency())원"
         self.datePriceLabel.text = "\(formattedDate)까지 아래 계좌로\n\(formattedPrice)을 입금해주세요"
-        self.datePriceLabel.setLineSpacing(lineSpacing: 6)
         self.datePriceLabel.setSubStringColor(to: [formattedDate, formattedPrice], with: .orange01)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/PaymentCompletionView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/PaymentCompletionView.swift
@@ -11,11 +11,11 @@ final class PaymentCompletionView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "결제가 완료되었어요"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .point4
         label.textColor = .grey05
+        label.text = "결제가 완료되었어요"
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/ReservedTicketView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/ReservedTicketView.swift
@@ -1,5 +1,5 @@
 //
-//  TicketInfoView.swift
+//  ReservedTicketView.swift
 //  Boolti
 //
 //  Created by Juhyeon Byun on 1/31/24.
@@ -23,7 +23,7 @@ final class ReservedTicketView: UIView {
     
     private lazy var labelStackView: UIStackView = {
         let view = UIStackView()
-        view.spacing = 8
+        view.spacing = 4
         view.axis = .vertical
         view.alignment = .fill
         
@@ -31,25 +31,23 @@ final class ReservedTicketView: UIView {
         return view
     }()
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .point1
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
-        label.setLineSpacing(lineSpacing: 4)
+        label.numberOfLines = 2
         label.textColor = .grey05
         return label
     }()
     
-    private let ticketDetailLabel: UILabel = {
-        let label = UILabel()
+    private let ticketDetailLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .caption
         label.textColor = .grey30
         return label
     }()
     
-    private let priceLabel: UILabel = {
-        let label = UILabel()
+    private let priceLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .caption
         label.textColor = .grey30
         return label
@@ -75,7 +73,6 @@ extension ReservedTicketView {
     
     func setData(concert: ConcertDetailEntity, selectedTicket: SelectedTicketEntity) {
         self.titleLabel.text = concert.name
-        self.titleLabel.setLineSpacing(lineSpacing: 4)
         self.ticketDetailLabel.text = "\(selectedTicket.ticketName) / 1매"
         self.priceLabel.text = "\(selectedTicket.price.formattedCurrency())원"
         self.poster.setImage(with: concert.posters.first?.thumbnailPath ?? "")

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/ConcertInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/ConcertInfoView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import RxSwift
 import SnapKit
 
 final class ConcertInfoView: UIView {
@@ -37,8 +36,7 @@ final class ConcertInfoView: UIView {
     private let titleLabel: BooltiUILabel = {
         let label = BooltiUILabel()
         label.font = .point2
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         label.textColor = .grey05
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/InvitationCodeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/InvitationCodeView.swift
@@ -25,11 +25,11 @@ final class InvitationCodeView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "초청 코드"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
+        label.text = "초청 코드"
         return label
     }()
     
@@ -48,8 +48,8 @@ final class InvitationCodeView: UIView {
         return button
     }()
     
-    private let codeStateLabel: UILabel = {
-        let label = UILabel()
+    private let codeStateLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .body1
         label.isHidden = true
         return label

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/PolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/PolicyView.swift
@@ -19,11 +19,11 @@ final class PolicyView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "취소/환불 규정"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
+        label.text = "취소/환불 규정"
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/TicketInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/TicketInfoView.swift
@@ -11,11 +11,11 @@ final class TicketInfoView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "티켓 정보"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
+        label.text = "티켓 정보"
         return label
     }()
     
@@ -35,7 +35,7 @@ final class TicketInfoView: UIView {
         let view = UIStackView()
         view.axis = .vertical
         view.alignment = .fill
-        view.spacing = 20
+        view.spacing = 16
         
         view.addArrangedSubviews([self.ticketTypeStackView, self.ticketCountStackView, self.totalPriceStackView])
         return view
@@ -48,8 +48,6 @@ final class TicketInfoView: UIView {
         
         self.configureUI()
         self.configureConstraints()
-        
-        self.setData(entity: .init(id: 1, concertId: 1, ticketType: .sales, ticketName: "일반 티켓 A", price: 5000, quantity: 100))
     }
     
     required init?(coder: NSCoder) {
@@ -75,13 +73,13 @@ extension TicketInfoView {
     private func makeSelectedTitleLabel(title: String) -> BooltiUILabel {
         let label = BooltiUILabel()
         label.font = .body3
-        label.text = title
         label.textColor = .grey30
+        label.text = title
         return label
     }
     
-    private func makeSelectedDataLabel() -> UILabel {
-        let label = UILabel()
+    private func makeSelectedDataLabel() -> BooltiUILabel {
+        let label = BooltiUILabel()
         label.font = .body3
         label.textColor = .grey15
         label.textAlignment = .right
@@ -91,6 +89,7 @@ extension TicketInfoView {
     private func makeStackView(with: [UILabel]) -> UIStackView {
         let view = UIStackView()
         view.axis = .horizontal
+        view.distribution = .equalSpacing
         view.addArrangedSubviews(with)
         return view
     }
@@ -114,7 +113,7 @@ extension TicketInfoView {
         self.stackView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(20)
             make.top.equalTo(self.titleLabel.snp.bottom).offset(20)
-            make.bottom.equalToSuperview().inset(28)
+            make.bottom.equalToSuperview().inset(20)
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Logout/LogoutViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Logout/LogoutViewController.swift
@@ -30,11 +30,11 @@ final class LogoutViewController: BooltiViewController {
         return button
     }()
 
-    private let askingLogoutLabel: UILabel = {
-        let label = UILabel()
-        label.text = "정말 로그아웃 하시겠어요?"
+    private let askingLogoutLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey15
+        label.text = "정말 로그아웃 하시겠어요?"
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/Views/MypageContentView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/Views/MypageContentView.swift
@@ -14,8 +14,8 @@ final class MypageContentView: UIView {
 
     private let disposeBag = DisposeBag()
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .pretendardB(18)
         label.textColor = .grey10
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/QRScanner/QRScannerList/Cells/QRScannerListTableViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/QRScanner/QRScannerList/Cells/QRScannerListTableViewCell.swift
@@ -17,11 +17,11 @@ final class QRScannerListTableViewCell: UITableViewCell {
         return view
     }()
     
-    private let concertNameLabel: UILabel = {
-        let label = UILabel()
+    private let concertNameLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .aggroB(16)
         label.textColor = .grey05
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         return label
     }()
     
@@ -58,7 +58,6 @@ extension QRScannerListTableViewCell {
     
     func setData(concertName: String, isConcertEnd: Bool) {
         self.concertNameLabel.text = concertName
-        self.concertNameLabel.setLineSpacing(lineSpacing: 6)
         
         if isConcertEnd {
             self.concertNameLabel.textColor = .grey50

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/Views/ConcertInformationView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/Views/ConcertInformationView.swift
@@ -24,8 +24,7 @@ final class ConcertInformationView: UIView {
         let label = BooltiUILabel()
         label.font = .aggroB(20)
         label.textColor = .grey05
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 2
+        label.numberOfLines = 3
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailInformationView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailInformationView.swift
@@ -13,7 +13,6 @@ final class TicketDetailInformationView: UIView {
         let label = BooltiUILabel()
         label.textColor = .grey10
         label.font = .aggroB(20)
-        label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 4
 
         return label
@@ -52,6 +51,7 @@ final class TicketDetailInformationView: UIView {
         let label = BooltiUILabel()
         label.textColor = .grey30
         label.font = .body2
+        label.numberOfLines = 1
 
         return label
     }()
@@ -73,7 +73,7 @@ final class TicketDetailInformationView: UIView {
 
     private let dimmedView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.init("#000000").withAlphaComponent(0.8)
+        view.backgroundColor = .black100.withAlphaComponent(0.8)
         view.isHidden = true
 
         return view
@@ -94,7 +94,6 @@ final class TicketDetailInformationView: UIView {
         self.locationLabel.text = " | \(item.location)"
         self.titleLabel.text = item.title
         self.qrCodeImageView.image = item.qrCode
-        self.titleLabel.setLineSpacing(lineSpacing: 4)
         self.configureGradient()
         self.configureStamp(with: item)
     }
@@ -143,7 +142,7 @@ final class TicketDetailInformationView: UIView {
         let bounds = CGRect(x: 1, y: 0, width: self.bounds.width-2, height: self.bounds.height)
         
         gradientLayer.frame = bounds
-        gradientLayer.colors = [UIColor.init("#000000").withAlphaComponent(0.0).cgColor, UIColor.init("#000000").withAlphaComponent(0.7).cgColor]
+        gradientLayer.colors = [UIColor.black100.withAlphaComponent(0.0).cgColor, UIColor.black100.withAlphaComponent(0.7).cgColor]
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
         gradientLayer.locations = [0.0, 1.0]

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
@@ -22,7 +22,6 @@ final class TicketNoticeView: UIView {
         let label = BooltiUILabel()
         label.font = .body1
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         label.textColor = .grey50
 
         return label
@@ -58,7 +57,6 @@ final class TicketNoticeView: UIView {
 
     func setData(with text: String) {
         self.noticeLabel.text = text
-        self.noticeLabel.setLineSpacing(lineSpacing: 6)
         self.layoutIfNeeded()
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/Views/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/Views/EntryCodeInputView.swift
@@ -35,8 +35,7 @@ final class EntryCodeInputView: UIView {
         label.text = "입장 코드는 주최자 계정의 마이 > QR 스캔 >\n해당 공연 스캐너에서 확인 가능해요"
         label.numberOfLines = 0
         label.textColor = .grey50
-        label.setLineSpacing(lineSpacing: 5)
-        label.textAlignment = .center
+        label.setAlignCenter()
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Views/TicketInformationView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Views/TicketInformationView.swift
@@ -1,19 +1,18 @@
-////
-////  TicketInformationView.swift
-////  Boolti
-////
-////  Created by Miro on 1/30/24.
-////
+//
+//  TicketInformationView.swift
+//  Boolti
+//
+//  Created by Miro on 1/30/24.
+//
 
 import UIKit
 
 final class TicketInformationView: UIView {
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey10
         label.font = .aggroB(20)
-        label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 2
 
         return label
@@ -40,18 +39,19 @@ final class TicketInformationView: UIView {
         return stackView
     }()
 
-    private let dateLabel: UILabel = {
-        let label = UILabel()
+    private let dateLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey30
         label.font = .body2
 
         return label
     }()
 
-    private let locationLabel: UILabel = {
-        let label = UILabel()
+    private let locationLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey30
         label.font = .body2
+        label.numberOfLines = 1
 
         return label
     }()
@@ -93,7 +93,6 @@ final class TicketInformationView: UIView {
         self.locationLabel.text = " | \(item.location)"
         self.titleLabel.text = item.title
         self.qrCodeImageView.image = item.qrCode
-        self.titleLabel.setLineSpacing(lineSpacing: 4)
         self.configureStamp(with: item.ticketStatus)
     }
     
@@ -123,11 +122,11 @@ final class TicketInformationView: UIView {
         self.qrCodeImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.right.equalToSuperview()
-            make.width.height.equalTo(70)
+            make.size.equalTo(70)
         }
 
         self.dimmedView.snp.makeConstraints { make in
-            make.width.height.equalTo(70)
+            make.size.equalTo(70)
             make.center.equalTo(self.qrCodeImageView)
         }
 

--- a/Boolti/Boolti/Sources/UILayer/Update/UpdatePopupViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Update/UpdatePopupViewController.swift
@@ -26,8 +26,8 @@ final class UpdatePopupViewController: UIViewController {
         return view
     }()
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey15
         label.text = "업데이트 알림"
@@ -35,8 +35,8 @@ final class UpdatePopupViewController: UIViewController {
         return label
     }()
     
-    private let subTitleLabel: UILabel = {
-        let label = UILabel()
+    private let subTitleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey50
         label.font = .body1
         label.numberOfLines = 2
@@ -98,14 +98,13 @@ extension UpdatePopupViewController {
         }
         
         self.titleLabel.snp.makeConstraints { make in
-            make.height.equalTo(26)
             make.centerX.equalTo(self.popupBackgroundView)
             make.top.equalTo(self.popupBackgroundView).offset(32)
         }
         
         self.subTitleLabel.snp.makeConstraints { make in
             make.centerX.equalTo(self.popupBackgroundView)
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(8)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(4)
         }
         
         self.updateButton.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/Update/UpdatePopupViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Update/UpdatePopupViewController.swift
@@ -41,8 +41,7 @@ final class UpdatePopupViewController: UIViewController {
         label.font = .body1
         label.numberOfLines = 2
         label.text = "지금 업데이트하고\n더 편리해진 불티를 만나보세요"
-        label.setLineSpacing(lineSpacing: 4)
-        label.textAlignment = .center
+        label.setAlignCenter()
         
         return label
     }()


### PR DESCRIPTION
## 작업한 내용
- 공연 리스트 셀 간격을 수정했어요.
- BooltiLabel의 기본 line break를 설정했어요.
  - 기존에 작성하던 line break를 따로 지정해주지 않아도 돼요. (기존에 있던 linebreak 코드 모두 확인 후 삭제했습니다!) 
  - ![image](https://github.com/Nexters/Boolti-iOS/assets/58043306/d18927be-145a-4cc4-9646-b19fe147614d)
- UILabel의 setLineSpacing 함수를 제거했어요.
- BooltiUIlabel로 변경하는 작업을 했어요! 이제 얼마 안남음 .. 🫠

## 스크린샷
<img src = "https://github.com/Nexters/Boolti-iOS/assets/58043306/9ce89160-4374-4773-bf68-d1a1b7b6e2e1" width="375" height="812">

## 관련 이슈
- Resolved: #132 
