### PR TITLE
Feature/#153 푸시 노티피케이션

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -279,6 +279,9 @@
 		878AF4692B60EC3A00C8838C /* ASAuthorizationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */; };
 		87A3716D2B76497B0061814E /* TicketReservationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */; };
 		87A3716F2B76534B0061814E /* TicketReservationItemEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */; };
+		87CE4F6A2B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */; };
+		87CE4F6C2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */; };
+		87CE4F6F2B8DDA59007A0C8F /* PushNotificationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */; };
 		87D2FAB22B6E96D20027FBE1 /* TicketDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FAB12B6E96D20027FBE1 /* TicketDetailViewController.swift */; };
 		87D2FAB42B6E977C0027FBE1 /* TicketDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FAB32B6E977C0027FBE1 /* TicketDetailDIContainer.swift */; };
 		87D2FAB62B6E97870027FBE1 /* TicketDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FAB52B6E97870027FBE1 /* TicketDetailViewModel.swift */; };
@@ -542,6 +545,9 @@
 		878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASAuthorizationController+Rx.swift"; sourceTree = "<group>"; };
 		87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationsTableViewCell.swift; sourceTree = "<group>"; };
 		87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationItemEntity.swift; sourceTree = "<group>"; };
+		87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterRequestDTO.swift; sourceTree = "<group>"; };
+		87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterResponseDTO.swift; sourceTree = "<group>"; };
+		87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationAPI.swift; sourceTree = "<group>"; };
 		87D2FAB12B6E96D20027FBE1 /* TicketDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailViewController.swift; sourceTree = "<group>"; };
 		87D2FAB32B6E977C0027FBE1 /* TicketDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailDIContainer.swift; sourceTree = "<group>"; };
 		87D2FAB52B6E97870027FBE1 /* TicketDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailViewModel.swift; sourceTree = "<group>"; };
@@ -875,6 +881,7 @@
 		84781C792B5BEBDA00D37921 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				87CE4F662B8DD93A007A0C8F /* PushNotification */,
 				84781C7A2B5BEBE500D37921 /* Auth */,
 				84DC6F632B728792001F9576 /* Concert */,
 				870099AA2B7742DC001779FB /* Ticket */,
@@ -924,6 +931,7 @@
 				8753CA722B71EA68002871C7 /* TicketAPI.swift */,
 				870099B42B77476E001779FB /* TicketReservationAPI.swift */,
 				846F5F392B7BBEC4000F86AE /* QRAPI.swift */,
+				87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */,
 			);
 			path = APIs;
 			sourceTree = "<group>";
@@ -1637,6 +1645,31 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		87CE4F662B8DD93A007A0C8F /* PushNotification */ = {
+			isa = PBXGroup;
+			children = (
+				87CE4F682B8DD950007A0C8F /* Response */,
+				87CE4F672B8DD946007A0C8F /* Request */,
+			);
+			path = PushNotification;
+			sourceTree = "<group>";
+		};
+		87CE4F672B8DD946007A0C8F /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		87CE4F682B8DD950007A0C8F /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
 		87D2FAB02B6E96BE0027FBE1 /* TicketDetail */ = {
 			isa = PBXGroup;
 			children = (
@@ -1871,6 +1904,7 @@
 				876BF16C2B6A43BB00DB4BCB /* TokenRefreshRequestDTO.swift in Sources */,
 				846F5F3C2B7BBF18000F86AE /* QRRepositoryType.swift in Sources */,
 				8746AD142B680A5C0037A1B1 /* TicketTypeTableViewCell.swift in Sources */,
+				87CE4F6C2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift in Sources */,
 				84FBBDFB2B675834009462E9 /* UIStackView+.swift in Sources */,
 				87D2FAB22B6E96D20027FBE1 /* TicketDetailViewController.swift in Sources */,
 				84781CAD2B5BF7A200D37921 /* HomeTabBarDIContainer.swift in Sources */,
@@ -1948,6 +1982,7 @@
 				876E41572B5F972A006BEEB7 /* LoginResponseDTO.swift in Sources */,
 				870099BE2B7767E7001779FB /* EmptyReservationsView.swift in Sources */,
 				8710D9542B74FAB500309FBF /* LogoutViewController.swift in Sources */,
+				87CE4F6F2B8DDA59007A0C8F /* PushNotificationAPI.swift in Sources */,
 				872605462B7932BD005CD0D4 /* TicketReservationDetailViewModel.swift in Sources */,
 				84781CC52B5BF9DE00D37921 /* TicketListViewController.swift in Sources */,
 				876BF16E2B6A45AD00DB4BCB /* TokenRefreshResponseDTO.swift in Sources */,
@@ -1958,6 +1993,7 @@
 				84A713452B7C83AE000BABCB /* QRMaker.swift in Sources */,
 				8710D94E2B74FA8B00309FBF /* TicketReservationsViewModel.swift in Sources */,
 				84781CA62B5BF6F500D37921 /* SplashDIContainer.swift in Sources */,
+				87CE4F6A2B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift in Sources */,
 				8757BA972B5FA6B0008503B5 /* AuthRepository.swift in Sources */,
 				84625A182B63E05700CC9077 /* BooltiPaddingLabel.swift in Sources */,
 				84A713392B7BD504000BABCB /* QRScanRequestDTO.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -282,6 +282,8 @@
 		87CE4F6A2B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */; };
 		87CE4F6C2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */; };
 		87CE4F6F2B8DDA59007A0C8F /* PushNotificationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */; };
+		87CE4F712B8DF7CE007A0C8F /* PushNotificationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F702B8DF7CE007A0C8F /* PushNotificationRepository.swift */; };
+		87CE4F732B8DF888007A0C8F /* PushNotificationRepositoryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F722B8DF888007A0C8F /* PushNotificationRepositoryType.swift */; };
 		87D2FAB22B6E96D20027FBE1 /* TicketDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FAB12B6E96D20027FBE1 /* TicketDetailViewController.swift */; };
 		87D2FAB42B6E977C0027FBE1 /* TicketDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FAB32B6E977C0027FBE1 /* TicketDetailDIContainer.swift */; };
 		87D2FAB62B6E97870027FBE1 /* TicketDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D2FAB52B6E97870027FBE1 /* TicketDetailViewModel.swift */; };
@@ -548,6 +550,8 @@
 		87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterRequestDTO.swift; sourceTree = "<group>"; };
 		87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterResponseDTO.swift; sourceTree = "<group>"; };
 		87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationAPI.swift; sourceTree = "<group>"; };
+		87CE4F702B8DF7CE007A0C8F /* PushNotificationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRepository.swift; sourceTree = "<group>"; };
+		87CE4F722B8DF888007A0C8F /* PushNotificationRepositoryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRepositoryType.swift; sourceTree = "<group>"; };
 		87D2FAB12B6E96D20027FBE1 /* TicketDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailViewController.swift; sourceTree = "<group>"; };
 		87D2FAB32B6E977C0027FBE1 /* TicketDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailDIContainer.swift; sourceTree = "<group>"; };
 		87D2FAB52B6E97870027FBE1 /* TicketDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketDetailViewModel.swift; sourceTree = "<group>"; };
@@ -643,6 +647,7 @@
 				84360F702B6BF70E009510D9 /* Auth */,
 				841D77D32B73B1B00068B1C5 /* ConcertRepository.swift */,
 				870099B62B77489A001779FB /* TicketReservationsRepository.swift */,
+				87CE4F702B8DF7CE007A0C8F /* PushNotificationRepository.swift */,
 				846F5F3D2B7BBF60000F86AE /* QRRepository.swift */,
 			);
 			path = Repositories;
@@ -655,6 +660,7 @@
 				841D77D52B73B3210068B1C5 /* ConcertRepositoryType.swift */,
 				84E48AC22B7E53A000F8BFD0 /* TicketReservationsRepositoryType.swift */,
 				846F5F3B2B7BBF18000F86AE /* QRRepositoryType.swift */,
+				87CE4F722B8DF888007A0C8F /* PushNotificationRepositoryType.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1911,6 +1917,7 @@
 				840B39632B78CEF700E7F8C8 /* ConcertListResponseDTO.swift in Sources */,
 				8726054B2B793BCF005CD0D4 /* ReservationHorizontalStackView.swift in Sources */,
 				84781C752B5BEB5600D37921 /* UserDefault.swift in Sources */,
+				87CE4F732B8DF888007A0C8F /* PushNotificationRepositoryType.swift in Sources */,
 				8710D9402B74E44400309FBF /* MypageContentView.swift in Sources */,
 				84781CAA2B5BF72200D37921 /* SplashViewModel.swift in Sources */,
 				84FEF6192B68ACDD00EBB64F /* salesTicketingEntity.swift in Sources */,
@@ -1963,6 +1970,7 @@
 				846F5F3E2B7BBF60000F86AE /* QRRepository.swift in Sources */,
 				8757BAA62B5FDED7008503B5 /* OAuthRepository.swift in Sources */,
 				848CBF0A2B65481500239303 /* TicketingDetailDIContainer.swift in Sources */,
+				87CE4F712B8DF7CE007A0C8F /* PushNotificationRepository.swift in Sources */,
 				8753CA732B71EA68002871C7 /* TicketAPI.swift in Sources */,
 				8726054F2B79FD49005CD0D4 /* TicketReservationDetailRequestDTO.swift in Sources */,
 				840B39612B78CE6300E7F8C8 /* ConcertListRequestDTO.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -223,7 +223,6 @@
 		8730F0242B7B664600D4F339 /* TicketRefundBankCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730F0232B7B664600D4F339 /* TicketRefundBankCollectionViewCell.swift */; };
 		8730F02C2B7B704200D4F339 /* BankEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730F02B2B7B704200D4F339 /* BankEntity.swift */; };
 		8730F02E2B7BAA2B00D4F339 /* RefundAccountNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730F02D2B7BAA2B00D4F339 /* RefundAccountNumberView.swift */; };
-		8746AD012B67F7610037A1B1 /* TicketInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746AD002B67F7610037A1B1 /* TicketInformationView.swift */; };
 		8746AD102B680A290037A1B1 /* SelectedTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746AD0F2B680A290037A1B1 /* SelectedTicketView.swift */; };
 		8746AD122B680A3E0037A1B1 /* TicketTypeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746AD112B680A3E0037A1B1 /* TicketTypeView.swift */; };
 		8746AD142B680A5C0037A1B1 /* TicketTypeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746AD132B680A5C0037A1B1 /* TicketTypeTableViewCell.swift */; };
@@ -252,6 +251,7 @@
 		8757BAB02B60069B008503B5 /* OAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757BAAF2B60069B008503B5 /* OAuthResponse.swift */; };
 		8757BAB62B6009B5008503B5 /* SignUpRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757BAB52B6009B5008503B5 /* SignUpRequestDTO.swift */; };
 		8757BAB82B600B1B008503B5 /* SignUpResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757BAB72B600B1B008503B5 /* SignUpResponseDTO.swift */; };
+		87617F6D2B8ECC3500828C69 /* TicketInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746AD002B67F7610037A1B1 /* TicketInformationView.swift */; };
 		876667542B73A82300DDB2B5 /* EntryCodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876667532B73A82300DDB2B5 /* EntryCodeInputView.swift */; };
 		8766B5592B641266004F266A /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = 8766B5582B641266004F266A /* Differentiator */; };
 		8766B55B2B641266004F266A /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = 8766B55A2B641266004F266A /* RxDataSources */; };
@@ -1809,6 +1809,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				87617F6D2B8ECC3500828C69 /* TicketInformationView.swift in Sources */,
 				84A024892B7B98710095A56E /* SelectedTicketEntity.swift in Sources */,
 				845F25442B89FA3800F6C328 /* PosterExpandDIContainer.swift in Sources */,
 				841D77DF2B7463020068B1C5 /* TicketListCollectionViewCell.swift in Sources */,
@@ -2009,9 +2010,7 @@
 				84781BE82B5BE17400D37921 /* Enviroment.swift in Sources */,
 				84DF59DC2B722EA0000816DA /* UpdatePopupDIContainer.swift in Sources */,
 				84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */,
-				8746AD012B67F7610037A1B1 /* TicketInformationView.swift in Sources */,
 				8730F0162B7B29EC00D4F339 /* TicketRefundRequestViewController.swift in Sources */,
-				8746AD012B67F7610037A1B1 /* TicketInformationView.swift in Sources */,
 				84625A0B2B63B2AE00CC9077 /* TicketSelectionViewModel.swift in Sources */,
 				870099B52B77476E001779FB /* TicketReservationAPI.swift in Sources */,
 				841D77D22B73B0C10068B1C5 /* ConcertAPI.swift in Sources */,

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -82,9 +82,9 @@ extension AppDelegate: MessagingDelegate {
 
         Messaging.messaging().subscribe(toTopic: defaultTopic) { error in
             if let error {
-                print(error)
+                debugPrint(error)
             } else {
-                print("구독을 완료했습니다.")
+                debugPrint("구독을 완료했습니다.")
             }
         }
     }
@@ -102,6 +102,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let messageTitle = response.notification.request.content.title
         let messageBody = response.notification.request.content.body
 
+        if let keyWindow = UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first?.windows.first {
+            if let rootViewController = keyWindow.rootViewController as? RootViewController {
+                if let homeTabBarViewController = rootViewController.presentedViewController as? HomeTabBarController {
+                    homeTabBarViewController.selectedIndex = 0
+                }
+            }
+        }
         completionHandler()
     }
 

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -58,9 +58,10 @@ extension AppDelegate: MessagingDelegate {
     
     /// 토큰 갱신 모니터링 & 토큰 가져오기
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-
+        guard let fcmToken else { return }
+        UserDefaults.deviceToken = fcmToken
         // TODO: device token 등록 서버 api 연결 or 회원가입 시 넣기
-        debugPrint(fcmToken ?? "")
+        debugPrint(fcmToken)
     }
 }
 

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -27,20 +27,37 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             completionHandler: { _, _ in }
         )
         application.registerForRemoteNotifications()
-        
+
         /// 메시지 대리자 설정
         Messaging.messaging().delegate = self
-        
+
         /// 자동 초기화 방지
         Messaging.messaging().isAutoInitEnabled = true
-        
+
         return true
     }
-    
+
     /// fcm에 device token 등록
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
+
+        /// 주제 구독
+        let defaultTopic: String
+
+        #if DEBUG
+        defaultTopic = "dev"
+        #elseif RELEASE
+        defaultTopic = "prod"
+        #endif
+
+        Messaging.messaging().subscribe(toTopic: defaultTopic) { error in
+            if let error {
+                print(error)
+            } else {
+                print("구독을 완료했습니다.")
+            }
+        }
     }
 
     // MARK: UISceneSession Lifecycle
@@ -55,7 +72,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - MessagingDelegate
 
 extension AppDelegate: MessagingDelegate {
-    
+
     /// 토큰 갱신 모니터링 & 토큰 가져오기
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let fcmToken else { return }
@@ -68,7 +85,7 @@ extension AppDelegate: MessagingDelegate {
 // MARK: - UNUserNotificationCenterDelegate
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    
+
     /// 푸시 클릭시
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
@@ -76,7 +93,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         let messageTitle = response.notification.request.content.title
         let messageBody = response.notification.request.content.body
-            
+
         completionHandler()
     }
 

--- a/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
@@ -12,6 +12,5 @@ enum UserDefaultsKey: String, CaseIterable {
     case userImageURLPath
     case accessToken
     case refreshToken
-    case deviceToken
     case isFirstLaunch
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -27,10 +27,7 @@ extension UserDefaults {
     
     @UserDefault<String>(key: UserDefaultsKey.refreshToken.rawValue, defaultValue: "")
     static var refreshToken
-    
-    @UserDefault<String>(key: UserDefaultsKey.deviceToken.rawValue, defaultValue: "")
-    static var deviceToken
-    
+
     @UserDefault<Bool>(key: UserDefaultsKey.isFirstLaunch.rawValue, defaultValue: true)
     static var isFirstLaunch
     
@@ -39,7 +36,6 @@ extension UserDefaults {
     static func removeAllUserInfo() {
         UserDefaults.accessToken = ""
         UserDefaults.refreshToken = ""
-        UserDefaults.deviceToken = ""
         UserDefaults.userId = -1
         UserDefaults.userName = ""
         UserDefaults.userEmail = ""

--- a/Boolti/Boolti/Sources/Network/APIs/PushNotificationAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/PushNotificationAPI.swift
@@ -34,7 +34,7 @@ extension PushNotificationAPI: ServiceAPI {
                 "deviceToken": DTO.deviceToken,
                 "deviceType": DTO.deviceType
             ]
-            return .requestParameters(parameters: query, encoding: URLEncoding.queryString)
+            return .requestParameters(parameters: query, encoding: JSONEncoding.prettyPrinted)
         }
     }
 }

--- a/Boolti/Boolti/Sources/Network/APIs/PushNotificationAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/PushNotificationAPI.swift
@@ -30,11 +30,7 @@ extension PushNotificationAPI: ServiceAPI {
     var task: Moya.Task {
         switch self {
         case .register(let DTO):
-            let query: [String: Any] = [
-                "deviceToken": DTO.deviceToken,
-                "deviceType": DTO.deviceType
-            ]
-            return .requestParameters(parameters: query, encoding: JSONEncoding.prettyPrinted)
+            return .requestJSONEncodable(DTO)
         }
     }
 }

--- a/Boolti/Boolti/Sources/Network/APIs/PushNotificationAPI.swift
+++ b/Boolti/Boolti/Sources/Network/APIs/PushNotificationAPI.swift
@@ -1,0 +1,40 @@
+//
+//  PushNotificationAPI.swift
+//  Boolti
+//
+//  Created by Miro on 2/27/24.
+//
+
+import Foundation
+
+import Moya
+
+enum PushNotificationAPI {
+
+    case register(requestDTO: DeviceTokenRegisterRequestDTO)
+}
+
+extension PushNotificationAPI: ServiceAPI {
+
+    var path: String {
+        switch self {
+        case .register:
+            return "/papi/v1/device-token"
+        }
+    }
+
+    var method: Moya.Method {
+        return .post
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .register(let DTO):
+            let query: [String: Any] = [
+                "deviceToken": DTO.deviceToken,
+                "deviceType": DTO.deviceType
+            ]
+            return .requestParameters(parameters: query, encoding: URLEncoding.queryString)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/Network/DTO/PushNotification/Request/DeviceTokenRegisterRequestDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/PushNotification/Request/DeviceTokenRegisterRequestDTO.swift
@@ -1,0 +1,14 @@
+//
+//  DeviceTokenRegisterRequestDTO.swift
+//  Boolti
+//
+//  Created by Miro on 2/27/24.
+//
+
+import Foundation
+
+struct DeviceTokenRegisterRequestDTO: Encodable {
+
+    let deviceToken: String
+    let deviceType: String = "IOS"
+}

--- a/Boolti/Boolti/Sources/Network/DTO/PushNotification/Response/DeviceTokenRegisterResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/PushNotification/Response/DeviceTokenRegisterResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  DeviceTokenRegisterResponseDTO.swift
+//  Boolti
+//
+//  Created by Miro on 2/27/24.
+//
+
+import Foundation
+
+struct DeviceTokenRegisterResponseDTO: Decodable {
+
+    let tokenId: String
+}

--- a/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
@@ -38,15 +38,19 @@ final class AuthRepository: AuthRepositoryType {
         return networkService.request(api)
             .map(LoginResponseDTO.self)
             .do { [weak self] loginReponseDTO in
+                guard let self = self else { return }
                 guard let accessToken = loginReponseDTO.accessToken,
                       let refreshToken = loginReponseDTO.refreshToken else { return }
                 UserDefaults.accessToken = accessToken
                 UserDefaults.refreshToken = refreshToken
 
-                self?.userInfo()
-                
+                self.userInfo().subscribe(onSuccess: { _ in
+                    debugPrint("UserAPI Success")
+                })
+                .disposed(by: self.disposeBag)
+
                 if provider == .kakao {
-                    self?.setKakaoUserInformation()
+                    self.setKakaoUserInformation()
                 }
             }
             .map { $0.signUpRequired }
@@ -67,7 +71,7 @@ final class AuthRepository: AuthRepositoryType {
             .disposed(by: self.disposeBag)
     }
 
-    func signUp(provider: OAuthProvider, identityToken: String?) {
+    func signUp(provider: OAuthProvider, identityToken: String?) -> Single<Void> {
         switch provider {
         case .kakao:
             self.signUpKakao()
@@ -76,9 +80,9 @@ final class AuthRepository: AuthRepositoryType {
         }
     }
 
-    private func signUpKakao() {
+    private func signUpKakao() -> Single<Void> {
         UserApi.shared.rx.me()
-            .subscribe(with: self, onSuccess: { owner, user in
+            .flatMap { user in
                 let email = user.kakaoAccount?.email ?? ""
                 let phoneNumber = user.kakaoAccount?.phoneNumber ?? ""
                 let nickName = user.kakaoAccount?.profile?.nickname ?? ""
@@ -95,15 +99,14 @@ final class AuthRepository: AuthRepositoryType {
                 )
 
                 let API = AuthAPI.signup(requestDTO: requestDTO)
-                owner.requestSignUp(API)
-            })
-            .disposed(by: self.disposeBag)
+                return self.requestSignUp(API)
+            }
     }
 
-    private func signUpApple(with identityToken: String?) {
-        guard let identityToken else { return }
+    private func signUpApple(with identityToken: String?) -> Single<Void> {
+        guard let identityToken else { return .just(())}
 
-        guard let jwt = try? JWT<IdentityTokenDTO>(jwtString: identityToken) else { return }
+        guard let jwt = try? JWT<IdentityTokenDTO>(jwtString: identityToken) else { return .just(()) }
         let oauthIdentity = jwt.claims.sub
 
         let requestDTO = SignUpRequestDTO(
@@ -116,22 +119,21 @@ final class AuthRepository: AuthRepositoryType {
         )
         let API = AuthAPI.signup(requestDTO: requestDTO)
 
-        self.requestSignUp(API)
+        return self.requestSignUp(API)
     }
 
-    private func requestSignUp(_ API: AuthAPI) {
-        self.networkService.request(API)
+    private func requestSignUp(_ API: AuthAPI) -> Single<Void> {
+        return self.networkService.request(API)
             .map(SignUpResponseDTO.self)
-            .subscribe { signUpResponseDTO in
+            .flatMap({ signUpResponseDTO in
                 guard let accessToken = signUpResponseDTO.accessToken,
-                      let refreshToken = signUpResponseDTO.refreshToken else { return }
-                
+                      let refreshToken = signUpResponseDTO.refreshToken else { return .just(())}
+
                 UserDefaults.accessToken = accessToken
                 UserDefaults.refreshToken = refreshToken
-                
-                self.userInfo()
-            }
-            .disposed(by: self.disposeBag)
+
+                return self.userInfo()
+            })
     }
     
     func logout() -> Single<Void> {
@@ -143,17 +145,17 @@ final class AuthRepository: AuthRepositoryType {
             .map { _ in return () }
     }
     
-    func userInfo() {
+    func userInfo() -> Single<Void> {
         let api = AuthAPI.user
         return self.networkService.request(api)
             .map(UserResponseDTO.self)
-            .subscribe(with: self) { owner, user in
+            .flatMap({ user -> Single<Void> in
                 UserDefaults.userId = user.id
                 UserDefaults.userName = user.nickname ?? ""
                 UserDefaults.userEmail = user.email ?? ""
                 UserDefaults.userImageURLPath = user.imgPath ?? ""
-            }
-            .disposed(by: self.disposeBag)
+
+                return .just(())
+            })
     }
-    
 }

--- a/Boolti/Boolti/Sources/Network/Repositories/Protocols/AuthRepositoryType.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Protocols/AuthRepositoryType.swift
@@ -13,7 +13,7 @@ protocol AuthRepositoryType {
     var networkService: NetworkProviderType { get }
     func fetchTokens() -> (String, String)
     func fetch(withProviderToken providerToken: String, provider: OAuthProvider) -> Single<Bool>
-    func signUp(provider: OAuthProvider, identityToken: String?)
+    func signUp(provider: OAuthProvider, identityToken: String?) -> Single<Void>
     func logout() -> Single<Void>
-    func userInfo()
+    func userInfo() -> Single<Void>
 }

--- a/Boolti/Boolti/Sources/Network/Repositories/Protocols/PushNotificationRepositoryType.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Protocols/PushNotificationRepositoryType.swift
@@ -1,0 +1,14 @@
+//
+//  PushNotificationRepositoryType.swift
+//  Boolti
+//
+//  Created by Miro on 2/27/24.
+//
+
+import Foundation
+
+protocol PushNotificationRepositoryType {
+
+    var networkService: NetworkProviderType { get }
+    func registerDeviceToken()
+}

--- a/Boolti/Boolti/Sources/Network/Repositories/PushNotificationRepository.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/PushNotificationRepository.swift
@@ -1,0 +1,41 @@
+//
+//  PushNotificationRepository.swift
+//  Boolti
+//
+//  Created by Miro on 2/27/24.
+//
+
+import Foundation
+
+import FirebaseMessaging
+import RxSwift
+
+final class PushNotificationRepository: PushNotificationRepositoryType {
+
+    var networkService: NetworkProviderType
+    private let disposeBag = DisposeBag()
+
+    init(networkService: NetworkProviderType) {
+        self.networkService = networkService
+    }
+
+    func registerDeviceToken() {
+        Messaging.messaging().token { token, error in
+            if let error {
+                print(error)
+            }
+            guard let token else { return }
+            guard UserDefaults.accessToken != "" else { return } // 만약 로그인을 안한 유저라면, API를 호출하지 않는다.
+
+            let requestDTO = DeviceTokenRegisterRequestDTO(deviceToken: token)
+            let API = PushNotificationAPI.register(requestDTO: requestDTO)
+
+            self.networkService.request(API)
+                .map(DeviceTokenRegisterResponseDTO.self)
+                .subscribe(with: self, onSuccess: { owner, response in
+                    print(response.tokenId)
+                })
+                .disposed(by: self.disposeBag)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
@@ -79,7 +79,8 @@ final class ConcertDetailDIContainer {
     private func createLoginViewDIContainer() -> LoginViewDIContainer {
         return LoginViewDIContainer(
             authRepository: self.authRepository,
-            socialLoginAPIService: OAuthRepository()
+            socialLoginAPIService: OAuthRepository(),
+            pushNotificationRepository: PushNotificationRepository(networkService: self.authRepository.networkService)
         )
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewDIContainer.swift
@@ -10,11 +10,17 @@ import Foundation
 final class LoginViewDIContainer {
 
     private let authRepository: AuthRepositoryType
-    private let socialLoginAPIService: OAuthRepositoryType
+    private let socialLoginRepository: OAuthRepositoryType
+    private let pushNotificationRepository: PushNotificationRepositoryType
 
-    init(authRepository: AuthRepositoryType, socialLoginAPIService: OAuthRepositoryType) {
+    init(
+        authRepository: AuthRepositoryType,
+        socialLoginAPIService: OAuthRepositoryType,
+        pushNotificationRepository: PushNotificationRepositoryType
+    ) {
         self.authRepository = authRepository
-        self.socialLoginAPIService = socialLoginAPIService
+        self.socialLoginRepository = socialLoginAPIService
+        self.pushNotificationRepository = pushNotificationRepository
     }
 
     func createLoginViewController() -> LoginViewController {
@@ -34,13 +40,19 @@ final class LoginViewDIContainer {
     private func createLoginViewModel() -> LoginViewModel {
         let viewModel = LoginViewModel(
             authRepository: self.authRepository,
-            socialLoginAPIService: self.socialLoginAPIService
+            socialLoginAPIService: self.socialLoginRepository,
+            pushNotificationRepository: self.pushNotificationRepository
         )
 
         return viewModel
     }
 
     private func createTermsAgreementViewDIContainer(identityCode: String, provider: OAuthProvider) -> TermsAgreementDIContainer {
-        return TermsAgreementDIContainer(identityCode: identityCode, provider: provider ,authRepository: self.authRepository)
+        return TermsAgreementDIContainer(
+            identityCode: identityCode,
+            provider: provider,
+            authRepository: self.authRepository,
+            pushNotificationRepository: self.pushNotificationRepository
+        )
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewModel.swift
@@ -29,16 +29,22 @@ final class LoginViewModel {
 
     private let authRepository: AuthRepositoryType
     private let socialLoginAPIService: OAuthRepositoryType
+    private let pushNotificationRepository: PushNotificationRepositoryType
 
     var identityToken: String?
     var provider: OAuthProvider?
 
     private let disposeBag = DisposeBag()
 
-    init(authRepository: AuthRepositoryType, socialLoginAPIService: OAuthRepositoryType) {
+    init(
+        authRepository: AuthRepositoryType,
+        socialLoginAPIService: OAuthRepositoryType,
+        pushNotificationRepository: PushNotificationRepositoryType
+    ) {
         self.authRepository = authRepository
         self.socialLoginAPIService = socialLoginAPIService
-        
+        self.pushNotificationRepository = pushNotificationRepository
+
         self.input = Input()
         self.output = Output()
         self.bindInputs()
@@ -55,6 +61,7 @@ final class LoginViewModel {
                         return owner.authRepository.fetch(withProviderToken: accessToken, provider: provider)
                     })
                     .subscribe(with: self) { owner, isSignUpRequired in
+                        owner.pushNotificationRepository.registerDeviceToken()
                         owner.output.didloginFinished.accept(isSignUpRequired)
                     }
                     .disposed(by: owner.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Login/Terms/TermsAgreementDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/Terms/TermsAgreementDIContainer.swift
@@ -12,15 +12,18 @@ final class TermsAgreementDIContainer {
     private let identityCode: String
     private let provider: OAuthProvider
     private let authRepository: AuthRepositoryType
+    private let pushNotificationRepository: PushNotificationRepositoryType
 
     init(
         identityCode: String,
         provider: OAuthProvider,
-        authRepository: AuthRepositoryType
+        authRepository: AuthRepositoryType,
+        pushNotificationRepository: PushNotificationRepositoryType
     ) {
         self.identityCode = identityCode
         self.provider = provider
         self.authRepository = authRepository
+        self.pushNotificationRepository = pushNotificationRepository
     }
 
     func createTermsAgreementViewController() -> TermsAgreementViewController {
@@ -30,7 +33,12 @@ final class TermsAgreementDIContainer {
     }
 
     private func createTermsAgreementViewModel() -> TermsAgreementViewModel {
-        let viewModel = TermsAgreementViewModel(identityCode: self.identityCode, provider: self.provider, authRepository: self.authRepository)
+        let viewModel = TermsAgreementViewModel(
+            identityCode: self.identityCode,
+            provider: self.provider,
+            authRepository: self.authRepository,
+            pushNotificationRepository: self.pushNotificationRepository
+        )
 
         return viewModel
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MyPageDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MyPageDIContainer.swift
@@ -84,7 +84,11 @@ final class MyPageDIContainer {
     }
 
     private func createLoginViewDIContainer() -> LoginViewDIContainer {
-        return LoginViewDIContainer(authRepository: self.authRepository, socialLoginAPIService: OAuthRepository())
+        return LoginViewDIContainer(
+            authRepository: self.authRepository,
+            socialLoginAPIService: OAuthRepository(),
+            pushNotificationRepository: PushNotificationRepository(networkService: self.authRepository.networkService)
+        )
     }
 
     private func createMyPageViewModel() -> MyPageViewModel {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundBankSelection/TicketRefundBankSelectionViewController.swift
@@ -55,7 +55,7 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
 
     private var isBankSelected: Bool = false
     var selectedItemIndex: Int?
-    var selectedItem: ((BankEntity) -> ())?
+    var selectedItem: ((BankEntity?) -> ())?
 
     init(selectedBank: BankEntity?) {
         super.init()
@@ -86,14 +86,7 @@ final class TicketRefundBankSelectionViewController: BooltiViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
-        // 아래의 로직 리팩토링하기! -> 화면 네비게이션 로직 + ViewModel 생성
-        guard let homeTabBarController = self.presentingViewController as? HomeTabBarController else { return }
-        guard let rootviewController = homeTabBarController.children[2] as? UINavigationController else { return }
-        guard let ticketRefundRequestViewController = rootviewController.viewControllers.filter({ $0 is TicketRefundRequestViewController
-        })[0] as? TicketRefundRequestViewController else { return }
-
-        ticketRefundRequestViewController.dimmedBackgroundView.isHidden = true
+        self.selectedItem?(nil)
     }
 
     private func configureUI() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -63,7 +63,7 @@ final class TicketRefundRequestViewController: BooltiViewController {
 
     private let requestRefundButton = BooltiButton(title: "환불 요청하기")
 
-    let dimmedBackgroundView: UIView = {
+    private let dimmedBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .black100.withAlphaComponent(0.85)
         view.isHidden = true
@@ -182,6 +182,8 @@ final class TicketRefundRequestViewController: BooltiViewController {
                 let viewController = TicketRefundBankSelectionViewController(selectedBank: owner.viewModel.output.selectedBank.value)
 
                 viewController.selectedItem = { item in
+                    owner.dimmedBackgroundView.isHidden = true
+                    guard let item else { return }
                     owner.viewModel.input.selectedItem.accept(item)
                 }
                 owner.dimmedBackgroundView.isHidden = false

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailDIContainer.swift
@@ -22,7 +22,7 @@ final class TicketReservationDetailDIContainer {
             let DIContainer = self.createTicketRefundReasonDIContainer()
 
             let viewController = DIContainer.createTicketRefundReasonViewController(reservationID: reservationID)
-
+ 
             return viewController
         }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailDIContainer.swift
@@ -26,7 +26,7 @@ final class TicketReservationDetailDIContainer {
             return viewController
         }
 
-        return TicketReservationDetailViewController(ticketRefundReasonlViewControllerFactory: ticketRefundReasonViewControllerFactory, viewModel: self.createTicketReservationDetailViewModel(reservationID: reservationID))
+        return TicketReservationDetailViewController(ticketRefundReasonViewControllerFactory: ticketRefundReasonViewControllerFactory, viewModel: self.createTicketReservationDetailViewModel(reservationID: reservationID))
     }
 
     private func createTicketRefundReasonDIContainer() -> TicketRefundReasonDIContainer {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -15,7 +15,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
 
     typealias ReservationID = String
 
-    private let ticketRefundReasonlViewControllerFactory: (ReservationID) -> TicketRefundReasonViewController
+    private let ticketRefundReasonViewControllerFactory: (ReservationID) -> TicketRefundReasonViewController
 
     private let viewModel: TicketReservationDetailViewModel
     private let disposeBag = DisposeBag()
@@ -118,10 +118,10 @@ final class TicketReservationDetailViewController: BooltiViewController {
     }()
 
     init(
-        ticketRefundReasonlViewControllerFactory: @escaping (ReservationID) -> TicketRefundReasonViewController,
+        ticketRefundReasonViewControllerFactory: @escaping (ReservationID) -> TicketRefundReasonViewController,
         viewModel: TicketReservationDetailViewModel
     ) {
-        self.ticketRefundReasonlViewControllerFactory = ticketRefundReasonlViewControllerFactory
+        self.ticketRefundReasonViewControllerFactory = ticketRefundReasonViewControllerFactory
         self.viewModel = viewModel
         super.init()
     }
@@ -238,7 +238,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
 
         self.requestRefundButton.rx.tap
             .bind(with: self) { owner, _ in
-                let viewController = owner.ticketRefundReasonlViewControllerFactory(owner.viewModel.reservationID)
+                let viewController = owner.ticketRefundReasonViewControllerFactory(owner.viewModel.reservationID)
                 owner.navigationController?.pushViewController(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -10,11 +10,11 @@ import Foundation
 final class RootDIContainer {
 
     let rootViewModel: RootViewModel
-    let networkProvider: NetworkProvider
+    let networkProvider: NetworkProviderType
 
     init() {
-        self.rootViewModel = RootViewModel()
         self.networkProvider = NetworkProvider()
+        self.rootViewModel = RootViewModel(networkService: self.networkProvider)
     }
 
     func createRootViewController() -> RootViewController {
@@ -29,7 +29,7 @@ final class RootDIContainer {
         }
 
         return RootViewController(
-            viewModel: rootViewModel,
+            viewModel: self.rootViewModel,
             splashViewControllerFactory: splashViewControllerFactory,
             hometabBarControllerFactory: homeTabBarControllerFactory
         )

--- a/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootDIContainer.swift
@@ -14,7 +14,7 @@ final class RootDIContainer {
 
     init() {
         self.networkProvider = NetworkProvider()
-        self.rootViewModel = RootViewModel(networkService: self.networkProvider)
+        self.rootViewModel = RootViewModel()
     }
 
     func createRootViewController() -> RootViewController {

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -44,6 +44,7 @@ final class RootViewController: UIViewController {
     private func bind() {
         self.rx.viewDidAppear
             .take(1)
+            .do { _ in self.viewModel.registerDeviceToken() }
             .flatMapFirst { _ in self.viewModel.navigation }
             .subscribe(onNext: { [weak self] destination in
                 let viewController = self?.createViewController(destination) ?? UIViewController()

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewController.swift
@@ -44,7 +44,6 @@ final class RootViewController: UIViewController {
     private func bind() {
         self.rx.viewDidAppear
             .take(1)
-            .do { _ in self.viewModel.registerDeviceToken() }
             .flatMapFirst { _ in self.viewModel.navigation }
             .subscribe(onNext: { [weak self] destination in
                 let viewController = self?.createViewController(destination) ?? UIViewController()

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
@@ -11,8 +11,28 @@ import RxSwift
 import RxRelay
 
 final class RootViewModel {
-    
+
+    private let disposeBag = DisposeBag()
+
+    private let networkService: NetworkProviderType
+
+    init(networkService: NetworkProviderType) {
+        self.networkService = networkService
+    }
+
     let navigation = BehaviorRelay<RootDestination>(value: .splash)
+
+    func registerDeviceToken() {
+        let requestDTO = DeviceTokenRegisterRequestDTO(deviceToken: UserDefaults.deviceToken)
+        let API = PushNotificationAPI.register(requestDTO: requestDTO)
+
+        self.networkService.request(API)
+            .map(DeviceTokenRegisterResponseDTO.self)
+            .subscribe(with: self, onSuccess: { owner, response in
+                print(response.tokenId)
+            })
+            .disposed(by: self.disposeBag)
+    }
 }
 
 extension RootViewModel: SplashViewModelDelegate {

--- a/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Root/RootViewModel.swift
@@ -12,27 +12,7 @@ import RxRelay
 
 final class RootViewModel {
 
-    private let disposeBag = DisposeBag()
-
-    private let networkService: NetworkProviderType
-
-    init(networkService: NetworkProviderType) {
-        self.networkService = networkService
-    }
-
     let navigation = BehaviorRelay<RootDestination>(value: .splash)
-
-    func registerDeviceToken() {
-        let requestDTO = DeviceTokenRegisterRequestDTO(deviceToken: UserDefaults.deviceToken)
-        let API = PushNotificationAPI.register(requestDTO: requestDTO)
-
-        self.networkService.request(API)
-            .map(DeviceTokenRegisterResponseDTO.self)
-            .subscribe(with: self, onSuccess: { owner, response in
-                print(response.tokenId)
-            })
-            .disposed(by: self.disposeBag)
-    }
 }
 
 extension RootViewModel: SplashViewModelDelegate {

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashDIContainer.swift
@@ -10,9 +10,9 @@ import Foundation
 final class SplashDIContainer {
 
     private let rootDIContainer: RootDIContainer
-    private let networkProvider: NetworkProvider
+    private let networkProvider: NetworkProviderType
 
-    init(rootDIContainer: RootDIContainer, networkProvider: NetworkProvider) {
+    init(rootDIContainer: RootDIContainer, networkProvider: NetworkProviderType) {
         self.rootDIContainer = rootDIContainer
         self.networkProvider = networkProvider
     }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
@@ -68,18 +68,11 @@ final class ReversalPolicyView: UIStackView {
         self.axis = .vertical
         self.clipsToBounds = true
 
-        var titleViewWidth: CGFloat
-
         if !isWithoutBoard {
             self.layer.cornerRadius = 8
             self.layer.borderWidth = 1
             self.layer.borderColor = UIColor.grey80.cgColor
-            titleViewWidth = 317
         } else {
-            guard let window = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
-                return
-            }
-            titleViewWidth = window.screen.bounds.width
             self.backgroundColor = .grey90
         }
 
@@ -93,7 +86,6 @@ final class ReversalPolicyView: UIStackView {
         ])
 
         self.titleView.snp.makeConstraints { make in
-//            make.width.equalTo(titleViewWidth)
             make.height.equalTo(66)
         }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -34,7 +34,7 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
     private lazy var rightCircleView: UIView = {
         let view = UIView()
         view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.grey50.cgColor
+        view.layer.borderColor = UIColor.grey80.cgColor
         view.backgroundColor = .grey95
 
         return view
@@ -127,15 +127,19 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
 
         self.configureBackGroundBlurViewEffect()
         self.configureConstraints()
-        self.configureBorder()
+        self.configureCircleView()
         self.configureSeperateLine()
         self.configureCornerGradient()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.configureGradientBorder()
     }
 
     func setData(with item: TicketItemEntity) {
         self.backgroundImageView.setImage(with: item.posterURLPath)
         self.posterImageView.setImage(with: item.posterURLPath)
-        // MARK 요거 정리하기!
         self.numberLabel.text = " ・ 1매"
         self.ticketTypeLabel.text = item.ticketName
         self.ticketInformationView.setData(with: item)
@@ -152,7 +156,7 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         self.layer.addSublayer(gradientLayer)
     }
 
-    private func configureBorder() {
+    private func configureCircleView() {
         self.rightCircleView.layer.cornerRadius = self.bounds.height * 0.0175
         self.leftCircleView.layer.cornerRadius = self.bounds.height * 0.0175
     }
@@ -164,6 +168,26 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         self.backgroundImageView.addSubview(visualEffectView)
 
         self.configureBackGroundGradient()
+    }
+
+    private func configureGradientBorder() {
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = self.backgroundImageView.bounds
+        gradientLayer.colors = [UIColor.grey80.cgColor, UIColor.grey50.cgColor, UIColor.grey10.cgColor]
+
+        gradientLayer.startPoint = CGPoint(x: 1.0, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.0, y: 1.0)
+
+        gradientLayer.locations = [0.1, 0.7, 0.9]
+
+        let renderer = UIGraphicsImageRenderer(bounds: bounds)
+        let gradient =  renderer.image { ctx in
+            gradientLayer.render(in: ctx.cgContext)
+        }
+
+        let gradientColor = UIColor(patternImage: gradient)
+        self.backgroundImageView.layer.borderColor = gradientColor.cgColor
+        self.backgroundImageView.layer.borderWidth = 1
     }
 
     private func configureBackGroundGradient() {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListDIContainer.swift
@@ -57,7 +57,8 @@ final class TicketListDIContainer {
     private func createLoginViewDIContainer() -> LoginViewDIContainer {
         return LoginViewDIContainer(
             authRepository: self.authRepository,
-            socialLoginAPIService: OAuthRepository()
+            socialLoginAPIService: OAuthRepository(),
+            pushNotificationRepository: PushNotificationRepository(networkService: self.authRepository.networkService)
         )
     }
 


### PR DESCRIPTION
## 작업한 내용

**[푸시 노티피케이션 작업을 수행했어요]**
- **'dev'와 'prod'를 나누어서 주제를 구독할 수 있게 구현했어요.**
  - 구독 메소드를 어디에다가 두어야할 지 고민을 했는데, `didFinishLaunchingWithOptions` 해당 메소드 안에 두었을 경우에는 에러가 나왔어요. 확인해보니 FCM 토큰을 fetch하기 전에 APNS 토큰이 fetch가 되지 않았다는 에러였어요. 그래서 `didRegisterForRemoteNotificationsWithDeviceToken` 여기서 할 지, `didReceiveRegistrationToken` 여기서 할 지 고민을 했었는데에 주제 구독은 모든 토큰들이 제대로 받아와지고 마지막에 하는 게 좋을 거 같아서 `didReceiveRegistrationToken`에 했어요.
- **PushNotificationRepository** 를 정의했어요.
  - 해당 레포지토리를 통해서 서버에게 Device Token을 보내요.
  - 로그인을 하지 않는 유저일 경우 해당 메소드를 실행하면 안되기 때문에 UserDefaults의 accessToken이 없으면 API 호출을 하지 않아요.
  - Device Token을 보내는 시점은 다음과 같아요. 
    - 앱을 켰을 때(로그인이 되어있을 경우)
    - 로그인 했을 경우
    - 회원가입을 했을 경우(로그인 했을 때 보내지 못했기에 회원가입 후, AccessToken을 받고나서 보낸다.)

**[은행 선택 Scene 및 TicketListCell Border Gradient 설정해주었어요.]**
- 은행 선택의 경우, 기존의 코드가 제대로 작동되지 않는 경우를 확인했어요.
  - ConcertList에서 입장 확인 중 탭을 눌러서 들어갈 경우, Navigation이 Mypage에서부터 들어가는 정상적인 흐름이 아니었어요. 그래서 Stack에 쌓인 View를 찾는 코드가 복잡해질 거 같아서 해당 부분의 로직을 변경했어요. 

**[생겼던 문제]**
- `didReceive` 메소드를 통해서 유저가 푸시를 탭했을 경우를 처리 할 수 있어요. 그리고 저희는 어떠한 푸시 알림이든 탭했을 경우, 콘서트 리스트로 이동하도록 구현했어요. 근데 앱이 켜져있는 경우에는 제대로 작동을 했는데, 앱이 종료된 이후에는 푸시 알림이 오지 않았어요. 기존의 코드는 아래 코드에서의 if문이 guard문으로 구현 되어있었는데, guard에서 else로 빠지면 completionHandler가 실행되지 않았어요. 그래서 공식문서를 확인해보니, 무조건 completionHandler를 실행시켜야된다고 되어있었어요.(앱이 꺼져있는 상태에서도 그런거 같아요.) 그래서 if문으로 바꾸고 나니, 정상적으로 알림이 왔고, 탭시 앱이 켜졌어요.
```swift
// 현재 코드
    func userNotificationCenter(_ center: UNUserNotificationCenter,
                                didReceive response: UNNotificationResponse,
                                withCompletionHandler completionHandler: @escaping () -> Void) {

        let messageTitle = response.notification.request.content.title
        let messageBody = response.notification.request.content.body

        if let keyWindow = UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first?.windows.first {
            if let rootViewController = keyWindow.rootViewController as? RootViewController {
                if let homeTabBarViewController = rootViewController.presentedViewController as? HomeTabBarController {
                    homeTabBarViewController.selectedIndex = 0
                }
            }
        }
        completionHandler()
    }
```

[궁금한 내용]
- 현재 우리의 코드 상태에서 UserDefaults.deviceToken가 필요없을 거 같다는 생각이 들었어요.
- UserDefaults에 있는 DeviceToken을 활용할 경우, 로그아웃을 하고 다시 로그인을 할 때, device Token이 비어있는 상태에요. 그래서 다시 Device Token을 받아오기 위해서는 앱을 다시 시작해야해요.
- 그래서 로그아웃 시, DeviceToken은 지우지 않는 방법도 고민을 했었는데... 해당 부분에관한 주현이의 의견이 궁금해요!

## 관련 이슈
- Resolved: #153 
