### PR TITLE
Chore/#160 티켓 크기 수정 및 Poster 비율 수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2252,7 +2252,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2293,7 +2293,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
@@ -200,7 +200,7 @@ final class TicketDetailView: UIView {
 
         self.posterImageView.snp.makeConstraints { make in
             make.top.equalTo(self.upperTagView.snp.bottom).offset(20)
-            make.height.equalTo(screenHeight * 0.44)
+            make.height.equalTo(screenHeight * 0.47)
             make.horizontalEdges.equalToSuperview().inset(20)
         }
 
@@ -226,7 +226,7 @@ final class TicketDetailView: UIView {
         self.backgroundImageView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(screenHeight * 0.44 + 169)
+            make.height.equalTo(screenHeight * 0.47 + 169)
         }
 
         self.rightCircleView.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -216,13 +216,13 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
 
         self.ticketInformationView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(self.bounds.width * 0.06)
-            make.bottom.equalToSuperview().inset(self.bounds.height * 0.05)
+            make.bottom.equalToSuperview().inset(self.bounds.height * 0.04)
         }
 
         self.posterImageView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(self.bounds.width * 0.06)
             make.top.equalTo(self.upperTagView.snp.bottom).offset(self.bounds.height * 0.04)
-            make.height.equalToSuperview().multipliedBy(0.65)
+            make.height.equalToSuperview().multipliedBy(0.67)
         }
 
         self.upperTagLabelStackView.snp.makeConstraints { make in
@@ -237,20 +237,20 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
 
         self.rightCircleView.snp.makeConstraints { make in
             make.width.height.equalTo(self.bounds.height * 0.035)
-            make.centerY.equalTo(self.snp.top).offset(self.bounds.height * 0.79)
+            make.centerY.equalTo(self.snp.top).offset(self.bounds.height * 0.805)
             make.centerX.equalTo(self.snp.right)
         }
 
         self.leftCircleView.snp.makeConstraints { make in
             make.width.height.equalTo(self.bounds.height * 0.035)
-            make.centerY.equalTo(self.snp.top).offset(self.bounds.height *  0.79)
+            make.centerY.equalTo(self.snp.top).offset(self.bounds.height *  0.805)
             make.centerX.equalTo(self.snp.left)
         }
     }
 
         private func configureSeperateLine() {
             let path = CGMutablePath()
-            let height = self.bounds.height * 0.79
+            let height = self.bounds.height * 0.805
             let width = self.bounds.width * 0.053
 
             path.move(to: CGPoint(x: width, y: height))

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -138,7 +138,7 @@ final class TicketListViewController: BooltiViewController {
                 trailing: 6
             )
 
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalWidth(1.61))
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalWidth(1.66))
 
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
@@ -159,7 +159,7 @@ final class TicketListViewController: BooltiViewController {
             let section = NSCollectionLayoutSection(group: group)
             section.boundarySupplementaryItems = [footer]
             section.orthogonalScrollingBehavior = .groupPagingCentered
-            section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 10, trailing: 0)
+            section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 7, trailing: 0)
 
             self.configureCollectionViewCarousel(of: section)
 


### PR DESCRIPTION
## 작업한 내용
- 티켓 크기 수정 및 Poster 비율 수정
  - Poster 비율을 세로로 길게 수정했습니다.
  - 티켓의 높이도 길게 수정했습니다.

## 스크린샷
|TicketList |
| --- |
|<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/646157dd-7c1f-42c4-a299-9e815e7acc59" width="250"/>|

## 관련 이슈
- Resolved: #160 
