### PR TITLE
Feature/#173 딥링크 구현하기(공연 공유) / 푸시 노티피케이션 수정 / 티켓 UI 수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		840B395F2B76966E00E7F8C8 /* ConcertListMainTitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B395E2B76966E00E7F8C8 /* ConcertListMainTitleCollectionViewCell.swift */; };
 		840B39612B78CE6300E7F8C8 /* ConcertListRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39602B78CE6300E7F8C8 /* ConcertListRequestDTO.swift */; };
 		840B39632B78CEF700E7F8C8 /* ConcertListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39622B78CEF700E7F8C8 /* ConcertListResponseDTO.swift */; };
-		840B39652B78DD6000E7F8C8 /* UICollectionViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39642B78DD6000E7F8C8 /* UICollectionViewCell+.swift */; };
 		840D84042B6F5C610078D352 /* TicketingPeriodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840D84032B6F5C610078D352 /* TicketingPeriodView.swift */; };
 		841D77D22B73B0C10068B1C5 /* ConcertAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841D77D12B73B0C10068B1C5 /* ConcertAPI.swift */; };
 		841D77D42B73B1B00068B1C5 /* ConcertRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841D77D32B73B1B00068B1C5 /* ConcertRepository.swift */; };
@@ -194,6 +193,7 @@
 		870099BA2B775A9C001779FB /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 870099B92B775A9C001779FB /* RxGesture */; };
 		870099BE2B7767E7001779FB /* EmptyReservationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870099BD2B7767E7001779FB /* EmptyReservationsView.swift */; };
 		870B75FF2B7CC447008970B3 /* TicketRefundRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870B75FE2B7CC447008970B3 /* TicketRefundRequestDTO.swift */; };
+		870C33362BBC29B600ED212C /* UICollectionReusableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870C33352BBC29B600ED212C /* UICollectionReusableView+.swift */; };
 		87101EF72B5DF8FE004BD418 /* RootDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EF62B5DF8FE004BD418 /* RootDestination.swift */; };
 		87101EFA2B5DF9A3004BD418 /* RxAppState in Frameworks */ = {isa = PBXBuildFile; productRef = 87101EF92B5DF9A3004BD418 /* RxAppState */; };
 		87101EFC2B5DFC60004BD418 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87101EFB2B5DFC60004BD418 /* NetworkProvider.swift */; };
@@ -321,7 +321,6 @@
 		840B395E2B76966E00E7F8C8 /* ConcertListMainTitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertListMainTitleCollectionViewCell.swift; sourceTree = "<group>"; };
 		840B39602B78CE6300E7F8C8 /* ConcertListRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertListRequestDTO.swift; sourceTree = "<group>"; };
 		840B39622B78CEF700E7F8C8 /* ConcertListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertListResponseDTO.swift; sourceTree = "<group>"; };
-		840B39642B78DD6000E7F8C8 /* UICollectionViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+.swift"; sourceTree = "<group>"; };
 		840D84032B6F5C610078D352 /* TicketingPeriodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingPeriodView.swift; sourceTree = "<group>"; };
 		841D77D12B73B0C10068B1C5 /* ConcertAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertAPI.swift; sourceTree = "<group>"; };
 		841D77D32B73B1B00068B1C5 /* ConcertRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertRepository.swift; sourceTree = "<group>"; };
@@ -472,6 +471,7 @@
 		870099B62B77489A001779FB /* TicketReservationsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationsRepository.swift; sourceTree = "<group>"; };
 		870099BD2B7767E7001779FB /* EmptyReservationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyReservationsView.swift; sourceTree = "<group>"; };
 		870B75FE2B7CC447008970B3 /* TicketRefundRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketRefundRequestDTO.swift; sourceTree = "<group>"; };
+		870C33352BBC29B600ED212C /* UICollectionReusableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView+.swift"; sourceTree = "<group>"; };
 		87101EF62B5DF8FE004BD418 /* RootDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootDestination.swift; sourceTree = "<group>"; };
 		87101EFB2B5DFC60004BD418 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		8710D93F2B74E44400309FBF /* MypageContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageContentView.swift; sourceTree = "<group>"; };
@@ -901,9 +901,9 @@
 				841D77E02B7464250068B1C5 /* UIImageView+.swift */,
 				84FBBDFA2B675834009462E9 /* UIStackView+.swift */,
 				84625A152B63C33D00CC9077 /* UITableViewCell+.swift */,
-				840B39642B78DD6000E7F8C8 /* UICollectionViewCell+.swift */,
 				84FEF6162B68A6D100EBB64F /* UIResponder+.swift */,
 				87F7DF442B82322E0068A6C9 /* Notification.Name+.swift */,
+				870C33352BBC29B600ED212C /* UICollectionReusableView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1978,11 +1978,11 @@
 				8753CA772B71F004002871C7 /* TicketListItemResponseDTO.swift in Sources */,
 				849FBD512B5E920A006EB865 /* AppInfo.swift in Sources */,
 				221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */,
+				870C33362BBC29B600ED212C /* UICollectionReusableView+.swift in Sources */,
 				8730F0202B7B520A00D4F339 /* SelectRefundBankView.swift in Sources */,
 				84FBBE0B2B6888CB009462E9 /* InvitationCodeView.swift in Sources */,
 				84896A4B2B6A6D6C00CB3E33 /* DepositSummaryView.swift in Sources */,
 				841FA6412B8326BD00441848 /* BooltiPopupView.swift in Sources */,
-				840B39652B78DD6000E7F8C8 /* UICollectionViewCell+.swift in Sources */,
 				8769BF982B625DBF00DA9A67 /* TermsAgreementViewModel.swift in Sources */,
 				842C1C662B7DA8C800EFE5A0 /* ResignInfoViewController.swift in Sources */,
 				876BF16C2B6A43BB00DB4BCB /* TokenRefreshRequestDTO.swift in Sources */,

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         /// 탭 Bar index 초기화하기/concertID 초기화하기
         UserDefaults.tabBarIndex = 0
-        UserDefaults.concertID = 0
+        UserDefaults.concertID = nil
 
         return true
     }

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -120,10 +120,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     private func titleData(from userInfo: [AnyHashable : Any]) -> NotificationMessageTitle? {
-        guard let apsData = userInfo["aps"] as? [String : AnyObject] else { return nil }
-        guard let alertData = apsData["alert"] as? [String : Any] else { return nil }
-        guard let title = alertData["title"] as? String else  { return nil }
-
-        return NotificationMessageTitle(title)
+        guard let messageType = userInfo["type"] as? String else { return nil }
+        return NotificationMessageTitle(messageType)
     }
 }

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -36,8 +36,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         /// 자동 초기화 방지
         Messaging.messaging().isAutoInitEnabled = true
 
-        /// 탭 Bar index 초기화하기
+        /// 탭 Bar index 초기화하기/concertID 초기화하기
         UserDefaults.tabBarIndex = 0
+        UserDefaults.concertID = 0
 
         return true
     }

--- a/Boolti/Boolti/Application/Info.plist
+++ b/Boolti/Boolti/Application/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>BASE_URL</key>
 	<string>${BASE_URL}</string>
 	<key>CFBundleURLTypes</key>
@@ -19,6 +17,8 @@
 	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<string>NO</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>KAKAO_NATIVE_APP_KEY</key>
 	<string>${KAKAO_NATIVE_APP_KEY}</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import RxKakaoSDKAuth
 import KakaoSDKAuth
+import FirebaseDynamicLinks
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -33,7 +34,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
     }
-    
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        if let incomingURL = userActivity.webpageURL {
+            let linkHandled = DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLinks, error in
+                print(dynamicLinks?.url)
+            }
+        }
+    }
+
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -12,21 +12,25 @@ import KakaoSDKAuth
 import FirebaseDynamicLinks
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    
+
     var window: UIWindow?
-    
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        
+
+        if let userActivity = connectionOptions.userActivities.first {
+            self.scene(scene, continue: userActivity)
+        }
+
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         window?.overrideUserInterfaceStyle = .light
-        
+
         let rootDIContainer = RootDIContainer()
         let rootViewController = rootDIContainer.createRootViewController()
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }
-    
+
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             if (AuthApi.isKakaoTalkLoginUrl(url)) {
@@ -37,11 +41,32 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         if let incomingURL = userActivity.webpageURL {
-            let linkHandled = DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLinks, error in
-                print(dynamicLinks?.url)
+            let _ = DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLinks, error in
+
+                // 현재 파라미터가 하나 뿐이므로 일단 showID만 때내기
+                // 만약 다른 dynamic link가 들어오게 되면 다른 함수로 빼서 처리하기!
+                guard let url = dynamicLinks?.url else { return }
+                let urlString = url.absoluteString
+                let components = URLComponents(string: urlString)
+                let queryitems = components?.queryItems ?? []
+
+                guard let concertID = Int(queryitems.filter({ $0.name == "showId" }).first?.value ?? "") else { return }
+                UserDefaults.concertID = concertID
+
+                // active인지 아닌 지를 확인해서 둘 메소드 다 실행되지는 않게 구현하기
+                NotificationCenter.default.post(
+                    name: Notification.Name.didTabBarSelectedIndexChanged,
+                    object: nil,
+                    userInfo: ["tabBarIndex" : HomeTab.concert.rawValue]
+                )
+                NotificationCenter.default.post(
+                    name: Notification.Name.DynamicDestination.concertDetail,
+                    object: nil
+                )
             }
         }
     }
+
 
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
@@ -49,22 +74,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-    
+
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-    
+
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-    
+
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-    
+
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -47,10 +47,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 // 만약 다른 dynamic link가 들어오게 되면 다른 함수로 빼서 처리하기!
                 guard let url = dynamicLinks?.url else { return }
                 let urlString = url.absoluteString
-                let components = URLComponents(string: urlString)
-                let queryitems = components?.queryItems ?? []
+                let components = urlString.split(separator: "/")
 
-                guard let concertID = Int(queryitems.filter({ $0.name == "showId" }).first?.value ?? "") else { return }
+                guard let lastComponent = components.last else { return }
+                guard let concertID = Int(lastComponent) else { return }
                 UserDefaults.concertID = concertID
 
                 // active인지 아닌 지를 확인해서 둘 메소드 다 실행되지는 않게 구현하기

--- a/Boolti/Boolti/Boolti.entitlements
+++ b/Boolti/Boolti/Boolti.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:nexters.page.link</string>
+	</array>
 </dict>
 </plist>

--- a/Boolti/Boolti/Boolti.entitlements
+++ b/Boolti/Boolti/Boolti.entitlements
@@ -10,7 +10,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:nexters.page.link</string>
+		<string>applinks:boolti.page.link</string>
 	</array>
 </dict>
 </plist>

--- a/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
@@ -10,10 +10,12 @@ import Foundation
 enum AppInfo {
     static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
 
-    private static let appId = "6476589322"
+    static let appId = "6476589322"
+    static let bundleID = "com.nexters.boolti"
     static let booltiAppStoreLink = "itms-apps://itunes.apple.com/app/app-store/\(appId)"
     static let booltiShareLink = "https://apps.apple.com/kr/app/id\(appId)"
-    
+    static let booltiDeepLinkPrefix = "https://app.boolti.in/"
+
     static let termsPolicyLink = "https://boolti.notion.site/b4c5beac61c2480886da75a1f3afb982"
     static let privacyPolicyLink = "https://boolti.notion.site/5f73661efdcd4507a1e5b6827aa0da70"
     static let refundPolicyLink = "https://boolti.notion.site/d2a89e2c19824c60bb1e928370d16989"

--- a/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
@@ -15,7 +15,7 @@ enum AppInfo {
     static let booltiAppStoreLink = "itms-apps://itunes.apple.com/app/app-store/\(appId)"
     static let booltiShareLink = "https://apps.apple.com/kr/app/id\(appId)"
     // 변경될 예정
-    static let booltiDeepLinkPrefix = "https://nexters.page.link"
+    static let booltiDeepLinkPrefix = "https://boolti.page.link"
 
     static let termsPolicyLink = "https://boolti.notion.site/b4c5beac61c2480886da75a1f3afb982"
     static let privacyPolicyLink = "https://boolti.notion.site/5f73661efdcd4507a1e5b6827aa0da70"

--- a/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
@@ -14,7 +14,8 @@ enum AppInfo {
     static let bundleID = "com.nexters.boolti"
     static let booltiAppStoreLink = "itms-apps://itunes.apple.com/app/app-store/\(appId)"
     static let booltiShareLink = "https://apps.apple.com/kr/app/id\(appId)"
-    static let booltiDeepLinkPrefix = "https://app.boolti.in/"
+    // 변경될 예정
+    static let booltiDeepLinkPrefix = "https://nexters.page.link"
 
     static let termsPolicyLink = "https://boolti.notion.site/b4c5beac61c2480886da75a1f3afb982"
     static let privacyPolicyLink = "https://boolti.notion.site/5f73661efdcd4507a1e5b6827aa0da70"

--- a/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
@@ -14,4 +14,5 @@ enum UserDefaultsKey: String, CaseIterable {
     case refreshToken
     case oauthProvider
     case tabBarIndex
+    case concertID
 }

--- a/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
@@ -11,7 +11,7 @@ enum NotificationMessageTitle {
 
     case didTicketIssued
     case concertWillStart
-    case didrefundCompleted
+    case didRefundCompleted
     case despositRequest
 
     init?(_ rawValue: String){
@@ -23,7 +23,7 @@ enum NotificationMessageTitle {
         case "DEPOSIT_REQUEST": // 입금 요청
             self = .despositRequest
         case "REFUND_COMPLETED": // 환불 완료
-            self = .didrefundCompleted
+            self = .didRefundCompleted
         default:
             return nil
         }
@@ -31,11 +31,9 @@ enum NotificationMessageTitle {
 
     var tabBarIndex: Int {
         switch self {
-        case .didTicketIssued:
+        case .didTicketIssued, .concertWillStart:
             return 1
-        case .concertWillStart:
-            return 1
-        case .didrefundCompleted:
+        case .didRefundCompleted:
             return 2
         case .despositRequest:
             return 0

--- a/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/NotificationMessageTitle.swift
@@ -11,13 +11,19 @@ enum NotificationMessageTitle {
 
     case didTicketIssued
     case concertWillStart
+    case didrefundCompleted
+    case despositRequest
 
     init?(_ rawValue: String){
         switch rawValue {
-        case "발권 완료": // 발권 완료
+        case "RESERVATION_COMPLETED": // 발권 완료
             self  = .didTicketIssued
-        case "입장 대기": // 입장 대기
+        case "ENTER_NOTIFICATION": // 입장 대기
             self = .concertWillStart
+        case "DEPOSIT_REQUEST": // 입금 요청
+            self = .despositRequest
+        case "REFUND_COMPLETED": // 환불 완료
+            self = .didrefundCompleted
         default:
             return nil
         }
@@ -29,6 +35,10 @@ enum NotificationMessageTitle {
             return 1
         case .concertWillStart:
             return 1
+        case .didrefundCompleted:
+            return 2
+        case .despositRequest:
+            return 0
         }
     }
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
@@ -11,4 +11,8 @@ extension Notification.Name {
     static let refreshTokenHasExpired = Notification.Name("refreshTokenHasExpired")
     static let serverError = Notification.Name("serverError")
     static let didTabBarSelectedIndexChanged = Notification.Name("didTabBarSelectedIndexChanged")
+
+    enum DynamicDestination {
+        static let concertDetail = Notification.Name("concertDetail")
+    }
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/UICollectionReusableView+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UICollectionReusableView+.swift
@@ -1,13 +1,13 @@
 //
-//  UICollectionViewCell+.swift
+//  UICollectionReusableView.swift
 //  Boolti
 //
-//  Created by Juhyeon Byun on 2/11/24.
+//  Created by Miro on 4/2/24.
 //
 
 import UIKit
 
-extension UICollectionViewCell {
+extension UICollectionReusableView {
 
     static var className: String {
         return String(describing: Self.self)

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -34,6 +34,9 @@ extension UserDefaults {
     @UserDefault<Int>(key: UserDefaultsKey.tabBarIndex.rawValue, defaultValue:  0)
     static var tabBarIndex
 
+    @UserDefault<Int>(key: UserDefaultsKey.concertID.rawValue, defaultValue:  0)
+    static var concertID
+
     // MARK: - Custom Methods
 
     static func removeAllUserInfo() {

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -34,7 +34,7 @@ extension UserDefaults {
     @UserDefault<Int>(key: UserDefaultsKey.tabBarIndex.rawValue, defaultValue:  0)
     static var tabBarIndex
 
-    @UserDefault<Int>(key: UserDefaultsKey.concertID.rawValue, defaultValue:  0)
+    @UserDefault<Int?>(key: UserDefaultsKey.concertID.rawValue, defaultValue: nil)
     static var concertID
 
     // MARK: - Custom Methods

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -260,16 +260,23 @@ extension ConcertDetailViewController {
                 guard let concertID = self.viewModel.output.concertDetail.value?.id else { return }
 
                 let image = KFImage(URL(string: posterURL))
-                guard let deepLinkURL = owner.concerDetailDeepLinkURL(concertID) else { return }
-                let activityViewController = UIActivityViewController(
-                    activityItems: [deepLinkURL, image],
-                    applicationActivities: nil
-                )
-                activityViewController.popoverPresentationController?.sourceView = owner.view
-                owner.present(activityViewController, animated: true, completion: nil)
+                guard let longDeepLinkURL = owner.concerDetailDeepLinkURL(concertID) else { return }
+
+                DynamicLinkComponents.shortenURL(longDeepLinkURL, options: nil) { url, warnings, error in
+                    print(url)
+                    print(error)
+                    guard let url = url, error == nil else { return }
+                    let activityViewController = UIActivityViewController(
+                        activityItems: [url, image],
+                        applicationActivities: nil
+                    )
+                    print(activityViewController)
+                    activityViewController.popoverPresentationController?.sourceView = owner.view
+                    owner.present(activityViewController, animated: true, completion: nil)
+                }
             }
             .disposed(by: self.disposeBag)
-        
+
         self.navigationBar.didMoreButtonTap()
             .emit(with: self) { owner, _ in
                 let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
@@ -290,7 +297,7 @@ extension ConcertDetailViewController {
 
     private func concerDetailDeepLinkURL(_ concertID: Int) -> URL? {
         // 변경될 예정
-        guard let link = URL(string: "https://www.boolti.com/show?showId=\(concertID)") else { return nil }
+        guard let link = URL(string: "https://app.boolti.in/show?showId=\(concertID)") else { return nil }
 
         let dynamicLinksDomainURIPrefix = AppInfo.booltiDeepLinkPrefix
         guard let linkBuilder = DynamicLinkComponents(
@@ -300,7 +307,7 @@ extension ConcertDetailViewController {
 
         linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: AppInfo.bundleID)
         linkBuilder.iOSParameters?.appStoreID = AppInfo.appId
-        // 안드로이드 packageID도 받아야됨
+        linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.bundleID)
 
         return linkBuilder.url
     }

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -263,14 +263,11 @@ extension ConcertDetailViewController {
                 guard let longDeepLinkURL = owner.concerDetailDeepLinkURL(concertID) else { return }
 
                 DynamicLinkComponents.shortenURL(longDeepLinkURL, options: nil) { url, warnings, error in
-                    print(url)
-                    print(error)
                     guard let url = url, error == nil else { return }
                     let activityViewController = UIActivityViewController(
                         activityItems: [url, image],
                         applicationActivities: nil
                     )
-                    print(activityViewController)
                     activityViewController.popoverPresentationController?.sourceView = owner.view
                     owner.present(activityViewController, animated: true, completion: nil)
                 }
@@ -297,7 +294,8 @@ extension ConcertDetailViewController {
 
     private func concerDetailDeepLinkURL(_ concertID: Int) -> URL? {
         // 변경될 예정
-        guard let link = URL(string: "https://app.boolti.in/show?showId=\(concertID)") else { return nil }
+        // https://preview.boolti.in/show/$showId
+        guard let link = URL(string: "https://preview.boolti.in/show/\(concertID)") else { return nil }
 
         let dynamicLinksDomainURIPrefix = AppInfo.booltiDeepLinkPrefix
         guard let linkBuilder = DynamicLinkComponents(

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -261,7 +261,6 @@ extension ConcertDetailViewController {
 
                 let image = KFImage(URL(string: posterURL))
                 guard let deepLinkURL = owner.concerDetailDeepLinkURL(concertID) else { return }
-
                 let activityViewController = UIActivityViewController(
                     activityItems: [deepLinkURL, image],
                     applicationActivities: nil

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -273,7 +273,6 @@ extension ConcertDetailViewController {
                 }
             }
             .disposed(by: self.disposeBag)
-
         self.navigationBar.didMoreButtonTap()
             .emit(with: self) { owner, _ in
                 let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
@@ -296,7 +295,6 @@ extension ConcertDetailViewController {
         // 변경될 예정
         // https://preview.boolti.in/show/$showId
         guard let link = URL(string: "https://preview.boolti.in/show/\(concertID)") else { return nil }
-
         let dynamicLinksDomainURIPrefix = AppInfo.booltiDeepLinkPrefix
         guard let linkBuilder = DynamicLinkComponents(
             link: link,

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -257,25 +257,15 @@ extension ConcertDetailViewController {
             .emit(with: self) { owner, _ in
                 guard let posterURL = owner.viewModel.output.concertDetail.value?.posters.first?.path
                 else { return }
-
                 guard let concertID = self.viewModel.output.concertDetail.value?.id else { return }
-                guard let link = URL(string: "https://app.boolti.in/show?showId=\(concertID)") else { return }
-                let dynamicLinksDomainURIPrefix = AppInfo.booltiDeepLinkPrefix
-                guard let linkBuilder = DynamicLinkComponents(
-                    link: link,
-                    domainURIPrefix: dynamicLinksDomainURIPrefix
-                ) else { return }
-
-                linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: AppInfo.bundleID)
-                linkBuilder.iOSParameters?.appStoreID = AppInfo.appId
-//                linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: "com.example.android")
-
-                guard let longDynamicLink = linkBuilder.url else { return }
-                print("The long URL is: \(longDynamicLink)")
 
                 let image = KFImage(URL(string: posterURL))
-                
-                let activityViewController = UIActivityViewController(activityItems: [longDynamicLink, image], applicationActivities: nil)
+                guard let deepLinkURL = owner.concerDetailDeepLinkURL(concertID) else { return }
+
+                let activityViewController = UIActivityViewController(
+                    activityItems: [deepLinkURL, image],
+                    applicationActivities: nil
+                )
                 activityViewController.popoverPresentationController?.sourceView = owner.view
                 owner.present(activityViewController, animated: true, completion: nil)
             }
@@ -297,6 +287,23 @@ extension ConcertDetailViewController {
                 owner.present(alertController, animated: true)
             }
             .disposed(by: self.disposeBag)
+    }
+
+    private func concerDetailDeepLinkURL(_ concertID: Int) -> URL? {
+        // 변경될 예정
+        guard let link = URL(string: "https://www.boolti.com/show?showId=\(concertID)") else { return nil }
+
+        let dynamicLinksDomainURIPrefix = AppInfo.booltiDeepLinkPrefix
+        guard let linkBuilder = DynamicLinkComponents(
+            link: link,
+            domainURIPrefix: dynamicLinksDomainURIPrefix
+        ) else { return nil }
+
+        linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: AppInfo.bundleID)
+        linkBuilder.iOSParameters?.appStoreID = AppInfo.appId
+        // 안드로이드 packageID도 받아야됨
+
+        return linkBuilder.url
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -256,10 +256,10 @@ extension ConcertListViewController {
     }
 
     func configureDynamicLinkDestination() {
-        if UserDefaults.concertID != 0 {
-            let viewController = concertDetailViewControllerFactory(UserDefaults.concertID)
+        if let concertID = UserDefaults.concertID {
+            let viewController = concertDetailViewControllerFactory(concertID)
             self.navigationController?.pushViewController(viewController, animated: true)
-            UserDefaults.concertID = 0 // 바로 초기화
+            UserDefaults.concertID = nil // 바로 초기화
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -14,7 +14,7 @@ final class ConcertListViewController: BooltiViewController {
     // MARK: Properties
     
     typealias ConcertId = Int
-    
+
     private let viewModel: ConcertListViewModel
     private let disposeBag = DisposeBag()
     private let concertDetailViewControllerFactory: (ConcertId) -> ConcertDetailViewController
@@ -68,6 +68,10 @@ final class ConcertListViewController: BooltiViewController {
         self.tabBarController?.tabBar.isHidden = false
         self.viewModel.confirmCheckingTickets()
         self.viewModel.fetchConcertList(concertName: nil)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        self.configureDynamicLinkDestination()
     }
 }
 
@@ -248,6 +252,14 @@ extension ConcertListViewController {
         self.mainCollectionView.snp.makeConstraints { make in
             make.bottom.horizontalEdges.equalToSuperview()
             make.top.equalTo(self.view.safeAreaLayoutGuide)
+        }
+    }
+
+    func configureDynamicLinkDestination() {
+        if UserDefaults.concertID != 0 {
+            let viewController = concertDetailViewControllerFactory(UserDefaults.concertID)
+            self.navigationController?.pushViewController(viewController, animated: true)
+            UserDefaults.concertID = 0 // 바로 초기화
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -10,13 +10,13 @@ import UIKit
 import RxSwift
 
 final class HomeTabBarController: UITabBarController {
-    
+
     // MARK: Properties
 
     private let viewModel: HomeTabBarViewModel
     private let viewControllerFactory: (HomeTab) -> UIViewController
     private let disposeBag = DisposeBag()
-    
+
     // MARK: Init
 
     init(
@@ -34,7 +34,6 @@ final class HomeTabBarController: UITabBarController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         self.configureUI()
         self.bind()
     }
@@ -46,7 +45,7 @@ extension HomeTabBarController {
     
     private func bind() {
 
-        self.rx.didSelect.distinctUntilChanged()
+        self.rx.didSelect
             .map { [weak self] selected in self?.viewControllers?.firstIndex(where: { selected === $0 }) }
             .compactMap { $0 }
             .asDriver(onErrorJustReturn: 0)
@@ -55,7 +54,7 @@ extension HomeTabBarController {
             }
             .disposed(by: self.disposeBag)
 
-        viewModel.tabItems.distinctUntilChanged()
+        self.viewModel.tabItems.distinctUntilChanged()
             .subscribe(with: self, onNext: { owner, tabItems in
                 let viewControllers = tabItems.map { tabItem -> UIViewController in
                     let viewController = owner.viewControllerFactory(tabItem)
@@ -65,7 +64,7 @@ extension HomeTabBarController {
             })
             .disposed(by: disposeBag)
 
-        viewModel.currentTab.distinctUntilChanged()
+        self.viewModel.currentTab.distinctUntilChanged()
             .map { $0.rawValue }
             .filter { [weak self] currentTab in
                 let isVaildTab = currentTab < self?.viewControllers?.count ?? 0
@@ -77,6 +76,25 @@ extension HomeTabBarController {
             })
             .disposed(by: disposeBag)
 
+        self.viewModel.popToRootViewController
+            .subscribe(with: self) { owner, homeTab in
+                guard let viewController = owner.viewControllers?[homeTab.rawValue] as? UINavigationController else { return }
+                viewController.popToRootViewController(animated: false)
+            }
+            .disposed(by: self.disposeBag)
+
+        self.viewModel.dynamicLinkDestination
+            .subscribe(with: self) { owner, viewControllerType in
+                // 아래 코드 정리하기!.. - 타입 캐스팅 일일이 하지 않고, 제네릭타입으로 할 수 있게 구현해보기
+                if let concertDetailVC = viewControllerType as? ConcertDetailViewController.Type {
+                    guard let viewController = owner.viewControllers?[HomeTab.concert.rawValue] as? UINavigationController
+                    else { return }
+                    guard let concertListViewController = viewController.topViewController as? ConcertListViewController
+                    else { return }
+                    concertListViewController.configureDynamicLinkDestination()
+                }
+            }
+            .disposed(by: self.disposeBag)
     }
 }
 
@@ -92,7 +110,7 @@ extension HomeTabBarController {
         self.tabBar.scrollEdgeAppearance = appearance
         self.tabBar.tintColor = .grey10
         self.tabBar.unselectedItemTintColor = .grey50
-        
+
         let topBorder = CALayer()
         topBorder.frame = CGRect(x: 0, y: 0, width: tabBar.frame.size.width, height: 1.0)
         topBorder.backgroundColor = UIColor.grey85.cgColor

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -86,7 +86,7 @@ extension HomeTabBarController {
         self.viewModel.dynamicLinkDestination
             .subscribe(with: self) { owner, viewControllerType in
                 // 아래 코드 정리하기!.. - 타입 캐스팅 일일이 하지 않고, 제네릭타입으로 할 수 있게 구현해보기
-                if let concertDetailVC = viewControllerType as? ConcertDetailViewController.Type {
+                if let _ = viewControllerType as? ConcertListViewController.Type {
                     guard let viewController = owner.viewControllers?[HomeTab.concert.rawValue] as? UINavigationController
                     else { return }
                     guard let concertListViewController = viewController.topViewController as? ConcertListViewController

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -51,14 +51,11 @@ final class HomeTabBarViewModel {
     @objc func changeTabBarSelectedIndex(_ notification:Notification) {
         guard let userInfo = notification.userInfo else { return }
         guard let index = userInfo["tabBarIndex"] as? Int else { return }
-        guard let selectedTab = HomeTab(rawValue: index) else { return }
 
         // 현재 탭에서 싹다 pop하기
         self.popToRootViewController.accept(self.currentTab.value)
         // 새로운 탭으로 옮기기
         self.selectTab(index: index)
-        // 요거 나누기!.. pop하는 거랑 navigate 하는거랑...!
-//        self.popToRootViewController.accept(selectedTab)
     }
 
     @objc func navigateToConcertDetail() {

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -19,6 +19,8 @@ final class HomeTabBarViewModel {
 
     let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
     let currentTab = BehaviorRelay<HomeTab>(value: .concert)
+    let popToRootViewController = PublishRelay<HomeTab>()
+    let dynamicLinkDestination = PublishRelay<BooltiViewController.Type>()
 
     func selectTab(index: Int) {
         guard let selectedTab = HomeTab(rawValue: index) else { return }
@@ -37,6 +39,13 @@ final class HomeTabBarViewModel {
             name: Notification.Name.didTabBarSelectedIndexChanged,
             object: nil
         )
+        // 요것도 파라미터로 받아서 ConcertDetail을 넣을 수 있도록 하기
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(navigateToConcertDetail),
+            name: Notification.Name.DynamicDestination.concertDetail,
+            object: nil
+        )
     }
 
     @objc func changeTabBarSelectedIndex(_ notification:Notification) {
@@ -44,6 +53,15 @@ final class HomeTabBarViewModel {
         guard let index = userInfo["tabBarIndex"] as? Int else { return }
         guard let selectedTab = HomeTab(rawValue: index) else { return }
 
-        self.currentTab.accept(selectedTab)
+        // 현재 탭에서 싹다 pop하기
+        self.popToRootViewController.accept(self.currentTab.value)
+        // 새로운 탭으로 옮기기
+        self.selectTab(index: index)
+        // 요거 나누기!.. pop하는 거랑 navigate 하는거랑...!
+//        self.popToRootViewController.accept(selectedTab)
+    }
+
+    @objc func navigateToConcertDetail() {
+        self.dynamicLinkDestination.accept(ConcertListViewController.self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
@@ -151,7 +151,7 @@ final class TicketDetailView: UIView {
         self.ticketDetailInformationView.setData(with: item)
         self.posterImageView.setImage(with: item.posterURLPath)
         self.backgroundImageView.setImage(with: item.posterURLPath)
-        self.ticketTypeLabel.text = "\(item.ticketName)"
+        self.ticketTypeLabel.text = item.ticketName
         self.ticketNumberLabel.text = item.csTicketID
         self.ticketInquiryView.setData(with: "\(item.hostName) (\(item.hostPhoneNumber))")
         self.ticketNoticeView.setData(with: item.notice)

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketDetailView.swift
@@ -53,6 +53,14 @@ final class TicketDetailView: UIView {
         return imageView
     }()
 
+    private let ticketNumberLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .grey80.withAlphaComponent(0.75)
+        label.font = .pretendardB(14)
+
+        return label
+    }()
+
     private let backgroundImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.clipsToBounds = true
@@ -143,7 +151,8 @@ final class TicketDetailView: UIView {
         self.ticketDetailInformationView.setData(with: item)
         self.posterImageView.setImage(with: item.posterURLPath)
         self.backgroundImageView.setImage(with: item.posterURLPath)
-        self.ticketTypeLabel.text = "\(item.ticketName) ・ 1매"
+        self.ticketTypeLabel.text = "\(item.ticketName)"
+        self.ticketNumberLabel.text = item.csTicketID
         self.ticketInquiryView.setData(with: "\(item.hostName) (\(item.hostPhoneNumber))")
         self.ticketNoticeView.setData(with: item.notice)
 
@@ -169,6 +178,7 @@ final class TicketDetailView: UIView {
             self.upperTagView,
             self.booltiLogoImageView,
             self.ticketTypeLabel,
+            self.ticketNumberLabel,
             self.posterImageView,
             self.backgroundBorderView,
             self.ticketDetailInformationView,
@@ -210,12 +220,17 @@ final class TicketDetailView: UIView {
 
         self.booltiLogoImageView.snp.makeConstraints { make in
             make.centerY.equalTo(self.upperTagView.snp.centerY)
-            make.right.equalTo(self.posterImageView)
+            make.left.equalTo(self.posterImageView.snp.left)
         }
 
         self.ticketTypeLabel.snp.makeConstraints { make in
             make.centerY.equalTo(self.booltiLogoImageView.snp.centerY)
-            make.left.equalToSuperview().inset(20)
+            make.left.equalTo(self.booltiLogoImageView.snp.right).offset(5)
+        }
+
+        self.ticketNumberLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.upperTagView.snp.centerY)
+            make.right.equalTo(self.upperTagView.snp.right).inset(16)
         }
 
         self.ticketDetailInformationView.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -56,16 +56,16 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         return view
     }()
 
-    private let ticketNumberLabel: UILabel = {
-        let label = UILabel()
+    private let ticketNumberLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey80.withAlphaComponent(0.75)
         label.font = .pretendardB(14)
 
         return label
     }()
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey10
         label.font = .headline1
         label.numberOfLines = 2
@@ -79,8 +79,8 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
 
-    private let ticketTypeLabel: UILabel = {
-        let label = UILabel()
+    private let ticketTypeLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
         label.textColor = .grey80.withAlphaComponent(0.8)
         label.font = .pretendardB(14)
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -7,7 +7,11 @@
 
 import UIKit
 
+import RxSwift
+
 final class TicketListCollectionViewCell: UICollectionViewCell {
+    
+    var disposeBag = DisposeBag()
 
     private var backgroundImageView: UIImageView = {
         let imageView = UIImageView()
@@ -98,7 +102,8 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        
+        self.ticketNumberLabel.text = nil
+        self.ticketTypeLabel.text = nil
         self.ticketInformationView.resetData()
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/Cells/TicketListCollectionViewCell.swift
@@ -56,17 +56,9 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         return view
     }()
 
-    private lazy var upperTagLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.addArrangedSubviews([self.ticketTypeLabel, self.numberLabel])
-
-        return stackView
-    }()
-
-    private let numberLabel: UILabel = {
+    private let ticketNumberLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .grey80.withAlphaComponent(0.85)
+        label.textColor = .grey80.withAlphaComponent(0.75)
         label.font = .pretendardB(14)
 
         return label
@@ -115,7 +107,8 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
         self.addSubviews([
             self.backgroundImageView,
             self.posterImageView,
-            self.upperTagLabelStackView,
+            self.ticketTypeLabel,
+            self.ticketNumberLabel,
             self.booltiLogoImageView,
             self.ticketInformationView,
             self.rightCircleView,
@@ -140,7 +133,7 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
     func setData(with item: TicketItemEntity) {
         self.backgroundImageView.setImage(with: item.posterURLPath)
         self.posterImageView.setImage(with: item.posterURLPath)
-        self.numberLabel.text = " ・ 1매"
+        self.ticketNumberLabel.text = item.csTicketID
         self.ticketTypeLabel.text = item.ticketName
         self.ticketInformationView.setData(with: item)
     }
@@ -225,14 +218,19 @@ final class TicketListCollectionViewCell: UICollectionViewCell {
             make.height.equalToSuperview().multipliedBy(0.67)
         }
 
-        self.upperTagLabelStackView.snp.makeConstraints { make in
+        self.booltiLogoImageView.snp.makeConstraints { make in
             make.centerY.equalTo(self.upperTagView.snp.centerY)
             make.left.equalTo(self.ticketInformationView)
         }
 
-        self.booltiLogoImageView.snp.makeConstraints { make in
+        self.ticketTypeLabel.snp.makeConstraints { make in
             make.centerY.equalTo(self.upperTagView.snp.centerY)
-            make.right.equalTo(self.ticketInformationView)
+            make.left.equalTo(self.booltiLogoImageView.snp.right).offset(5)
+        }
+
+        self.ticketNumberLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.upperTagView.snp.centerY)
+            make.right.equalTo(self.upperTagView.snp.right).inset(16)
         }
 
         self.rightCircleView.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -45,12 +45,12 @@ final class TicketListViewController: BooltiViewController {
         collectionView.alwaysBounceVertical = false
         collectionView.register(
             TicketListCollectionViewCell.self,
-            forCellWithReuseIdentifier: String(describing: TicketListCollectionViewCell.self)
+            forCellWithReuseIdentifier: TicketListCollectionViewCell.className
         )
         collectionView.register(
             TicketListFooterView.self,
             forSupplementaryViewOfKind: TicketListViewController.ticketListFooterViewKind,
-            withReuseIdentifier: String(describing: TicketListFooterView.self)
+            withReuseIdentifier: TicketListFooterView.className
         )
 
         return collectionView
@@ -171,9 +171,9 @@ final class TicketListViewController: BooltiViewController {
 
     private func configureCollectionViewCarousel(of section: NSCollectionLayoutSection) {
         section.visibleItemsInvalidationHandler = { [weak self] visibleItems, offset, environment in
-            
+
             let visibleCellItems = visibleItems.filter {
-              $0.representedElementKind != TicketListViewController.ticketListFooterViewKind
+                $0.representedElementKind != TicketListViewController.ticketListFooterViewKind
             }
 
             let inset = (environment.container.contentSize.width)*0.05
@@ -285,7 +285,7 @@ final class TicketListViewController: BooltiViewController {
             collectionView: self.collectionView,
             cellProvider: { [weak self ] collectionView, indexPath, item in
                 guard let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: String(describing: TicketListCollectionViewCell.self),
+                    withReuseIdentifier: TicketListCollectionViewCell.className,
                     for: indexPath
                 ) as? TicketListCollectionViewCell else { return UICollectionViewCell() }
                 cell.setData(with: item)
@@ -293,11 +293,15 @@ final class TicketListViewController: BooltiViewController {
                     self?.bindQRCodeExpandView(cell, with: item)
                 }
 
-            return cell
-        })
+                return cell
+            })
 
         self.datasource?.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in
-            let supplementaryView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: String(describing: TicketListFooterView.self), for: indexPath)
+            let supplementaryView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: TicketListFooterView.className,
+                for: indexPath
+            )
 
             self?.bind(supplementaryView)
             return supplementaryView

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -288,6 +288,7 @@ final class TicketListViewController: BooltiViewController {
                     withReuseIdentifier: TicketListCollectionViewCell.className,
                     for: indexPath
                 ) as? TicketListCollectionViewCell else { return UICollectionViewCell() }
+                cell.disposeBag = DisposeBag()
                 cell.setData(with: item)
                 if item.ticketStatus == .notUsed {
                     self?.bindQRCodeExpandView(cell, with: item)
@@ -321,7 +322,7 @@ final class TicketListViewController: BooltiViewController {
                 viewController.modalPresentationStyle = .fullScreen
                 owner.present(viewController, animated: true)
             }
-            .disposed(by: self.disposeBag)
+            .disposed(by: cell.disposeBag)
     }
 
     private func bind(_ footerView: UICollectionReusableView) {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -284,7 +284,10 @@ final class TicketListViewController: BooltiViewController {
         self.datasource = UICollectionViewDiffableDataSource(
             collectionView: self.collectionView,
             cellProvider: { [weak self ] collectionView, indexPath, item in
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: String(describing: TicketListCollectionViewCell.self), for: indexPath) as? TicketListCollectionViewCell else { return UICollectionViewCell() }
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: String(describing: TicketListCollectionViewCell.self),
+                    for: indexPath
+                ) as? TicketListCollectionViewCell else { return UICollectionViewCell() }
                 cell.setData(with: item)
                 if item.ticketStatus == .notUsed {
                     self?.bindQRCodeExpandView(cell, with: item)


### PR DESCRIPTION
## 작업한 내용

### 딥링크 구현(공연 공유)
- 딥링크를 활용하기위한 entitlement를 추가해주었어요.
- 현재 딥링크의 주소는 임의로 만들어준 것이기에 안드와 FE와 다음에 한번 맞춰야될 거 같아요!
  - 현재는 안드에서 공유한 것이 iOS에는 공유가 안됨. (역도 성립)

### 푸시 노티피케이션 수정
- 기존에는 서버에서 노티피케이션을 통해서 내려주는 data 값이 없었는데, 이번 스프린트에 생겼어요.
- 그래서, 내려주는 값으로 어떤 노티피케이션인 지 판단하는 로직으로 수정했어요.

### 티켓 UI 수정
- 티켓의 맨 위쪽에 걸리는 tag의 UI를 수정했어요.

## 스크린샷
- 직접 시뮬레이터에서 돌려봐야지 실행이 잘됩니다!! 스크린샷으로 올릴려고했는데 노트북이 이상해서 안올라가는 거 같아요...

## 관련 이슈
- Resolved: #173 
