### PR TITLE
Feature/#172 Push Notification 선택 시, 화면 이동 로직 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		878AF4692B60EC3A00C8838C /* ASAuthorizationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */; };
 		87A3716D2B76497B0061814E /* TicketReservationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */; };
 		87A3716F2B76534B0061814E /* TicketReservationItemEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */; };
+		87C7594C2BA93EA40009A83E /* NotificationMessageTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C7594B2BA93EA40009A83E /* NotificationMessageTitle.swift */; };
 		87CE4F6A2B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */; };
 		87CE4F6C2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */; };
 		87CE4F6F2B8DDA59007A0C8F /* PushNotificationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */; };
@@ -554,6 +555,7 @@
 		878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASAuthorizationController+Rx.swift"; sourceTree = "<group>"; };
 		87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationsTableViewCell.swift; sourceTree = "<group>"; };
 		87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationItemEntity.swift; sourceTree = "<group>"; };
+		87C7594B2BA93EA40009A83E /* NotificationMessageTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMessageTitle.swift; sourceTree = "<group>"; };
 		87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterRequestDTO.swift; sourceTree = "<group>"; };
 		87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterResponseDTO.swift; sourceTree = "<group>"; };
 		87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationAPI.swift; sourceTree = "<group>"; };
@@ -824,6 +826,7 @@
 		84781BE32B5BDD9100D37921 /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				87C7594A2BA93E800009A83E /* Enums */,
 				849FBD4F2B5E91F7006EB865 /* Constants */,
 				84781C782B5BEBB800D37921 /* Utils */,
 				84781C6E2B5BEA9E00D37921 /* Extensions */,
@@ -1692,6 +1695,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		87C7594A2BA93E800009A83E /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				87C7594B2BA93EA40009A83E /* NotificationMessageTitle.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
 		87CE4F662B8DD93A007A0C8F /* PushNotification */ = {
 			isa = PBXGroup;
 			children = (
@@ -2078,6 +2089,7 @@
 				840B39592B7670FC00E7F8C8 /* ConcertEntity.swift in Sources */,
 				8453D7FE2B7539770048F103 /* SalesTicketRequestDTO.swift in Sources */,
 				8710D9502B74FA9A00309FBF /* TicketReservationsDIContainer.swift in Sources */,
+				87C7594C2BA93EA40009A83E /* NotificationMessageTitle.swift in Sources */,
 				84EF916C2B8C4B5F0073C89A /* AppleOAuthUserInfo.swift in Sources */,
 				84A7134A2B7C8999000BABCB /* QRExpandViewController.swift in Sources */,
 				877CAFC92B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift in Sources */,

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -97,13 +97,20 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
 
-        let messageTitle = response.notification.request.content.title
-        let messageBody = response.notification.request.content.body
+        let title = response.notification.request.content.title
+        let notificationMessageTitle = NotificationMessageTitle(title)
 
         if let keyWindow = UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first?.windows.first {
             if let rootViewController = keyWindow.rootViewController as? RootViewController {
                 if let homeTabBarViewController = rootViewController.presentedViewController as? HomeTabBarController {
-                    homeTabBarViewController.selectedIndex = 0
+                    switch notificationMessageTitle {
+                    case .didTicketIssued:
+                        homeTabBarViewController.selectedIndex = 1
+                    case .concertWillStart:
+                        homeTabBarViewController.selectedIndex = 1
+                    case .none:
+                        homeTabBarViewController.selectedIndex = 0
+                    }
                 }
             }
         }

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -66,7 +66,7 @@ extension AppDelegate: MessagingDelegate {
         guard let fcmToken else { return }
         debugPrint(fcmToken)
         self.registerSubject()
-        
+
         // 토큰이 갱신될 경우
         self.pushNotificationRepository.registerDeviceToken()
     }
@@ -100,22 +100,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
 
-        let title = response.notification.request.content.title
-        let notificationMessageTitle = NotificationMessageTitle(title)
+        let userInfo = response.notification.request.content.userInfo
 
-        if let keyWindow = UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first?.windows.first {
-            if let rootViewController = keyWindow.rootViewController as? RootViewController {
-                if let homeTabBarViewController = rootViewController.presentedViewController as? HomeTabBarController {
-                    switch notificationMessageTitle {
-                    case .didTicketIssued:
-                        homeTabBarViewController.selectedIndex = 1
-                    case .concertWillStart:
-                        homeTabBarViewController.selectedIndex = 1
-                    case .none:
-                        homeTabBarViewController.selectedIndex = 0
-                    }
-                }
-            }
+        if let notificationMessageTitle = titleData(from: userInfo) {
+            UserDefaults.tabBarIndex = notificationMessageTitle.tabBarIndex
+            NotificationCenter.default.post(
+                name: Notification.Name.didTabBarSelectedIndexChanged,
+                object: nil,
+                userInfo: ["tabBarIndex" : notificationMessageTitle.tabBarIndex]
+            )
         }
         completionHandler()
     }
@@ -123,5 +116,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     /// Foreground에 푸시알림이 올 때 실행되는 메서드
     func userNotificationCenter(_ center: UNUserNotificationCenter,willPresent notification: UNNotification,withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.badge, .sound, .list, .banner])
+    }
+
+    private func titleData(from userInfo: [AnyHashable : Any]) -> NotificationMessageTitle? {
+        guard let apsData = userInfo["aps"] as? [String : AnyObject] else { return nil }
+        guard let alertData = apsData["alert"] as? [String : Any] else { return nil }
+        guard let title = alertData["title"] as? String else  { return nil }
+
+        return NotificationMessageTitle(title)
     }
 }

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -36,6 +36,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         /// 자동 초기화 방지
         Messaging.messaging().isAutoInitEnabled = true
 
+        /// 탭 Bar index 초기화하기
+        UserDefaults.tabBarIndex = 0
+
         return true
     }
 

--- a/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
@@ -13,4 +13,5 @@ enum UserDefaultsKey: String, CaseIterable {
     case accessToken
     case refreshToken
     case oauthProvider
+    case tabBarIndex
 }

--- a/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
@@ -1,0 +1,25 @@
+//
+//  NotificationMessageTitle.swift
+//  Boolti
+//
+//  Created by Miro on 3/19/24.
+//
+
+import Foundation
+
+enum NotificationMessageTitle {
+
+    case didTicketIssued
+    case concertWillStart
+
+    init?(_ rawValue: String){
+        switch rawValue {
+        case "발권 완료": // 발권 완료
+            self  = .didTicketIssued
+        case "입장 대기": // 입장 대기
+            self = .didTicketIssued
+        default:
+            return nil
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
@@ -17,9 +17,18 @@ enum NotificationMessageTitle {
         case "발권 완료": // 발권 완료
             self  = .didTicketIssued
         case "입장 대기": // 입장 대기
-            self = .didTicketIssued
+            self = .concertWillStart
         default:
             return nil
+        }
+    }
+
+    var tabBarIndex: Int {
+        switch self {
+        case .didTicketIssued:
+            return 1
+        case .concertWillStart:
+            return 1
         }
     }
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
@@ -10,4 +10,5 @@ import Foundation
 extension Notification.Name {
     static let refreshTokenHasExpired = Notification.Name("refreshTokenHasExpired")
     static let serverError = Notification.Name("serverError")
+    static let didTabBarSelectedIndexChanged = Notification.Name("didTabBarSelectedIndexChanged")
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -30,7 +30,10 @@ extension UserDefaults {
     
     @UserDefault<OAuthProvider>(key: UserDefaultsKey.oauthProvider.rawValue, defaultValue: .kakao)
     static var oauthProvider
-    
+
+    @UserDefault<Int>(key: UserDefaultsKey.tabBarIndex.rawValue, defaultValue:  0)
+    static var tabBarIndex
+
     // MARK: - Custom Methods
 
     static func removeAllUserInfo() {

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -45,6 +45,7 @@ final class HomeTabBarController: UITabBarController {
 extension HomeTabBarController {
     
     private func bind() {
+
         self.rx.didSelect.distinctUntilChanged()
             .map { [weak self] selected in self?.viewControllers?.firstIndex(where: { selected === $0 }) }
             .compactMap { $0 }
@@ -75,6 +76,7 @@ extension HomeTabBarController {
                 owner.selectedIndex = selectedIndex
             })
             .disposed(by: disposeBag)
+
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -12,11 +12,38 @@ import RxRelay
 
 final class HomeTabBarViewModel {
 
+    init() {
+        self.configureNotificationCenter()
+        self.configureCurrentTab()
+    }
+
     let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
-    let currentTab = PublishRelay<HomeTab>()
+    let currentTab = BehaviorRelay<HomeTab>(value: .concert)
 
     func selectTab(index: Int) {
         guard let selectedTab = HomeTab(rawValue: index) else { return }
-        currentTab.accept(selectedTab)
+        self.currentTab.accept(selectedTab)
+    }
+
+    private func configureCurrentTab() {
+        guard let selectedTab = HomeTab(rawValue: UserDefaults.tabBarIndex) else { return }
+        self.currentTab.accept(selectedTab)
+    }
+
+    private func configureNotificationCenter() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(changeTabBarSelectedIndex(_:)),
+            name: Notification.Name.didTabBarSelectedIndexChanged,
+            object: nil
+        )
+    }
+
+    @objc func changeTabBarSelectedIndex(_ notification:Notification) {
+        guard let userInfo = notification.userInfo else { return }
+        guard let index = userInfo["tabBarIndex"] as? Int else { return }
+        guard let selectedTab = HomeTab(rawValue: index) else { return }
+
+        self.currentTab.accept(selectedTab)
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 푸시 메세지를 선택했을 시, 고려해야될 사항은 두 가지에요.
  - 앱이 켜져있을 때
  - 앱이 꺼져있을 때

먼저 앱이 켜져있을 때의 경우, userNotificationCenter의 didReceive 메소드를 통해서 notification 메세지가 무엇인 지 판단해요. 그리고 NotificationCenter를 통해서 HomeTabBarController의 selectedIndex를 변경시켜줘요.

근데, 앱이 꺼져있을 경우, 아직 HomeTabBarController가 생성되지 않았기에 NotificationCenter를 observe할 수가 없어요. 그래서 UserDefaults를 통해서 어떠한 index로 이동해야될 지 설정해주었어요.

이 과정에서 HomeTabBarViewModel에 NotificationCenter의 observer를 설정해주었고, 새로운 UserDefaults를 정의해주었어요.

또한 앱이 꺼져있을 경우, 화면을 이동시키는 로직을 조금 더 효율적인 방식으로 할 수 있을 지는 더 고민해봐야할 거 같아요!
(+ 아직 푸시 content가 서버 쪽에서 완벽하게 정의되지 않아서, 일단 푸시의 title로 enum 케이스를 설정해주었는데 추후에 서버 명세서 및 환불/예매 노티 명세가 제대로 나오면 변경해야될 거 같아요!)
(+ 지금 서버에서 내려오는 Title이랑 혜선이가 올려준 노티 명세서 속 Title이 달라서, 일단은 후자에 맞춰서 진행했어요! 그래서 지금 서버에서 내려오는 Title로는 이동되지 않아요!)

## 스크린샷
| 앱이 켜져있을 때 | 앱이 꺼져있을 때 |
| ----- | ----- |
|<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/e4798fbb-1ddd-4e58-9309-6f25e875f036" width="250"/>|<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/06bbd702-b510-4a5c-9b5a-b02975569e56" width="250"/>|

## 관련 이슈
- Resolved: #172 