### PR TITLE
Feature/#144 공연 이미지 확대 + 줌

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		843918FE2B7A82E700CC62AA /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843918FD2B7A82E700CC62AA /* ReportViewModel.swift */; };
 		8453D7FC2B7539270048F103 /* SalesTicketResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8453D7FB2B7539270048F103 /* SalesTicketResponseDTO.swift */; };
 		8453D7FE2B7539770048F103 /* SalesTicketRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8453D7FD2B7539770048F103 /* SalesTicketRequestDTO.swift */; };
+		845F25442B89FA3800F6C328 /* PosterExpandDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F25432B89FA3800F6C328 /* PosterExpandDIContainer.swift */; };
+		845F25462B89FA5000F6C328 /* PosterExpandViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F25452B89FA5000F6C328 /* PosterExpandViewController.swift */; };
+		845F25482B89FA5A00F6C328 /* PosterExpandViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F25472B89FA5A00F6C328 /* PosterExpandViewModel.swift */; };
 		84625A042B6382C300CC9077 /* BooltiBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84625A032B6382C300CC9077 /* BooltiBottomSheetViewController.swift */; };
 		84625A092B63A01100CC9077 /* TicketSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84625A082B63A01100CC9077 /* TicketSelectionViewController.swift */; };
 		84625A0B2B63B2AE00CC9077 /* TicketSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84625A0A2B63B2AE00CC9077 /* TicketSelectionViewModel.swift */; };
@@ -316,6 +319,9 @@
 		843918FD2B7A82E700CC62AA /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 		8453D7FB2B7539270048F103 /* SalesTicketResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesTicketResponseDTO.swift; sourceTree = "<group>"; };
 		8453D7FD2B7539770048F103 /* SalesTicketRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesTicketRequestDTO.swift; sourceTree = "<group>"; };
+		845F25432B89FA3800F6C328 /* PosterExpandDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterExpandDIContainer.swift; sourceTree = "<group>"; };
+		845F25452B89FA5000F6C328 /* PosterExpandViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterExpandViewController.swift; sourceTree = "<group>"; };
+		845F25472B89FA5A00F6C328 /* PosterExpandViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterExpandViewModel.swift; sourceTree = "<group>"; };
 		84625A032B6382C300CC9077 /* BooltiBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiBottomSheetViewController.swift; sourceTree = "<group>"; };
 		84625A082B63A01100CC9077 /* TicketSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketSelectionViewController.swift; sourceTree = "<group>"; };
 		84625A0A2B63B2AE00CC9077 /* TicketSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketSelectionViewModel.swift; sourceTree = "<group>"; };
@@ -662,6 +668,16 @@
 			path = Report;
 			sourceTree = "<group>";
 		};
+		845F25412B89F9CC00F6C328 /* PosterExpand */ = {
+			isa = PBXGroup;
+			children = (
+				845F25432B89FA3800F6C328 /* PosterExpandDIContainer.swift */,
+				845F25452B89FA5000F6C328 /* PosterExpandViewController.swift */,
+				845F25472B89FA5A00F6C328 /* PosterExpandViewModel.swift */,
+			);
+			path = PosterExpand;
+			sourceTree = "<group>";
+		};
 		84625A0C2B63B2D100CC9077 /* TicketSelection */ = {
 			isa = PBXGroup;
 			children = (
@@ -986,6 +1002,7 @@
 			children = (
 				84E512482B6E702E002658D1 /* ConcertList */,
 				84E512492B6E71B6002658D1 /* ConcertDetail */,
+				845F25412B89F9CC00F6C328 /* PosterExpand */,
 				84DF59DF2B726C34000816DA /* ConcertContentExpand */,
 				843918F82B7A827F00CC62AA /* Report */,
 				84625A0C2B63B2D100CC9077 /* TicketSelection */,
@@ -1732,6 +1749,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				84A024892B7B98710095A56E /* SelectedTicketEntity.swift in Sources */,
+				845F25442B89FA3800F6C328 /* PosterExpandDIContainer.swift in Sources */,
 				841D77DF2B7463020068B1C5 /* TicketListCollectionViewCell.swift in Sources */,
 				841D77DE2B7462EA0068B1C5 /* ServiceAPI.swift in Sources */,
 				841D77DD2B7462980068B1C5 /* TicketItemEntity.swift in Sources */,
@@ -1816,6 +1834,7 @@
 				84781CA82B5BF71900D37921 /* SplashViewController.swift in Sources */,
 				8730F0222B7B5D8200D4F339 /* TicketRefundBankSelectionViewController.swift in Sources */,
 				843918FE2B7A82E700CC62AA /* ReportViewModel.swift in Sources */,
+				845F25462B89FA5000F6C328 /* PosterExpandViewController.swift in Sources */,
 				87101EFE2B5DFCD2004BD418 /* AuthRepositoryType.swift in Sources */,
 				841D77D42B73B1B00068B1C5 /* ConcertRepository.swift in Sources */,
 				8753CA772B71F004002871C7 /* TicketListItemResponseDTO.swift in Sources */,
@@ -1839,6 +1858,7 @@
 				8710D9402B74E44400309FBF /* MypageContentView.swift in Sources */,
 				84781CAA2B5BF72200D37921 /* SplashViewModel.swift in Sources */,
 				84FEF6192B68ACDD00EBB64F /* salesTicketingEntity.swift in Sources */,
+				845F25482B89FA5A00F6C328 /* PosterExpandViewModel.swift in Sources */,
 				8710D95A2B750A5500309FBF /* MyPageDestination.swift in Sources */,
 				8757BAA42B5FDEA2008503B5 /* OAuthAPIServiceType.swift in Sources */,
 				8757BAA22B5FDE0D008503B5 /* LoginViewModel.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		84E5124F2B6E773F002658D1 /* ConcertDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5124E2B6E773F002658D1 /* ConcertDetailViewModel.swift */; };
 		84E512532B6E9E0B002658D1 /* ConcertPosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E512522B6E9E0B002658D1 /* ConcertPosterView.swift */; };
 		84EC6A642B6CF973009AC6BB /* BooltiToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EC6A632B6CF973009AC6BB /* BooltiToastView.swift */; };
+		84EF916A2B8A435C0073C89A /* PosterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EF91692B8A435C0073C89A /* PosterCollectionViewCell.swift */; };
 		84FBB2CA2B80D0E8001F4211 /* BooltiUILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBB2C92B80D0E8001F4211 /* BooltiUILabel.swift */; };
 		84FBB2CC2B80DC6B001F4211 /* MypageProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBB2CB2B80DC6B001F4211 /* MypageProfileView.swift */; };
 		84FBBDF32B673877009462E9 /* ConcertInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBBDF22B673877009462E9 /* ConcertInfoView.swift */; };
@@ -427,6 +428,7 @@
 		84E5124E2B6E773F002658D1 /* ConcertDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertDetailViewModel.swift; sourceTree = "<group>"; };
 		84E512522B6E9E0B002658D1 /* ConcertPosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertPosterView.swift; sourceTree = "<group>"; };
 		84EC6A632B6CF973009AC6BB /* BooltiToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiToastView.swift; sourceTree = "<group>"; };
+		84EF91692B8A435C0073C89A /* PosterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterCollectionViewCell.swift; sourceTree = "<group>"; };
 		84FBB2C92B80D0E8001F4211 /* BooltiUILabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiUILabel.swift; sourceTree = "<group>"; };
 		84FBB2CB2B80DC6B001F4211 /* MypageProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageProfileView.swift; sourceTree = "<group>"; };
 		84FBBDF22B673877009462E9 /* ConcertInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertInfoView.swift; sourceTree = "<group>"; };
@@ -671,6 +673,7 @@
 		845F25412B89F9CC00F6C328 /* PosterExpand */ = {
 			isa = PBXGroup;
 			children = (
+				84EF91682B8A43490073C89A /* Cells */,
 				845F25432B89FA3800F6C328 /* PosterExpandDIContainer.swift */,
 				845F25452B89FA5000F6C328 /* PosterExpandViewController.swift */,
 				845F25472B89FA5A00F6C328 /* PosterExpandViewModel.swift */,
@@ -1256,6 +1259,14 @@
 				84886E912B70AA85005D2329 /* OrganizerInfoView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		84EF91682B8A43490073C89A /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				84EF91692B8A435C0073C89A /* PosterCollectionViewCell.swift */,
+			);
+			path = Cells;
 			sourceTree = "<group>";
 		};
 		84FBBDF12B673834009462E9 /* Views */ = {
@@ -1870,6 +1881,7 @@
 				84D1C37F2B79379200527998 /* SalesTicketingRequestDTO.swift in Sources */,
 				84896A472B6A677400CB3E33 /* TicketingCompletionViewModel.swift in Sources */,
 				84A0248C2B7B996F0095A56E /* QRScannerDIContainer.swift in Sources */,
+				84EF916A2B8A435C0073C89A /* PosterCollectionViewCell.swift in Sources */,
 				84781CBE2B5BF95100D37921 /* MyPageDIContainer.swift in Sources */,
 				84781BCF2B5BDAFC00D37921 /* SceneDelegate.swift in Sources */,
 				842C1C642B7DA8A700EFE5A0 /* ResignDIContainer.swift in Sources */,

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
@@ -9,6 +9,7 @@ final class ConcertDetailDIContainer {
 
     // MARK: Properties
     
+    typealias Posters = [ConcertDetailEntity.Poster]
     typealias Content = String
     typealias ConcertId = Int
     
@@ -32,6 +33,13 @@ final class ConcertDetailDIContainer {
             let DIContainer = self.createLoginViewDIContainer()
             
             let viewController = DIContainer.createLoginViewController()
+            return viewController
+        }
+        
+        let posterExpandViewControllerFactory: (Posters) -> PosterExpandViewController = { posters in
+            let DIContainer = self.createPosterExpandDIContainer()
+
+            let viewController = DIContainer.createPosterExpandViewController(posters: posters)
             return viewController
         }
         
@@ -59,6 +67,7 @@ final class ConcertDetailDIContainer {
         let viewController = ConcertDetailViewController(
             viewModel: viewModel, 
             loginViewControllerFactory: loginViewControllerFactory,
+            posterExpandViewControllerFactory: posterExpandViewControllerFactory,
             concertContentExpandViewControllerFactory: concertContentExpandViewControllerFactory,
             reportViewControllerFactory: reportViewControllerFactory,
             ticketSelectionViewControllerFactory: ticketSelectionViewControllerFactory
@@ -72,6 +81,10 @@ final class ConcertDetailDIContainer {
             authRepository: self.authRepository,
             socialLoginAPIService: OAuthRepository()
         )
+    }
+    
+    private func createPosterExpandDIContainer() -> PosterExpandDIContainer {
+        return PosterExpandDIContainer()
     }
     
     private func createConcertContentExpandDIContainer() -> ConcertContentExpandDIContainer {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -142,8 +142,11 @@ extension ConcertDetailViewController {
     
     private func bindOutputs() {
         self.viewModel.output.concertDetail
+            .skip(1)
             .take(1)
             .bind(with: self) { owner, entity in
+                guard let entity = entity else { return }
+                
                 owner.concertPosterView.setData(images: entity.posters, title: entity.name)
                 owner.ticketingPeriodView.setData(startDate: entity.salesStartTime, endDate: entity.salesEndTime)
                 owner.placeInfoView.setData(name: entity.placeName, streetAddress: entity.streetAddress, detailAddress: entity.detailAddress)
@@ -194,7 +197,7 @@ extension ConcertDetailViewController {
     private func bindPlaceInfoView() {
         self.placeInfoView.didAddressCopyButtonTap()
             .emit(with: self) { owner, _ in
-                UIPasteboard.general.string = owner.viewModel.output.concertDetailEntity?.streetAddress
+                UIPasteboard.general.string = owner.viewModel.output.concertDetail.value?.streetAddress
                 owner.showToast(message: "공연장 주소가 복사되었어요")
             }
             .disposed(by: self.disposeBag)
@@ -203,7 +206,7 @@ extension ConcertDetailViewController {
     private func bindContentInfoView() {
         self.contentInfoView.didAddressExpandButtonTap()
             .emit(with: self) { owner, _ in
-                owner.viewModel.input.didExpandButtonTap.accept(())
+                owner.viewModel.input.didExpandButtonTap.onNext(())
             }
             .disposed(by: self.disposeBag)
     }
@@ -235,7 +238,7 @@ extension ConcertDetailViewController {
         self.navigationBar.didShareButtonTap()
             .emit(with: self) { owner, _ in
                 guard let url = URL(string: AppInfo.booltiShareLink),
-                      let posterURL = owner.viewModel.output.concertDetailEntity?.posters.first?.path
+                      let posterURL = owner.viewModel.output.concertDetail.value?.posters.first?.path
                 else { return }
                 
                 let image = KFImage(URL(string: posterURL))

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewModel.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 enum ConcertDetailDestination {
     case login
+    case posterExpand(posters: [ConcertDetailEntity.Poster])
     case contentExpand(content: String)
     case ticketSelection(concertId: Int)
 }
@@ -59,6 +60,7 @@ final class ConcertDetailViewModel {
     
     struct Input {
         let didTicketingButtonTap = PublishSubject<Void>()
+        let didPosterViewTap = PublishSubject<Void>()
         let didExpandButtonTap = PublishSubject<Void>()
     }
     
@@ -71,7 +73,7 @@ final class ConcertDetailViewModel {
     let input: Input
     var output: Output
     
-    let concertId: Int
+    private let concertId: Int
     
     // MARK: Init
     
@@ -96,6 +98,13 @@ extension ConcertDetailViewModel {
             .bind(with: self) { owner, _ in
                 guard let notice = owner.output.concertDetail.value?.notice else { return }
                 owner.output.navigate.accept(.contentExpand(content: notice))
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.input.didPosterViewTap
+            .bind(with: self) { owner, _ in
+                guard let posters = owner.output.concertDetail.value?.posters else { return }
+                owner.output.navigate.accept(.posterExpand(posters: posters))
             }
             .disposed(by: self.disposeBag)
         

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
@@ -74,10 +74,8 @@ extension ConcertPosterView {
             imageView.setImage(with: images[index].path)
             imageView.contentMode = .scaleAspectFill
 
-            let positionX = self.scrollViewHeight * CGFloat(index)
+            let positionX = self.scrollViewWidth * CGFloat(index)
             imageView.frame = CGRect(x: positionX, y: 0, width: self.scrollViewWidth, height: self.scrollViewHeight)
-
-            imageView.frame.origin.x = self.scrollViewWidth * CGFloat(index)
             
             if images.count > 1 {
                 let gradientLayer = CAGradientLayer()

--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/Cells/PosterCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/Cells/PosterCollectionViewCell.swift
@@ -1,0 +1,76 @@
+//
+//  PosterCollectionViewCell.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/25/24.
+//
+
+import UIKit
+
+final class PosterCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: UI Component
+
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.isPagingEnabled = true
+        scrollView.delegate = self
+        scrollView.addSubview(self.imageView)
+        
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 5.0
+        return scrollView
+    }()
+    
+    private let imageView: UIImageView = {
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 637 * (UIScreen.main.bounds.height / 812)))
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    // MARK: Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.configureUI()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+}
+
+// MARK: - Methods
+
+extension PosterCollectionViewCell {
+ 
+    func setData(with path: String) {
+        self.imageView.setImage(with: path)
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension PosterCollectionViewCell: UIScrollViewDelegate {
+    
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+         return self.imageView
+     }
+}
+
+// MARK: - UI
+
+extension PosterCollectionViewCell {
+    
+    private func configureUI() {
+        self.addSubview(self.scrollView)
+        
+        self.scrollView.snp.makeConstraints { make in
+            make.width.equalToSuperview()
+            make.height.equalTo(self.imageView.frame.height)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/Cells/PosterCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/Cells/PosterCollectionViewCell.swift
@@ -15,7 +15,7 @@ final class PosterCollectionViewCell: UICollectionViewCell {
         let scrollView = UIScrollView()
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
-        scrollView.isPagingEnabled = true
+        scrollView.isScrollEnabled = false
         scrollView.delegate = self
         scrollView.addSubview(self.imageView)
         
@@ -59,6 +59,22 @@ extension PosterCollectionViewCell: UIScrollViewDelegate {
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
          return self.imageView
      }
+
+    func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        if scale > 1.0 && scale <= 5.0 {
+            scrollView.isScrollEnabled = true
+        } else {
+            scrollView.isScrollEnabled = false
+        }
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.zoomScale <= 1.0 {
+            scrollView.zoomScale = 1.0
+        } else if scrollView.zoomScale >= 5.0 {
+            scrollView.zoomScale = 5.0
+        }
+    }
 }
 
 // MARK: - UI

--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/Cells/PosterCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/Cells/PosterCollectionViewCell.swift
@@ -69,8 +69,7 @@ extension PosterCollectionViewCell {
         self.addSubview(self.scrollView)
         
         self.scrollView.snp.makeConstraints { make in
-            make.width.equalToSuperview()
-            make.height.equalTo(self.imageView.frame.height)
+            make.edges.equalToSuperview()
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandDIContainer.swift
@@ -1,0 +1,24 @@
+//
+//  PosterExpandDIContainer.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/24/24.
+//
+
+final class PosterExpandDIContainer {
+    
+    func createPosterExpandViewController(posters: [ConcertDetailEntity.Poster]) -> PosterExpandViewController {
+        let viewModel = createPosterExpandViewModel(posters: posters)
+
+        let viewController = PosterExpandViewController(
+            viewModel: viewModel
+        )
+
+        return viewController
+    }
+    
+    private func createPosterExpandViewModel(posters: [ConcertDetailEntity.Poster]) -> PosterExpandViewModel {
+        return PosterExpandViewModel(posters: posters)
+    }
+
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandViewController.swift
@@ -1,0 +1,148 @@
+//
+//  PosterExpandViewController.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/24/24.
+//
+
+import UIKit
+
+import RxSwift
+
+final class PosterExpandViewController: BooltiViewController {
+    
+    // MARK: Properties
+    
+    private let viewModel: PosterExpandViewModel
+    private let disposeBag = DisposeBag()
+    
+    // MARK: UI Component
+    
+    private let closeButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.closeButton, for: .normal)
+        return button
+    }()
+    
+    private lazy var posterScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.isPagingEnabled = true
+        scrollView.delegate = self
+        return scrollView
+    }()
+    
+    private let pageControl = UIPageControl()
+    
+    // MARK: Init
+    
+    init(viewModel: PosterExpandViewModel) {
+        self.viewModel = viewModel
+        
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.configureUI()
+        self.configureConstraints()
+        self.bindUIComponents()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        self.configureScrollView()
+    }
+}
+
+// MARK: - Methods
+
+extension PosterExpandViewController {
+    
+    private func bindUIComponents() {
+        self.closeButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.dismiss(animated: true)
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func configureScrollView() {
+        let scrollViewWidth: CGFloat = self.view.frame.width
+        let scrollViewHeight: CGFloat = self.pageControl.frame.minY - self.closeButton.frame.maxY - 30
+        
+        for index in 0..<self.viewModel.posters.count{
+            let backgroundView = UIView()
+
+            let imageView = UIImageView()
+            imageView.setImage(with: self.viewModel.posters[index].path)
+            imageView.contentMode = .scaleAspectFit
+
+            let positionX = scrollViewWidth * CGFloat(index)
+            backgroundView.frame = CGRect(x: positionX, y: 0, width: scrollViewWidth, height: scrollViewHeight)
+            
+            backgroundView.addSubview(imageView)
+            imageView.snp.makeConstraints { make in
+                make.edges.equalTo(backgroundView)
+            }
+            
+            self.posterScrollView.addSubview(backgroundView)
+        }
+        
+        self.posterScrollView.contentSize = CGSize(
+            width: scrollViewWidth * CGFloat(self.viewModel.posters.count),
+            height: scrollViewHeight
+        )
+        self.pageControl.numberOfPages = self.viewModel.posters.count
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension PosterExpandViewController: UIScrollViewDelegate {
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let currentPage = Int(round(self.posterScrollView.contentOffset.x / self.view.frame.width))
+        self.pageControl.currentPage = currentPage
+    }
+}
+
+// MARK: - UI
+
+extension PosterExpandViewController {
+    
+    private func configureUI() {
+        self.view.addSubviews([self.closeButton,
+                               self.posterScrollView,
+                               self.pageControl])
+        
+        self.view.backgroundColor = .grey95
+    }
+    
+    private func configureConstraints() {
+        self.closeButton.snp.makeConstraints { make in
+            make.size.equalTo(24)
+            make.left.equalToSuperview().inset(20)
+            make.top.equalTo(self.view.safeAreaLayoutGuide).inset(10)
+        }
+        
+        self.posterScrollView.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide).inset(44)
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(47)
+        }
+        
+        self.pageControl.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(20)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  PosterExpandViewModel.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 2/24/24.
+//
+
+import Foundation
+
+final class PosterExpandViewModel {
+    
+    // MARK: Properties
+    
+    let posters: [ConcertDetailEntity.Poster]
+    
+    // MARK: Init
+    
+    init(posters: [ConcertDetailEntity.Poster]) {
+        self.posters = posters
+    }
+}


### PR DESCRIPTION
## 작업한 내용
- 공연 상세에서 공연 이미지를 누르면 확대되고, 줌이 가능한 뷰를 구현했어요.
- 기존에 공연 상세의 이미지는 scrollView만을 이용했는데, 줌 했을 때 이미지 가져오는 뷰에서 오류가 좀 있어서 CollectionView -> CollectionViewCell -> ScrollView -> 한 개의 ImageView로 구현을 했어요.
  - 각각의 Cell에는 Cell크기와 같은 ScrollView가 있고, 이 ScrollView안에는 하나의 ImageView가 있어요!
- 줌했을 때 가끔 포커스가 이상한 곳으로 갈 때가 있는데, 이 부분은 더 찾아보고 보완할게요 .. 

## 스크린샷
![RPReplay_Final1708790467](https://github.com/Nexters/Boolti-iOS/assets/58043306/a0c7eeab-55c3-4c2b-94c5-f85442900a09) 

- 포커스가 이상한 곳으로 감 이슈 수정된 버전
![RPReplay_Final1708871386](https://github.com/Nexters/Boolti-iOS/assets/58043306/92612a55-cf9d-4801-8540-51af7bbc7e6c)

## 관련 이슈
- Resolved: #144 
