### PR TITLE
Fix/#184 취소/환불 규정 뷰 padding label 짤림 이슈 해결

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiPaddingLabel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiPaddingLabel.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class BooltiPaddingLabel: UILabel {
-    
+
     private var padding = UIEdgeInsets(top: 4.0, left: 12.0, bottom: 4.0, right: 12.0)
 
     convenience init(padding: UIEdgeInsets) {
@@ -17,14 +17,18 @@ final class BooltiPaddingLabel: UILabel {
     }
     
     override func drawText(in rect: CGRect) {
-        super.drawText(in: rect.inset(by: padding))
+        super.drawText(in: rect.inset(by: self.padding))
     }
     
     override var intrinsicContentSize: CGSize {
         var contentSize = super.intrinsicContentSize
-        contentSize.height += padding.top + padding.bottom
-        contentSize.width += padding.left + padding.right
-        
+        contentSize.height += self.padding.top + self.padding.bottom
+        contentSize.width += self.padding.left + self.padding.right
+
         return contentSize
+    }
+
+    override var bounds: CGRect {
+        didSet { self.preferredMaxLayoutWidth = self.bounds.width - (self.padding.left + self.padding.right) }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -191,6 +191,10 @@ final class TicketRefundRequestViewController: BooltiViewController {
             make.top.horizontalEdges.equalToSuperview()
         }
 
+        self.dimmedBackgroundView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
         [
             self.concertInformationView,
             self.accountHolderStackView,

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -293,7 +293,6 @@ final class TicketReservationDetailViewController: BooltiViewController {
 
         // 결제 정보
         self.totalPaymentAmountView.setData("\(entity.totalPaymentAmount)원")
-
         self.configureRefundButton(with: entity)
 
         // 티켓 정보

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
@@ -42,7 +42,7 @@ final class ReversalPolicyView: UIStackView {
         return imageView
     }()
 
-    private lazy var reversalPolicyLabel: UILabel = {
+    private lazy var reversalPolicyLabel: BooltiPaddingLabel = {
         let label = BooltiPaddingLabel(padding: UIEdgeInsets(top: 0, left: 20, bottom: 24, right: 20))
         label.text = """
         • 티켓 판매 기간 내 발권 취소 및 환불은 서비스 내 처리가 가능하며, 판매 기간 이후에는 주최자에게 직접 연락 바랍니다.
@@ -102,10 +102,6 @@ final class ReversalPolicyView: UIStackView {
         self.viewCollapseImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.right.equalTo(self.titleView.snp.right).inset(20)
-        }
-
-        self.reversalPolicyLabel.snp.makeConstraints { make in
-            make.height.equalTo(260)
         }
     }
 


### PR DESCRIPTION
## 작업한 내용
- 취소/환불 규정 뷰 padding label 짤림 이슈 해결
  - BooltiPaddingLabel의 bounds에 문제가 있어서 preferredMaxLayoutWidth 값을 설정해주어서 알맞게 bound가 잡히도록 구현해주었어요.
- 은행 선택 시 dim 뷰가 보이지 않는 이슈가 있어서 constraint를 잡아줌으로써 해결해주었어요.

## 관련 이슈
- Resolved: #184 
