### PR TITLE
Chore/#163 로그인/회원가입 Throttle 작업 추가 및 유저 이름 업데이트 에러 해결

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2252,7 +2252,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2269,7 +2269,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2293,7 +2293,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2310,7 +2310,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -75,7 +75,6 @@ extension ConcertListViewController {
     private func bindOutputs() {
         self.viewModel.output.checkingTicketCount
             .skip(1)
-            .distinctUntilChanged()
             .asDriver(onErrorJustReturn: 0)
             .drive(with: self) { owner, concerts in
                 owner.mainCollectionView.reloadSections([0, 1], animationStyle: .automatic)

--- a/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewController.swift
@@ -125,6 +125,7 @@ extension LoginViewController {
         self.kakaoLoginButton.rx.tap
             .asDriver()
             .map { OAuthProvider.kakao }
+            .throttle(.seconds(2), latest: false)
             .drive(with: self) { owner, provider in
                 owner.viewModel.input.loginButtonDidTapEvent.onNext(provider)
             }
@@ -133,6 +134,7 @@ extension LoginViewController {
         self.appleLoginButton.rx.tap
             .asDriver()
             .map { OAuthProvider.apple }
+            .throttle(.seconds(2), latest: false)
             .drive(with: self) { owner, provider in
                 owner.viewModel.input.loginButtonDidTapEvent.onNext(provider)
             }

--- a/Boolti/Boolti/Sources/UILayer/Login/Terms/TermsAgreementViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/Terms/TermsAgreementViewController.swift
@@ -85,7 +85,11 @@ extension TermsAgreementViewController {
     
     private func bindInputs() {
         self.agreementButton.rx.tap
-            .bind(to: self.viewModel.input.didAgreementButtonTapEvent)
+            .asDriver()
+            .throttle(.seconds(2), latest: false)
+            .drive(with: self, onNext: { owner, _ in
+                owner.viewModel.input.didAgreementButtonTapEvent.onNext(())
+            })
             .disposed(by: self.disposeBag)
     }
     


### PR DESCRIPTION
## 작업한 내용
- 로그인/회원가입 Throttle 작업 추가 
  - 로그인과 회원가입 버튼에 Throttle 작업을 추가했어요.
  - (추후에 API를 쏘는 작업에서 전체적으로 다 Throttle 작업을 해줘야될 거 같아요)
- 유저 이름 업데이트 에러 해결
  - 왜 유저 이름이 업데이트 되지 않는 지 확인해봤는데, 분기처리 과정에서 카카오 로그인 -> 로그아웃 -> 애플 로그인 시(그 반대도 동일), 아래 confirmCheckingTickets 함수의 else문으로 빠지게 되고, fetchCheckingTickets()로 넘어가게되더라구요. 그리고 Output의 checkingTicketCount에 event 값을 던지게 되는데, Output을 받는 곳에서 distinctUntilChanged()가 설정되어있어서 이전 값과 동일하면 유저 이름을 업데이트 해주지 않더라구요. 그래서 일단 해당 operator를 삭제해줬는데, 이렇게 될 경우, 불필요한 reload가 생기긴해요..🥲 일단은 임시방편으로 operator를 삭제해주는 방식으로 수정했습니다!
```swift
func confirmCheckingTickets() {
        if UserDefaults.accessToken.isEmpty {
            self.output.checkingTicketCount.accept(-1)
        } else {
            // 🔥여기를 지난다.🔥
            self.fetchCheckingTickets()
        }
    }
    
    private func fetchCheckingTickets() {
        self.ticketReservationRepository.ticketReservations()
            .asObservable()
            .subscribe(with: self, onNext: { owner, ticketReservations in
                let waitingForDepositReservations = ticketReservations.filter { $0.reservationStatus == .waitingForDeposit }
                let count = waitingForDepositReservations.count > 0 ? 1 : 0
                // 🔥이전의 값과 동일한 값을 checkingTicketCount로 보낸다.🔥
                owner.output.checkingTicketCount.accept(count)
            })
            .disposed(by: self.disposeBag)
    }
```

## 관련 이슈
- Resolved: #163 
