### PR TITLE
Chore/#165 2차 MVP 이후 코드 정리(Rx Operator 및 Navigate 로직 변경)

### DIFF
--- a/Boolti/Boolti/Sources/Entities/Ticket/TicketDetailItemEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Ticket/TicketDetailItemEntity.swift
@@ -15,6 +15,7 @@ struct TicketDetailItemEntity {
     let title: String
     let date: String
     let location: String
+    let streetAddress: String
     let qrCode: UIImage
     let notice: String
     let ticketID: Int

--- a/Boolti/Boolti/Sources/Entities/Ticket/TicketItemEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Ticket/TicketItemEntity.swift
@@ -9,7 +9,6 @@ import UIKit
 
 struct TicketItemEntity: Hashable {
 
-    let id = UUID()
     let ticketType: TicketType
     let ticketName: String
     let posterURLPath: String
@@ -20,10 +19,15 @@ struct TicketItemEntity: Hashable {
     let ticketID: Int
     let csTicketID: String
     var ticketStatus: TicketStatus
-}
 
-extension TicketItemEntity {
+    // 일단 ticketID를 통해서 유일한 객체를 만든다!..
+    // 만약 item 중 ticketID가 동일한 것이 존재하면 안된다!
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.ticketID)
+    }
+
+    // 만약 ticketID가 동일하고, ticketStatus가 동일하면 같은 놈으로 취급한다.
     static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.ticketID == rhs.ticketID && lhs.ticketStatus == rhs.ticketStatus
+        return lhs.hashValue == rhs.hashValue && lhs.ticketStatus == rhs.ticketStatus
     }
 }

--- a/Boolti/Boolti/Sources/Entities/Ticket/TicketItemEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Ticket/TicketItemEntity.swift
@@ -21,3 +21,9 @@ struct TicketItemEntity: Hashable {
     let csTicketID: String
     var ticketStatus: TicketStatus
 }
+
+extension TicketItemEntity {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.ticketID == rhs.ticketID && lhs.ticketStatus == rhs.ticketStatus
+    }
+}

--- a/Boolti/Boolti/Sources/Network/DTO/Ticket/Response/TicketDetailResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Ticket/Response/TicketDetailResponseDTO.swift
@@ -57,6 +57,7 @@ extension TicketDetailResponseDTO {
             title: self.showName,
             date: self.showDate,
             location: self.placeName,
+            streetAddress: self.streetAddress,
             qrCode: qrCodeImage,
             notice: self.ticketNotice,
             ticketID: self.ticketId,

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
@@ -188,19 +188,13 @@ final class TicketRefundConfirmViewController: BooltiViewController {
         self.viewModel.output.didRequestFundCompleted
             .asDriver(onErrorDriveWith: .never())
             .drive(with: self) { owner, _ in
-                // MARK: dismiss pop 하는 로직 제대로 공부해서 수정하기
-                guard let homeTabBarController = owner.presentingViewController as? HomeTabBarController else { return }
-                guard let rootviewController = homeTabBarController.children[2] as? UINavigationController else { return }
-                print(rootviewController.viewControllers)
-                guard let ticketReservationDetailViewController = rootviewController.viewControllers.filter({ $0 is TicketReservationDetailViewController
-                })[0] as? TicketReservationDetailViewController else { return }
-                print(ticketReservationDetailViewController)
-                guard let ticketRefundVC = rootviewController.viewControllers.filter({ $0 is TicketRefundRequestViewController
-                })[0] as? TicketRefundRequestViewController else { return }
+                guard let refundRequestViewController = owner.presentingViewController as? TicketRefundRequestViewController else { return }
+                guard let viewControllers = refundRequestViewController.navigationController?.viewControllers else { return }
+                guard let reservationListViewControllers = viewControllers.filter({ $0 is TicketReservationsViewController }).first as? TicketReservationsViewController else { return }
 
                 owner.showToast(message: "환불 요청이 완료되었어요")
                 owner.dismiss(animated: true) {
-                    ticketRefundVC.navigationController?.popToViewController(ticketReservationDetailViewController, animated: true)
+                    refundRequestViewController.navigationController?.popToViewController(reservationListViewControllers, animated: true)
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -311,7 +311,8 @@ final class TicketRefundRequestViewController: BooltiViewController {
                     owner.viewModel.reasonText,
                     refundAccountInfomration
                 )
-                viewController.modalPresentationStyle = .fullScreen
+                viewController.modalPresentationStyle = .overCurrentContext
+                owner.definesPresentationContext = true
                 owner.present(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -207,7 +207,8 @@ final class TicketDetailViewController: BooltiViewController {
                 let concertID = String(ticketDetail.concertID)
 
                 let viewController = owner.ticketEntryCodeControllerFactory(ticketID, concertID)
-                viewController.modalPresentationStyle = .overFullScreen
+                viewController.modalPresentationStyle = .overCurrentContext
+                owner.definesPresentationContext = true
                 owner.present(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -173,7 +173,8 @@ final class TicketDetailViewController: BooltiViewController {
 
         self.ticketDetailView.didCopyAddressButtonTap
             .bind(with: self) { owner, _ in
-                UIPasteboard.general.string = owner.viewModel.output.fetchedTicketDetail.value?.location
+                guard let streetAddress = owner.viewModel.output.fetchedTicketDetail.value?.streetAddress else { return }
+                UIPasteboard.general.string = streetAddress
                 owner.showToast(message: "공연장 주소가 복사되었어요")
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -71,14 +71,11 @@ final class TicketEntryCodeViewController: BooltiViewController {
             .drive(with: self, onNext: { owner, response in
                 switch response {
                 case .valid:
-                    guard let homeTabBarController = owner.presentingViewController as? HomeTabBarController else { return }
-                    guard let rootviewController = homeTabBarController.children[1] as? UINavigationController else { return }
-                    guard let ticketDetailViewController = rootviewController.viewControllers.filter({ $0 is TicketDetailViewController
-                    })[0] as? TicketDetailViewController else { return }
+                    guard let detailViewController = owner.presentingViewController as? TicketDetailViewController else { return }
 
                     owner.dismiss(animated: true) {
-                        ticketDetailViewController.showToast(message: "사용되었어요")
-                        ticketDetailViewController.entryCodeButton.isHidden = true
+                        detailViewController.showToast(message: "사용되었어요")
+                        detailViewController.entryCodeButton.isHidden = true
                     }
                 default:
                     owner.entryCodeInputView.setData(with: response)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -232,6 +232,7 @@ final class TicketListViewController: BooltiViewController {
             .disposed(by: self.disposeBag)
 
         self.viewModel.output.isAccessTokenLoaded
+            .skip(1)
             .asDriver(onErrorJustReturn: false)
             .drive(with: self, onNext: { owner, isLoaded in
                 // AccessToken이 없으면 -> LoginEnterView를 띄우기!..
@@ -255,6 +256,8 @@ final class TicketListViewController: BooltiViewController {
             .disposed(by: self.disposeBag)
 
         self.viewModel.output.sectionModels
+            .skip(1)
+            .distinctUntilChanged()
             .asDriver(onErrorJustReturn: [])
             .drive(with: self, onNext: { owner, ticketItems in
                 owner.applySnapshot(ticketItems)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -311,7 +311,7 @@ final class TicketListViewController: BooltiViewController {
             .drive(with: self) { owner, _ in
                 guard let QRCodeImage = qrCodeImageView.image else { return }
                 let viewController = owner.qrExpandViewControllerFactory(QRCodeImage, ticketName)
-                viewController.modalPresentationStyle = .overFullScreen
+                viewController.modalPresentationStyle = .fullScreen
                 owner.present(viewController, animated: true)
             }
             .disposed(by: self.disposeBag)


### PR DESCRIPTION
## 작업한 내용

* TicketList에서 불필요한 API Call을 방지하기 위한 작업을 진행했어요.
  * skip 및 distinctUntilChanged()를 활용했어요.
  * distinctUntilChanged를 활용하기위해서 기존의 TicketItemEntity을 수정했어요. TicketID로 hash값을 설정하고, Equatable은 hash 값과 ticket의 status(사용됨 or 사용되지않음)으로 판단할 수 있도록 구현했어요.
* presentingVC가 tabbarVC가 되는 문제점을 파악하고 currentContext와 definesPresentationContext를 통해서 해결했어요.(해당 부분은 ReadME에서 상세하게 작성할 예정이에요.)
* TicketDetail에서 제대로된 도로명 주소를 복사할 수 있도록 받지 않았던 필드를 TicketDetailEntity 프로퍼티에 추가해주었어요.
* TicketList에서는 QR expand를 한 이후에 무조건 API call을 해주도록 기존의 overFullScreen을 fullScreen으로 변경해주었어요. TicketDetail에서는 스크롤을 해서 새로고침할 수 있지만, TicketList에서는 없기 때문에 바로 업데이트를 해주는 게 맞겠다는 생각을 했어요.

## 관련 이슈
- Resolved: #167 
