### PR TITLE
Chore/#143  Design QA(ticket + Reservation)

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -591,10 +591,10 @@
 		840B39532B7667B100E7F8C8 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */,
-				840B395A2B7679EC00E7F8C8 /* SearchBarCollectionViewCell.swift */,
 				840B395C2B768B0800E7F8C8 /* CheckingTicketCollectionViewCell.swift */,
+				840B395A2B7679EC00E7F8C8 /* SearchBarCollectionViewCell.swift */,
 				840B395E2B76966E00E7F8C8 /* ConcertListMainTitleCollectionViewCell.swift */,
+				840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";

--- a/Boolti/Boolti/Sources/Entities/Ticket/TicketReservationDetailEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Ticket/TicketReservationDetailEntity.swift
@@ -39,4 +39,5 @@ struct TicketReservationDetailEntity {
     let purchaserPhoneNumber: String
     let depositorName: String
     let depositorPhoneNumber: String
+    let salesEndTime: String
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/UILabel+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UILabel+.swift
@@ -27,6 +27,9 @@ extension UILabel {
             style.maximumLineHeight = lineHeight
             style.minimumLineHeight = lineHeight
             
+            style.lineBreakMode = .byTruncatingTail
+            style.lineBreakStrategy = .hangulWordPriority
+            
             let attributes: [NSAttributedString.Key: Any] = [
             .paragraphStyle: style,
             .baselineOffset: (lineHeight - font.lineHeight) / 2
@@ -34,27 +37,6 @@ extension UILabel {
             
             let attributeString = NSAttributedString(string: text,
                                                      attributes: attributes)
-            self.attributedText = attributeString
-        }
-    }
-    
-    // TODO: 아래 메서드 수정 예정 (행간 조절 말고, lineHeight 사용)
-    
-    /// 행간 조정 메서드
-    func setLineSpacing(lineSpacing: CGFloat) {
-        if let text = self.text {
-            let style = NSMutableParagraphStyle()
-            
-            style.lineSpacing = lineSpacing
-            style.lineBreakMode = .byTruncatingTail
-            style.lineBreakStrategy = .hangulWordPriority
-            
-            let attributes: [NSAttributedString.Key: Any] = [
-            .paragraphStyle: style
-            ]
-
-            let attributeString = NSMutableAttributedString(string: text,
-                                                            attributes: attributes)
             self.attributedText = attributeString
         }
     }
@@ -69,7 +51,6 @@ extension UILabel {
             style.maximumLineHeight = lineHeight
             style.minimumLineHeight = lineHeight
             
-            style.lineBreakMode = .byWordWrapping
             style.lineBreakStrategy = .hangulWordPriority
             style.headIndent = 10
             attributedString.addAttribute(.paragraphStyle, value: style, range: NSMakeRange(0, attributedString.length))

--- a/Boolti/Boolti/Sources/Network/DTO/Reservation/Response/TicketReservationDetailResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Reservation/Response/TicketReservationDetailResponseDTO.swift
@@ -53,7 +53,8 @@ extension TicketReservationDetailResponseDTO {
             purchaseName: self.reservationName,
             purchaserPhoneNumber: self.reservationPhoneNumber,
             depositorName: self.depositorName ?? "",
-            depositorPhoneNumber: self.depositorPhoneNumber ?? ""
+            depositorPhoneNumber: self.depositorPhoneNumber ?? "",
+            salesEndTime: self.salesEndTime
         )
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -62,6 +62,7 @@ class BooltiViewController: UIViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        print("🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️")
     }
     
     // MARK: Override

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiViewController.swift
@@ -62,7 +62,6 @@ class BooltiViewController: UIViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        print("🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️")
     }
     
     // MARK: Override

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
@@ -42,7 +42,6 @@ final class ConcertPosterView: UIView {
         label.font = .point3
         label.textColor = .grey05
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ContentInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ContentInfoView.swift
@@ -38,7 +38,6 @@ final class ContentInfoView: UIView {
         label.textColor = .grey30
         label.font = .body3
         label.numberOfLines = 0
-        label.lineBreakMode = .byTruncatingTail
         
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/DatetimeInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/DatetimeInfoView.swift
@@ -25,7 +25,6 @@ final class DatetimeInfoView: UIView {
         label.textColor = .grey30
         label.font = .body3
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/PlaceInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/PlaceInfoView.swift
@@ -57,7 +57,6 @@ final class PlaceInfoView: UIView {
         label.textColor = .grey30
         label.font = .body3
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/ConcertCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/ConcertCollectionViewCell.swift
@@ -85,8 +85,7 @@ final class ConcertCollectionViewCell: UICollectionViewCell {
         let label = BooltiUILabel()
         label.font = .point1
         label.textColor = .grey05
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -182,14 +182,14 @@ extension ConcertListViewController: UICollectionViewDelegateFlowLayout {
         case 2:
             return CGSize(width: self.mainCollectionView.frame.width - 40, height: 80)
         default:
-            return CGSize(width: (self.mainCollectionView.frame.width - 40) / 2 - 7.5, height: 313)
+            return CGSize(width: (self.mainCollectionView.frame.width - 40) / 2 - 7.5, height: 313 * self.view.frame.height / 812)
         }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         switch section {
         case 3:
-            return UIEdgeInsets(top: 12, left: 0, bottom: 20, right: 0)
+            return UIEdgeInsets(top: 12, left: 0, bottom: 0, right: 0)
         default:
             return .zero
         }
@@ -207,7 +207,7 @@ extension ConcertListViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         switch section {
         case 3:
-            return 28
+            return 20
         default:
             return 0
         }

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/DepositSummaryView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/DepositSummaryView.swift
@@ -11,21 +11,20 @@ final class DepositSummaryView: UIView {
     
     // MARK: UI Component
     
-    private let datePriceLabel: UILabel = {
-        let label = UILabel()
+    private let datePriceLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.numberOfLines = 2
         label.font = .point4
         label.textColor = .grey05
         return label
     }()
     
-    private let infoLabel: UILabel = {
-        let label = UILabel()
+    private let infoLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.numberOfLines = 2
-        label.text = "입금 마감일까지 입금이 확인되지 않는 경우\n주문이 자동 취소됩니다."
         label.font = .body1
         label.textColor = .grey50
-        label.setLineSpacing(lineSpacing: 6)
+        label.text = "입금 마감일까지 입금이 확인되지 않는 경우\n주문이 자동 취소됩니다."
         return label
     }()
     
@@ -60,7 +59,6 @@ extension DepositSummaryView {
         let formattedDate = date.format(.simple)
         let formattedPrice = "\(price.formattedCurrency())원"
         self.datePriceLabel.text = "\(formattedDate)까지 아래 계좌로\n\(formattedPrice)을 입금해주세요"
-        self.datePriceLabel.setLineSpacing(lineSpacing: 6)
         self.datePriceLabel.setSubStringColor(to: [formattedDate, formattedPrice], with: .orange01)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/PaymentCompletionView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/PaymentCompletionView.swift
@@ -11,11 +11,11 @@ final class PaymentCompletionView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "결제가 완료되었어요"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .point4
         label.textColor = .grey05
+        label.text = "결제가 완료되었어요"
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/ReservedTicketView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingCompletion/Views/ReservedTicketView.swift
@@ -1,5 +1,5 @@
 //
-//  TicketInfoView.swift
+//  ReservedTicketView.swift
 //  Boolti
 //
 //  Created by Juhyeon Byun on 1/31/24.
@@ -23,7 +23,7 @@ final class ReservedTicketView: UIView {
     
     private lazy var labelStackView: UIStackView = {
         let view = UIStackView()
-        view.spacing = 8
+        view.spacing = 4
         view.axis = .vertical
         view.alignment = .fill
         
@@ -31,25 +31,23 @@ final class ReservedTicketView: UIView {
         return view
     }()
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .point1
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
-        label.setLineSpacing(lineSpacing: 4)
+        label.numberOfLines = 2
         label.textColor = .grey05
         return label
     }()
     
-    private let ticketDetailLabel: UILabel = {
-        let label = UILabel()
+    private let ticketDetailLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .caption
         label.textColor = .grey30
         return label
     }()
     
-    private let priceLabel: UILabel = {
-        let label = UILabel()
+    private let priceLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .caption
         label.textColor = .grey30
         return label
@@ -75,7 +73,6 @@ extension ReservedTicketView {
     
     func setData(concert: ConcertDetailEntity, selectedTicket: SelectedTicketEntity) {
         self.titleLabel.text = concert.name
-        self.titleLabel.setLineSpacing(lineSpacing: 4)
         self.ticketDetailLabel.text = "\(selectedTicket.ticketName) / 1매"
         self.priceLabel.text = "\(selectedTicket.price.formattedCurrency())원"
         self.poster.setImage(with: concert.posters.first?.thumbnailPath ?? "")

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/ConcertInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/ConcertInfoView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import RxSwift
 import SnapKit
 
 final class ConcertInfoView: UIView {
@@ -37,8 +36,7 @@ final class ConcertInfoView: UIView {
     private let titleLabel: BooltiUILabel = {
         let label = BooltiUILabel()
         label.font = .point2
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         label.textColor = .grey05
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/InvitationCodeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/InvitationCodeView.swift
@@ -25,11 +25,11 @@ final class InvitationCodeView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "초청 코드"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
+        label.text = "초청 코드"
         return label
     }()
     
@@ -48,8 +48,8 @@ final class InvitationCodeView: UIView {
         return button
     }()
     
-    private let codeStateLabel: UILabel = {
-        let label = UILabel()
+    private let codeStateLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .body1
         label.isHidden = true
         return label

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/PolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/PolicyView.swift
@@ -19,11 +19,11 @@ final class PolicyView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "취소/환불 규정"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
+        label.text = "취소/환불 규정"
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/TicketInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/TicketingDetail/Views/TicketInfoView.swift
@@ -11,11 +11,11 @@ final class TicketInfoView: UIView {
     
     // MARK: UI Component
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "티켓 정보"
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
+        label.text = "티켓 정보"
         return label
     }()
     
@@ -35,7 +35,7 @@ final class TicketInfoView: UIView {
         let view = UIStackView()
         view.axis = .vertical
         view.alignment = .fill
-        view.spacing = 20
+        view.spacing = 16
         
         view.addArrangedSubviews([self.ticketTypeStackView, self.ticketCountStackView, self.totalPriceStackView])
         return view
@@ -48,8 +48,6 @@ final class TicketInfoView: UIView {
         
         self.configureUI()
         self.configureConstraints()
-        
-        self.setData(entity: .init(id: 1, concertId: 1, ticketType: .sales, ticketName: "일반 티켓 A", price: 5000, quantity: 100))
     }
     
     required init?(coder: NSCoder) {
@@ -75,13 +73,13 @@ extension TicketInfoView {
     private func makeSelectedTitleLabel(title: String) -> BooltiUILabel {
         let label = BooltiUILabel()
         label.font = .body3
-        label.text = title
         label.textColor = .grey30
+        label.text = title
         return label
     }
     
-    private func makeSelectedDataLabel() -> UILabel {
-        let label = UILabel()
+    private func makeSelectedDataLabel() -> BooltiUILabel {
+        let label = BooltiUILabel()
         label.font = .body3
         label.textColor = .grey15
         label.textAlignment = .right
@@ -91,6 +89,7 @@ extension TicketInfoView {
     private func makeStackView(with: [UILabel]) -> UIStackView {
         let view = UIStackView()
         view.axis = .horizontal
+        view.distribution = .equalSpacing
         view.addArrangedSubviews(with)
         return view
     }
@@ -114,7 +113,7 @@ extension TicketInfoView {
         self.stackView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(20)
             make.top.equalTo(self.titleLabel.snp.bottom).offset(20)
-            make.bottom.equalToSuperview().inset(28)
+            make.bottom.equalToSuperview().inset(20)
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Logout/LogoutViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Logout/LogoutViewController.swift
@@ -30,11 +30,11 @@ final class LogoutViewController: BooltiViewController {
         return button
     }()
 
-    private let askingLogoutLabel: UILabel = {
-        let label = UILabel()
-        label.text = "정말 로그아웃 하시겠어요?"
+    private let askingLogoutLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey15
+        label.text = "정말 로그아웃 하시겠어요?"
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/Views/MypageContentView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/Views/MypageContentView.swift
@@ -14,8 +14,8 @@ final class MypageContentView: UIView {
 
     private let disposeBag = DisposeBag()
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .pretendardB(18)
         label.textColor = .grey10
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/QRScanner/QRScannerList/Cells/QRScannerListTableViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/QRScanner/QRScannerList/Cells/QRScannerListTableViewCell.swift
@@ -17,11 +17,11 @@ final class QRScannerListTableViewCell: UITableViewCell {
         return view
     }()
     
-    private let concertNameLabel: UILabel = {
-        let label = UILabel()
+    private let concertNameLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .aggroB(16)
         label.textColor = .grey05
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         return label
     }()
     
@@ -58,7 +58,6 @@ extension QRScannerListTableViewCell {
     
     func setData(concertName: String, isConcertEnd: Bool) {
         self.concertNameLabel.text = concertName
-        self.concertNameLabel.setLineSpacing(lineSpacing: 6)
         
         if isConcertEnd {
             self.concertNameLabel.textColor = .grey50

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/BankEntity.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/BankEntity.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct BankEntity {
+struct BankEntity: Equatable {
     let bankName: String
     let bankCode: String
     let bankIconImage: UIImage

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/Cells/TicketRefundBankCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/Cells/TicketRefundBankCollectionViewCell.swift
@@ -25,16 +25,9 @@ final class TicketRefundBankCollectionViewCell: UICollectionViewCell {
 
     override var isSelected: Bool {
         didSet {
-            self.isSelectedState = self.isSelected
-        }
-    }
-
-    var isSelectedState: Bool = false {
-        didSet {
             self.updateSelectionUI()
         }
     }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.configureUI()
@@ -70,9 +63,9 @@ final class TicketRefundBankCollectionViewCell: UICollectionViewCell {
     }
     
     private func updateSelectionUI() {
-        self.layer.borderColor = self.isSelectedState ? UIColor.grey10.cgColor : nil
-        self.layer.borderWidth = self.isSelectedState ? 1.0 : 0
-        self.contentView.alpha = self.isSelectedState ? 1.0 : 0.4
+        self.layer.borderColor = self.isSelected ? UIColor.grey10.cgColor : nil
+        self.layer.borderWidth = self.isSelected ? 1.0 : 0
+        self.contentView.alpha = self.isSelected ? 1.0 : 0.4
     }
 
     private func configureConstraints() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/Cells/TicketRefundBankCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/Cells/TicketRefundBankCollectionViewCell.swift
@@ -25,6 +25,12 @@ final class TicketRefundBankCollectionViewCell: UICollectionViewCell {
 
     override var isSelected: Bool {
         didSet {
+            self.isSelectedState = self.isSelected
+        }
+    }
+
+    var isSelectedState: Bool = false {
+        didSet {
             self.updateSelectionUI()
         }
     }
@@ -45,6 +51,7 @@ final class TicketRefundBankCollectionViewCell: UICollectionViewCell {
         self.bankImageView.image = nil
         self.bankNameLabel.text = nil
         self.layer.borderWidth = 0
+        self.contentView.alpha = 1.0
     }
     
     private func configureUI() {
@@ -63,9 +70,9 @@ final class TicketRefundBankCollectionViewCell: UICollectionViewCell {
     }
     
     private func updateSelectionUI() {
-        self.layer.borderColor = self.isSelected ? UIColor.grey10.cgColor : nil
-        self.layer.borderWidth = self.isSelected ? 1.0 : 0
-        self.alpha = self.isSelected ? 1.0 : 0.4
+        self.layer.borderColor = self.isSelectedState ? UIColor.grey10.cgColor : nil
+        self.layer.borderWidth = self.isSelectedState ? 1.0 : 0
+        self.contentView.alpha = self.isSelectedState ? 1.0 : 0.4
     }
 
     private func configureConstraints() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
@@ -53,17 +53,28 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
 
     private let finishSelectionButton = BooltiButton(title: "선택 완료하기")
 
-    var isBankSelected: Bool = false
-    var selectedItem: ((BankEntity) -> ())?
+    private var isBankSelected: Bool = false
+    // ViewModel 활용하지 않아서 아래와 같이 VC의 프로퍼티로 구현
+    var selectedItemIndex: Int?
+    var selectedItem: ((BankEntity?) -> ())?
 
     // viewModel로 설정할 예정
 
-    override init() {
+    init(selectedBank: BankEntity?) {
         super.init()
+        self.setSelectedItemIndex(with: selectedBank)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setSelectedItemIndex(with selectedBank: BankEntity?) {
+        guard let selectedBank else { return }
+        self.isBankSelected = true
+        let index = BankEntity.all.firstIndex { $0 == selectedBank }
+        guard let index else { return }
+        self.selectedItemIndex = index
     }
 
     override func viewDidLoad() {
@@ -74,6 +85,7 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
         self.configureBottomSheet()
         self.bindUIComponents()
         self.bindOutputs()
+        self.configureSelectedItem()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -112,34 +124,46 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
             .disposed(by: self.disposeBag)
     }
 
+    private func configureSelectedItem() {
+        guard let index = self.selectedItemIndex else { return }
+        let selectedIndexPath = IndexPath(item: index, section: 0)
+
+        self.collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredVertically)
+        self.finishSelectionButton.isEnabled = true
+        self.isBankSelected = true
+    }
+
     private func bindUIComponents() {
+
         self.collectionView.rx.itemSelected
             .subscribe(with: self) { owner, selectedIndexPath in
                 owner.isBankSelected = true
-                
-                // TODO: 선택 완료했을 때만 넘어가야함
-                owner.selectedItem?(BankEntity.all[selectedIndexPath.row])
-                owner.updateCellUI(selectedIndexPath)
 
-                if !owner.finishSelectionButton.isEnabled {
-                    owner.finishSelectionButton.isEnabled.toggle()
-                }
+                owner.selectedItemIndex = selectedIndexPath.row
+                owner.updateCellUI(selectedIndexPath.row)
+
+                owner.finishSelectionButton.isEnabled = true
             }
             .disposed(by: self.disposeBag)
 
         self.finishSelectionButton.rx.tap
             .bind(with: self) { owner, _ in
+
+                if let index = owner.selectedItemIndex {
+                    owner.selectedItem?(BankEntity.all[index])
+                } else {
+                    owner.selectedItem?(nil)
+                }
                 owner.dismiss(animated: true)
             }
             .disposed(by: self.disposeBag)
     }
 
-    private func updateCellUI(_ selectedIndexPath: ControlEvent<IndexPath>.Element) {
+    private func updateCellUI(_ selectedIndexPathItem: Int) {
         for item in 0..<self.collectionView.numberOfItems(inSection: 0) {
             let indexPath = IndexPath(item: item, section: 0)
-            if let cell = self.collectionView.cellForItem(at: indexPath) as? TicketRefundBankCollectionViewCell {
-                cell.isSelected = (indexPath == selectedIndexPath)
-            }
+            guard let cell = self.collectionView.cellForItem(at: indexPath) as? TicketRefundBankCollectionViewCell else { return }
+            cell.isSelected = (indexPath.item == selectedIndexPathItem)
         }
     }
 
@@ -185,8 +209,13 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
             .asObservable()
             .bind(to: self.collectionView.rx
                 .items(cellIdentifier: TicketRefundBankCollectionViewCell.className, cellType: TicketRefundBankCollectionViewCell.self)
-            ) { index, entity, cell in
+            ) { [weak self] index, entity, cell in
+                guard let self = self else { return }
+
                 cell.setData(with: entity)
+
+                guard self.isBankSelected else { return }
+                cell.isSelectedState = (index == self.selectedItemIndex) ? true : false
             }
             .disposed(by: self.disposeBag)
     }
@@ -204,10 +233,10 @@ extension TicketRefundBankSelectionViewController: UICollectionViewDelegateFlowL
     }
     
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if let cell = cell as? TicketRefundBankCollectionViewCell {
-            if isBankSelected {
-                cell.alpha = cell.isSelected ? 1.0 : 0.4
-            }
+        guard let cell = cell as? TicketRefundBankCollectionViewCell else { return }
+
+        if isBankSelected {
+            cell.contentView.alpha = cell.isSelected ? 1.0 : 0.4
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
@@ -54,11 +54,8 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
     private let finishSelectionButton = BooltiButton(title: "선택 완료하기")
 
     private var isBankSelected: Bool = false
-    // ViewModel 활용하지 않아서 아래와 같이 VC의 프로퍼티로 구현
     var selectedItemIndex: Int?
-    var selectedItem: ((BankEntity?) -> ())?
-
-    // viewModel로 설정할 예정
+    var selectedItem: ((BankEntity) -> ())?
 
     init(selectedBank: BankEntity?) {
         super.init()
@@ -72,8 +69,7 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
     private func setSelectedItemIndex(with selectedBank: BankEntity?) {
         guard let selectedBank else { return }
         self.isBankSelected = true
-        let index = BankEntity.all.firstIndex { $0 == selectedBank }
-        guard let index else { return }
+        guard let index = BankEntity.all.firstIndex(where: { $0 == selectedBank }) else { return }
         self.selectedItemIndex = index
     }
 
@@ -127,12 +123,15 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
     private func configureSelectedItem() {
         guard let index = self.selectedItemIndex else { return }
         let selectedIndexPath = IndexPath(item: index, section: 0)
+        
+        DispatchQueue.main.async {
+            self.collectionView.selectItem(
+                at: selectedIndexPath,
+                animated: false,
+                scrollPosition: .centeredVertically
+            )
+        }
 
-        self.collectionView.selectItem(
-            at: selectedIndexPath,
-            animated: false,
-            scrollPosition: .centeredVertically
-        )
         self.finishSelectionButton.isEnabled = true
         self.isBankSelected = true
     }
@@ -152,12 +151,8 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
 
         self.finishSelectionButton.rx.tap
             .bind(with: self) { owner, _ in
-
-                if let index = owner.selectedItemIndex {
-                    owner.selectedItem?(BankEntity.all[index])
-                } else {
-                    owner.selectedItem?(nil)
-                }
+                guard let index = owner.selectedItemIndex else { return }
+                owner.selectedItem?(BankEntity.all[index])
                 owner.dismiss(animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
@@ -128,7 +128,11 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
         guard let index = self.selectedItemIndex else { return }
         let selectedIndexPath = IndexPath(item: index, section: 0)
 
-        self.collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredVertically)
+        self.collectionView.selectItem(
+            at: selectedIndexPath,
+            animated: false,
+            scrollPosition: .centeredVertically
+        )
         self.finishSelectionButton.isEnabled = true
         self.isBankSelected = true
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
@@ -219,7 +219,7 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
                 cell.setData(with: entity)
 
                 guard self.isBankSelected else { return }
-                cell.isSelectedState = (index == self.selectedItemIndex) ? true : false
+                cell.isSelected = (index == self.selectedItemIndex) ? true : false
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
@@ -126,7 +126,7 @@ final class TicketRefundConfirmViewController: BooltiViewController {
 
         self.refundInformationContentBackgroundView.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(self.contentBackGroundView).inset(20)
-            make.height.equalTo(144)
+            make.height.equalTo(168)
             make.top.equalTo(self.titleLabel.snp.bottom).offset(24)
         }
 
@@ -139,19 +139,19 @@ final class TicketRefundConfirmViewController: BooltiViewController {
         self.accountHolderPhoneNumberView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
-            make.top.equalTo(self.accountHolderNameView.snp.bottom).offset(8)
+            make.top.equalTo(self.accountHolderNameView.snp.bottom).offset(16)
         }
 
         self.accountBankNameView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
-            make.top.equalTo(self.accountHolderPhoneNumberView.snp.bottom).offset(8)
+            make.top.equalTo(self.accountHolderPhoneNumberView.snp.bottom).offset(16)
         }
 
         self.accountNumberView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
-            make.top.equalTo(self.accountBankNameView.snp.bottom).offset(8)
+            make.top.equalTo(self.accountBankNameView.snp.bottom).offset(16)
         }
 
         self.requestRefundButton.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/Views/RefundConfirmContentView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/Views/RefundConfirmContentView.swift
@@ -22,7 +22,7 @@ final class RefundConfirmContentView: UIView {
         let label = BooltiUILabel()
         label.textColor = .grey15
         label.font = .body1
-        label.textAlignment = .right
+        label.textAlignment = .left
 
         return label
     }()
@@ -53,10 +53,11 @@ final class RefundConfirmContentView: UIView {
 
         self.titleLabel.snp.makeConstraints { make in
             make.left.equalToSuperview()
+            make.width.equalTo(82)
         }
 
         self.contentLabel.snp.makeConstraints { make in
-            make.right.equalToSuperview()
+            make.left.equalTo(self.titleLabel.snp.right)
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -205,20 +205,6 @@ final class TicketRefundRequestViewController: BooltiViewController {
             }
             .disposed(by: self.disposeBag)
 
-        self.viewModel.output.isValidAccoundHolderName
-            .asDriver(onErrorDriveWith: .never())
-            .drive(with: self) { owner, isValid in
-                owner.accountHolderNameView.isValidTextTyped = isValid
-            }
-            .disposed(by: self.disposeBag)
-
-        self.viewModel.output.isValidAccoundHolderPhoneNumber
-            .asDriver(onErrorDriveWith: .never())
-            .drive(with: self) { owner, isValid in
-                owner.accountHolderPhoneNumberView.isValidTextTyped = isValid
-            }
-            .disposed(by: self.disposeBag)
-
         self.viewModel.output.isValidrefundAccountNumber
             .asDriver(onErrorDriveWith: .never())
             .drive(with: self) { owner, isValid in
@@ -235,14 +221,15 @@ final class TicketRefundRequestViewController: BooltiViewController {
             .disposed(by: self.disposeBag)
 
         Observable.combineLatest(
-            self.viewModel.output.isValidAccoundHolderName,
-            self.viewModel.output.isValidAccoundHolderPhoneNumber,
+            self.viewModel.output.isAccoundHolderNameEmpty,
+            self.viewModel.output.isAccoundHolderPhoneNumberEmpty,
             self.viewModel.output.isValidrefundAccountNumber,
             self.viewModel.output.selectedBank
         )
             .asDriver(onErrorDriveWith: .never())
-            .drive { [weak self] (isValidName, isValidPhoneNumber, isValidNumber, selectedBank) in
-                self?.requestRefundButton.isEnabled = isValidName && isValidPhoneNumber && isValidNumber && (selectedBank != nil)
+            .drive { [weak self] (isAccountHolderEmpty, isAccountPhoneNumberEmpty, isValidNumber, selectedBank) in
+
+                self?.requestRefundButton.isEnabled = !isAccountHolderEmpty && !isAccountPhoneNumberEmpty && isValidNumber && (selectedBank != nil)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -179,10 +179,11 @@ final class TicketRefundRequestViewController: BooltiViewController {
             .when(.recognized)
             .asDriver(onErrorDriveWith: .never())
             .drive(with: self) { owner, _ in
-                let viewController = TicketRefundBankSelectionViewController()
+                let viewController = TicketRefundBankSelectionViewController(selectedBank: owner.viewModel.output.selectedBank.value)
 
                 viewController.selectedItem = { item in
-                    owner.selectRefundBankView.setData(with: item.bankName)
+                    guard let item else { return }
+                    owner.viewModel.input.selectedItem.accept(item)
                 }
                 owner.dimmedBackgroundView.isHidden = false
 
@@ -222,6 +223,14 @@ final class TicketRefundRequestViewController: BooltiViewController {
             .asDriver(onErrorDriveWith: .never())
             .drive(with: self) { owner, isValid in
                 owner.refundAccountNumberView.isValidTextTyped = isValid
+            }
+            .disposed(by: self.disposeBag)
+
+        self.viewModel.output.selectedBank
+            .asDriver(onErrorDriveWith: .never())
+            .drive(with: self) { owner, bankEntity in
+                guard let bankEntity else { return }
+                owner.selectRefundBankView.setData(with: bankEntity.bankName)
             }
             .disposed(by: self.disposeBag)
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -182,7 +182,6 @@ final class TicketRefundRequestViewController: BooltiViewController {
                 let viewController = TicketRefundBankSelectionViewController(selectedBank: owner.viewModel.output.selectedBank.value)
 
                 viewController.selectedItem = { item in
-                    guard let item else { return }
                     owner.viewModel.input.selectedItem.accept(item)
                 }
                 owner.dimmedBackgroundView.isHidden = false

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -237,13 +237,12 @@ final class TicketRefundRequestViewController: BooltiViewController {
         Observable.combineLatest(
             self.viewModel.output.isValidAccoundHolderName,
             self.viewModel.output.isValidAccoundHolderPhoneNumber,
-            self.viewModel.output.isValidrefundAccountNumber
+            self.viewModel.output.isValidrefundAccountNumber,
+            self.viewModel.output.selectedBank
         )
             .asDriver(onErrorDriveWith: .never())
-            .drive { [weak self] (isValidName, isValidPhoneNumber, isValidNumber) in
-                // bankNameLabel도 rx로 바꿔야함!.. 다른 로직으로 검증!..
-                let isBankSelected = self?.selectRefundBankView.bankNameLabel.text != "은행 선택"
-                self?.requestRefundButton.isEnabled = isValidName && isValidPhoneNumber && isValidNumber && isBankSelected
+            .drive { [weak self] (isValidName, isValidPhoneNumber, isValidNumber, selectedBank) in
+                self?.requestRefundButton.isEnabled = isValidName && isValidPhoneNumber && isValidNumber && (selectedBank != nil)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewModel.swift
@@ -95,7 +95,7 @@ final class TicketRefundRequestViewModel {
     }
 
     private func checkPhoneNumber(_ text: String) -> Bool {
-        guard text.hasPrefix("010") else { return false }
+        guard (text.count == 13) && (text.hasPrefix("010")) else { return  false }
         return true
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewModel.swift
@@ -14,6 +14,7 @@ final class TicketRefundRequestViewModel {
 
     struct Input {
         let viewWillAppearEvent = PublishRelay<Void>()
+        let selectedItem = PublishRelay<BankEntity>()
         let accoundHolderNameText = BehaviorRelay<String>(value: "")
         let accountHolderPhoneNumberText = BehaviorRelay<String>(value: "")
         let refundAccountNumberText = BehaviorRelay<String>(value: "")
@@ -22,6 +23,7 @@ final class TicketRefundRequestViewModel {
     struct Output {
         let tickerReservationDetail = PublishRelay<TicketReservationDetailEntity>()
         let isValidAccoundHolderName = PublishRelay<Bool>()
+        let selectedBank = BehaviorRelay<BankEntity?>(value: nil)
         let isValidAccoundHolderPhoneNumber = PublishRelay<Bool>()
         let isValidrefundAccountNumber = PublishRelay<Bool>()
     }
@@ -73,6 +75,12 @@ final class TicketRefundRequestViewModel {
             .map { self.checkAccountNumber($0)}
             .subscribe(with: self) { owner, isValid in
                 owner.output.isValidrefundAccountNumber.accept(isValid)
+            }
+            .disposed(by: self.disposeBag)
+
+        self.input.selectedItem
+            .subscribe(with: self) { owner, bankEntity in
+                owner.output.selectedBank.accept(bankEntity)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewModel.swift
@@ -22,9 +22,9 @@ final class TicketRefundRequestViewModel {
 
     struct Output {
         let tickerReservationDetail = PublishRelay<TicketReservationDetailEntity>()
-        let isValidAccoundHolderName = PublishRelay<Bool>()
+        let isAccoundHolderNameEmpty = PublishRelay<Bool>()
+        let isAccoundHolderPhoneNumberEmpty = PublishRelay<Bool>()
         let selectedBank = BehaviorRelay<BankEntity?>(value: nil)
-        let isValidAccoundHolderPhoneNumber = PublishRelay<Bool>()
         let isValidrefundAccountNumber = PublishRelay<Bool>()
     }
 
@@ -58,16 +58,14 @@ final class TicketRefundRequestViewModel {
             .disposed(by: self.disposeBag)
 
         self.input.accoundHolderNameText
-            .map { self.checkName($0) }
-            .subscribe(with: self) { owner, isValid in
-                owner.output.isValidAccoundHolderName.accept(isValid)
+            .subscribe(with: self) { owner, text in
+                owner.output.isAccoundHolderNameEmpty.accept(text.isEmpty)
             }
             .disposed(by: self.disposeBag)
 
         self.input.accountHolderPhoneNumberText
-            .map { self.checkPhoneNumber($0)}
-            .subscribe(with: self) { owner, isValid in
-                owner.output.isValidAccoundHolderPhoneNumber.accept(isValid)
+            .subscribe(with: self) { owner, text in
+                owner.output.isAccoundHolderPhoneNumberEmpty.accept(text.isEmpty)
             }
             .disposed(by: self.disposeBag)
 
@@ -89,19 +87,8 @@ final class TicketRefundRequestViewModel {
         return self.ticketReservationsRepository.ticketReservationDetail(with: self.reservationID)
     }
 
-    private func checkName(_ text: String) -> Bool {
-        let koreanPattern = "^[가-힣]*$"
-        return text.range(of: koreanPattern, options: .regularExpression) != nil
-    }
-
-    private func checkPhoneNumber(_ text: String) -> Bool {
-        guard (text.count == 13) && (text.hasPrefix("010")) else { return  false }
-        return true
-    }
-
     private func checkAccountNumber(_ text: String) -> Bool {
         let phoneNumberPattern = #"^\d{11,14}$"#
         return text.range(of: phoneNumberPattern, options: .regularExpression) != nil
     }
-
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/Views/RefundAccountNumberView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/Views/RefundAccountNumberView.swift
@@ -20,7 +20,7 @@ final class RefundAccountNumberView: UIView {
         let label = UILabel()
         label.font = .pretendardR(14)
         label.textColor = .error
-        label.text = "계좌번호를 올바르게 입력해 주세요"
+        label.text = "올바른 계좌번호를 입력해 주세요"
         label.isHidden = true
 
         return label

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -275,7 +275,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.totalPaymentAmountView.setData("\(entity.totalPaymentAmount)원")
         self.paymentStatusView.setData(entity.reservationStatus.description)
 
-        self.configureRefundButton(with: entity.reservationStatus)
+        self.configureRefundButton(with: entity)
 
         // 티켓 정보
         self.ticketTypeView.setData(entity.ticketType.rawValue)
@@ -315,12 +315,15 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.depositorPhoneNumberView.setData(entity.depositorPhoneNumber)
     }
 
-    private func configureRefundButton(with reservationStatus: ReservationStatus) {
-        switch reservationStatus {
+    private func configureRefundButton(with entity: TicketReservationDetailEntity) {
+        switch entity.reservationStatus {
         case .reservationCompleted:
-            self.requestRefundButton.isHidden = false
-            return
-        case .waitingForRefund, .refundCompleted, .cancelled, .waitingForDeposit:
+            if Date() <= entity.salesEndTime.formatToDate() {
+                self.requestRefundButton.isHidden = false
+            } else {
+                self.requestRefundButton.isHidden = true
+            }
+        default:
             self.requestRefundButton.isHidden = true
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -114,6 +114,11 @@ final class TicketReservationDetailViewController: BooltiViewController {
         return button
     }()
 
+    private let blankSpaceView: UIView = {
+        let view = UIView()
+        return view
+    }()
+
     init(
         ticketRefundReasonlViewControllerFactory: @escaping (ReservationID) -> TicketRefundReasonViewController,
         viewModel: TicketReservationDetailViewModel
@@ -189,6 +194,10 @@ final class TicketReservationDetailViewController: BooltiViewController {
             make.width.equalTo(screenWidth-40)
         }
 
+        self.blankSpaceView.snp.makeConstraints { make in
+            make.height.equalTo(40)
+        }
+
         self.addArrangedSubViews()
     }
 
@@ -202,10 +211,9 @@ final class TicketReservationDetailViewController: BooltiViewController {
             self.purchaserInformationStackView,
             self.depositorInformationStackView,
             self.reversalPolicyView,
-            self.requestRefundButton
+            self.requestRefundButton,
+            self.blankSpaceView
         ])
-
-        self.contentStackView.setCustomSpacing(40, after: self.reversalPolicyView)
     }
 
     private func bindUIComponents() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -213,7 +213,6 @@ final class TicketReservationDetailViewController: BooltiViewController {
             self.requestRefundButton,
         ])
 
-        self.contentStackView.setCustomSpacing(0, after: self.concertInformationView)
         self.contentStackView.setCustomSpacing(0, after: self.reversalPolicyView)
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -30,7 +30,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         return scrollView
     }()
 
-    private lazy var contentStackView: UIStackView = {
+    private let  contentStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.distribution = .fill

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -36,8 +36,6 @@ final class TicketReservationDetailViewController: BooltiViewController {
         stackView.distribution = .fill
         stackView.alignment = .center
         stackView.spacing = 12
-        
-        stackView.setCustomSpacing(0, after: self.concertInformationView)
 
         return stackView
     }()
@@ -195,7 +193,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         }
 
         self.blankSpaceView.snp.makeConstraints { make in
-            make.height.equalTo(40)
+            make.height.equalTo(48)
         }
 
         self.addArrangedSubViews()
@@ -211,9 +209,12 @@ final class TicketReservationDetailViewController: BooltiViewController {
             self.purchaserInformationStackView,
             self.depositorInformationStackView,
             self.reversalPolicyView,
+            self.blankSpaceView,
             self.requestRefundButton,
-            self.blankSpaceView
         ])
+
+        self.contentStackView.setCustomSpacing(0, after: self.concertInformationView)
+        self.contentStackView.setCustomSpacing(0, after: self.reversalPolicyView)
     }
 
     private func bindUIComponents() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/Views/ConcertInformationView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/Views/ConcertInformationView.swift
@@ -24,8 +24,7 @@ final class ConcertInformationView: UIView {
         let label = BooltiUILabel()
         label.font = .aggroB(20)
         label.textColor = .grey05
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 2
+        label.numberOfLines = 3
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailInformationView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailInformationView.swift
@@ -13,7 +13,6 @@ final class TicketDetailInformationView: UIView {
         let label = BooltiUILabel()
         label.textColor = .grey10
         label.font = .aggroB(20)
-        label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 4
 
         return label
@@ -52,6 +51,7 @@ final class TicketDetailInformationView: UIView {
         let label = BooltiUILabel()
         label.textColor = .grey30
         label.font = .body2
+        label.numberOfLines = 1
 
         return label
     }()
@@ -73,7 +73,7 @@ final class TicketDetailInformationView: UIView {
 
     private let dimmedView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.init("#000000").withAlphaComponent(0.8)
+        view.backgroundColor = .black100.withAlphaComponent(0.8)
         view.isHidden = true
 
         return view
@@ -94,7 +94,6 @@ final class TicketDetailInformationView: UIView {
         self.locationLabel.text = " | \(item.location)"
         self.titleLabel.text = item.title
         self.qrCodeImageView.image = item.qrCode
-        self.titleLabel.setLineSpacing(lineSpacing: 4)
         self.configureGradient()
         self.configureStamp(with: item)
     }
@@ -143,7 +142,7 @@ final class TicketDetailInformationView: UIView {
         let bounds = CGRect(x: 1, y: 0, width: self.bounds.width-2, height: self.bounds.height)
         
         gradientLayer.frame = bounds
-        gradientLayer.colors = [UIColor.init("#000000").withAlphaComponent(0.0).cgColor, UIColor.init("#000000").withAlphaComponent(0.7).cgColor]
+        gradientLayer.colors = [UIColor.black100.withAlphaComponent(0.0).cgColor, UIColor.black100.withAlphaComponent(0.7).cgColor]
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
         gradientLayer.locations = [0.0, 1.0]

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
@@ -184,6 +184,11 @@ final class TicketDetailView: UIView {
 
     private func configureConstraints() {
 
+        guard let window = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return
+        }
+        let screenHeight = window.screen.bounds.height
+
         self.snp.makeConstraints { make in
             make.height.equalTo(1000)
         }
@@ -195,7 +200,7 @@ final class TicketDetailView: UIView {
 
         self.posterImageView.snp.makeConstraints { make in
             make.top.equalTo(self.upperTagView.snp.bottom).offset(20)
-            make.height.equalTo(400)
+            make.height.equalTo(screenHeight * 0.44)
             make.horizontalEdges.equalToSuperview().inset(20)
         }
 
@@ -221,7 +226,7 @@ final class TicketDetailView: UIView {
         self.backgroundImageView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(569)
+            make.height.equalTo(screenHeight * 0.44 + 169)
         }
 
         self.rightCircleView.snp.makeConstraints { make in
@@ -302,8 +307,8 @@ final class TicketDetailView: UIView {
 
         let path = CGMutablePath()
 
-        path.move(to: CGPoint(x: 20, y: 475))
-        path.addLine(to: CGPoint(x: self.bounds.width-20, y: 475))
+        path.move(to: CGPoint(x: 20, y: self.leftCircleView.frame.midY))
+        path.addLine(to: CGPoint(x: self.bounds.width-20, y: self.leftCircleView.frame.midY))
 
         let shapeLayer = CAShapeLayer()
         shapeLayer.path = path

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
@@ -150,6 +150,7 @@ final class TicketDetailView: UIView {
         self.configureBackGroundBlurViewEffect()
         self.configureCircleViews()
         self.configureSeperateLine()
+        self.configureCornerGradient()
         self.updateHeight()
     }
 
@@ -279,6 +280,17 @@ final class TicketDetailView: UIView {
         gradientLayer.frame = self.backgroundImageView.bounds
         self.backgroundImageView.layer.addSublayer(gradientLayer)
         self.backgroundImageView.bringSubviewToFront(self.upperTagView)
+    }
+
+    private func configureCornerGradient() {
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: 105, height: 105)
+        gradientLayer.colors = [UIColor.white00.withAlphaComponent(0.6).cgColor, UIColor.white00.withAlphaComponent(0.0).cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 0.5)
+        gradientLayer.locations = [0.0, 1.0]
+
+        self.layer.addSublayer(gradientLayer)
     }
 
     private func configureCircleViews() {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
@@ -22,7 +22,6 @@ final class TicketNoticeView: UIView {
         let label = BooltiUILabel()
         label.font = .body1
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
         label.textColor = .grey50
 
         return label
@@ -58,7 +57,6 @@ final class TicketNoticeView: UIView {
 
     func setData(with text: String) {
         self.noticeLabel.text = text
-        self.noticeLabel.setLineSpacing(lineSpacing: 6)
         self.layoutIfNeeded()
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/Views/EntryCodeInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/Views/EntryCodeInputView.swift
@@ -35,8 +35,7 @@ final class EntryCodeInputView: UIView {
         label.text = "입장 코드는 주최자 계정의 마이 > QR 스캔 >\n해당 공연 스캐너에서 확인 가능해요"
         label.numberOfLines = 0
         label.textColor = .grey50
-        label.setLineSpacing(lineSpacing: 5)
-        label.textAlignment = .center
+        label.setAlignCenter()
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -191,14 +191,14 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         }
 
         self.ticketInformationView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview().inset(self.bounds.width * 0.053)
-            make.bottom.equalToSuperview().inset(self.bounds.height * 0.038)
+            make.horizontalEdges.equalToSuperview().inset(self.bounds.width * 0.06)
+            make.bottom.equalToSuperview().inset(self.bounds.height * 0.05)
         }
 
         self.posterImageView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview().inset(self.bounds.width * 0.053)
-            make.top.equalTo(self.upperTagView.snp.bottom).offset(self.bounds.height * 0.038)
-            make.height.equalTo(self.posterImageView.snp.width).multipliedBy(1.4)
+            make.horizontalEdges.equalToSuperview().inset(self.bounds.width * 0.06)
+            make.top.equalTo(self.upperTagView.snp.bottom).offset(self.bounds.height * 0.04)
+            make.height.equalToSuperview().multipliedBy(0.65)
         }
 
         self.upperTagLabelStackView.snp.makeConstraints { make in
@@ -213,20 +213,20 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
 
         self.rightCircleView.snp.makeConstraints { make in
             make.width.height.equalTo(self.bounds.height * 0.035)
-            make.centerY.equalTo(self.snp.top).offset(self.bounds.height * 0.813)
+            make.centerY.equalTo(self.snp.top).offset(self.bounds.height * 0.79)
             make.centerX.equalTo(self.snp.right)
         }
 
         self.leftCircleView.snp.makeConstraints { make in
             make.width.height.equalTo(self.bounds.height * 0.035)
-            make.centerY.equalTo(self.snp.top).offset(self.bounds.height *  0.813)
+            make.centerY.equalTo(self.snp.top).offset(self.bounds.height *  0.79)
             make.centerX.equalTo(self.snp.left)
         }
     }
 
         private func configureSeperateLine() {
             let path = CGMutablePath()
-            let height = self.bounds.height * 0.813
+            let height = self.bounds.height * 0.79
             let width = self.bounds.width * 0.053
 
             path.move(to: CGPoint(x: width, y: height))

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -129,6 +129,7 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         self.configureConstraints()
         self.configureBorder()
         self.configureSeperateLine()
+        self.configureCornerGradient()
     }
 
     func setData(with item: TicketItemEntity) {
@@ -138,6 +139,17 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         self.numberLabel.text = " ・ 1매"
         self.ticketTypeLabel.text = item.ticketName
         self.ticketInformationView.setData(with: item)
+    }
+
+    private func configureCornerGradient() {
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: 105, height: 105)
+        gradientLayer.colors = [UIColor.white00.withAlphaComponent(0.6).cgColor, UIColor.white00.withAlphaComponent(0.0).cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 0.5)
+        gradientLayer.locations = [0.0, 1.0]
+
+        self.layer.addSublayer(gradientLayer)
     }
 
     private func configureBorder() {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -138,7 +138,7 @@ final class TicketListViewController: BooltiViewController {
                 trailing: 6
             )
 
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalWidth(1.68))
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalWidth(1.61))
 
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
@@ -159,6 +159,7 @@ final class TicketListViewController: BooltiViewController {
             let section = NSCollectionLayoutSection(group: group)
             section.boundarySupplementaryItems = [footer]
             section.orthogonalScrollingBehavior = .groupPagingCentered
+            section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 10, trailing: 0)
 
             self.configureCollectionViewCarousel(of: section)
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Views/TicketInformationView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Views/TicketInformationView.swift
@@ -1,19 +1,18 @@
-////
-////  TicketInformationView.swift
-////  Boolti
-////
-////  Created by Miro on 1/30/24.
-////
+//
+//  TicketInformationView.swift
+//  Boolti
+//
+//  Created by Miro on 1/30/24.
+//
 
 import UIKit
 
 final class TicketInformationView: UIView {
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey10
         label.font = .aggroB(20)
-        label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 2
 
         return label
@@ -40,18 +39,19 @@ final class TicketInformationView: UIView {
         return stackView
     }()
 
-    private let dateLabel: UILabel = {
-        let label = UILabel()
+    private let dateLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey30
         label.font = .body2
 
         return label
     }()
 
-    private let locationLabel: UILabel = {
-        let label = UILabel()
+    private let locationLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey30
         label.font = .body2
+        label.numberOfLines = 1
 
         return label
     }()
@@ -93,7 +93,6 @@ final class TicketInformationView: UIView {
         self.locationLabel.text = " | \(item.location)"
         self.titleLabel.text = item.title
         self.qrCodeImageView.image = item.qrCode
-        self.titleLabel.setLineSpacing(lineSpacing: 4)
         self.configureStamp(with: item.ticketStatus)
     }
     
@@ -123,11 +122,11 @@ final class TicketInformationView: UIView {
         self.qrCodeImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.right.equalToSuperview()
-            make.width.height.equalTo(70)
+            make.size.equalTo(70)
         }
 
         self.dimmedView.snp.makeConstraints { make in
-            make.width.height.equalTo(70)
+            make.size.equalTo(70)
             make.center.equalTo(self.qrCodeImageView)
         }
 

--- a/Boolti/Boolti/Sources/UILayer/Update/UpdatePopupViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Update/UpdatePopupViewController.swift
@@ -26,8 +26,8 @@ final class UpdatePopupViewController: UIViewController {
         return view
     }()
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey15
         label.text = "업데이트 알림"
@@ -35,14 +35,13 @@ final class UpdatePopupViewController: UIViewController {
         return label
     }()
     
-    private let subTitleLabel: UILabel = {
-        let label = UILabel()
+    private let subTitleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey50
         label.font = .body1
         label.numberOfLines = 2
         label.text = "지금 업데이트하고\n더 편리해진 불티를 만나보세요"
-        label.setLineSpacing(lineSpacing: 4)
-        label.textAlignment = .center
+        label.setAlignCenter()
         
         return label
     }()
@@ -99,14 +98,13 @@ extension UpdatePopupViewController {
         }
         
         self.titleLabel.snp.makeConstraints { make in
-            make.height.equalTo(26)
             make.centerX.equalTo(self.popupBackgroundView)
             make.top.equalTo(self.popupBackgroundView).offset(32)
         }
         
         self.subTitleLabel.snp.makeConstraints { make in
             make.centerX.equalTo(self.popupBackgroundView)
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(8)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(4)
         }
         
         self.updateButton.snp.makeConstraints { make in


### PR DESCRIPTION
## 작업한 내용
- 티켓 디테일 UI를 수정했어요.(Design QA에 나와있는 내용을 수정했어요!)
- 환불 하기 쪽 로직을 수정했어요.
  - 은행을 선택하고 돌아온 다음 다시 선택할 때 이전의 선택 사항을 유지할 수 있게 구현했어요.
  - 환불 계좌 유효성 검증 로직 변경 및 환불 계좌 확인 뷰의 UI를 수정했어요.

(중간에 Develop을 머지했는데, 변경된 파일이 현재 develop 이전 버전과 비교해서 체킹을 하는 거 같아요!.. 그래서 변경된 파일 보기 쫌 힘들 거 같은데.. 혹시 문제가 있으면 알려주시면 바로 달려가겠씁니다!!..)

## 스크린샷
|TicketDetail |TicketReservation |
| --- | --- |
|<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/7d36d826-d87f-4cba-84cb-840932083a36" width="250"/>|<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/f3d35075-0271-4659-929e-4743c9feb12b" width="250"/>|

## 관련 이슈
- Resolved: #143 
