### PR TITLE
Fix/#180 concertlist SE UI 깨짐 해결

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2305,7 +2305,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2346,7 +2346,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -204,7 +204,7 @@ extension ConcertListViewController: UICollectionViewDelegateFlowLayout {
         case 2:
             return CGSize(width: self.mainCollectionView.frame.width - 40, height: 80)
         case 3:
-            return CGSize(width: (self.mainCollectionView.frame.width - 40) / 2 - 7.5, height: 313 * self.view.frame.height / 812)
+            return CGSize(width: (self.mainCollectionView.frame.width - 40) / 2 - 7.5, height: max(313, 313 * self.view.bounds.height / 812))
         default:
             return CGSize(width: self.mainCollectionView.frame.width - 40, height: 86)
         }


### PR DESCRIPTION
## 작업한 내용
- 공연 리스트 셀 높이를 수정했어요

## 스크린샷
| SE | 15 Pro Max | 15 Pro |
|-|-|-|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-04-03 at 07 21 04](https://github.com/Nexters/Boolti-iOS/assets/58043306/64ef113c-23cd-4e67-83d3-e3e7994ee436) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-03 at 07 20 50](https://github.com/Nexters/Boolti-iOS/assets/58043306/7f748840-74d7-42e5-adb8-9ca1c9c99bdb) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 07 20 52](https://github.com/Nexters/Boolti-iOS/assets/58043306/4e10d0ee-3011-4c07-9634-3020e3213101) |

## 관련 이슈
- Resolved: #180 
