### PR TITLE
Chore/#190 토스트 문구 및 티켓 상태 문구 값 변경

### DIFF
--- a/Boolti/Boolti/Sources/Entities/Ticket/TicketReservationItemEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Ticket/TicketReservationItemEntity.swift
@@ -18,7 +18,7 @@ enum ReservationStatus: String {
         switch self {
         case .waitingForDeposit: return "입금 확인 중"
         case .cancelled: return "취소"
-        case .reservationCompleted: return "티켓 발권 완료"
+        case .reservationCompleted: return "발권 완료"
         case .waitingForRefund: return "취소 진행 중"
         case .refundCompleted: return "취소 완료"
         }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -231,7 +231,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.accountNumberView.didCopyButtonTap
             .bind(with: self) { owner, accountNumber in
                 UIPasteboard.general.string = accountNumber
-                owner.showToast(message: "계좌번호 복사완료")
+                owner.showToast(message: "계좌번호가 복사되었어요")
             }
             .disposed(by: self.disposeBag)
 


### PR DESCRIPTION
## 작업한 내용
- 예매 내역 / 예매 내역 상세 - 티켓 상태 텍스트 변경
- 계좌번호 복사 토스트 메세지 변경


<현재 동작>
티켓 발권 완료시 ' 티켓 발권 완료'로 노출

<기대 동작>
티켓 발권 완료시 ' 발권 완료'로 노출

예매 내역 상세 - 계좌번호 복사 토스트 메세지 변경

<재현 경로>
마이 > 예매 내역 > 예매 내역 상세 > [계좌번호] 클릭

<현재 동작>
토스트 메세지 '계좌번호 복사 완료'로 노출

<기대 동작>
토스트 메세지 '계좌번호가 복사되었어요'로 노출

## 관련 이슈
- Resolved: #190 
