### PR TITLE
Fix/#187 티켓 선택하기 setData 오류 수정 & 애니메이션 제거

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionViewController.swift
@@ -80,13 +80,11 @@ extension TicketSelectionViewController {
     
     private func setDetent(contentHeight: CGFloat) {
         if let sheet = sheetPresentationController {
-            sheet.animateChanges {
-                sheet.detents = [
-                    .custom { _ in
-                        return min(contentHeight, 484)
-                    }
-                ]
-            }
+            sheet.detents = [
+                .custom { _ in
+                    return min(contentHeight, 484)
+                }
+            ]
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/Views/SelectedSalesTicketView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/Views/SelectedSalesTicketView.swift
@@ -11,10 +11,6 @@ import RxCocoa
 
 final class SelectedSalesTicketView: UIView {
     
-    // MARK: Properties
-    
-    private var maxBuyCount: Int = 1
-    
     // MARK: UI Component
     
     private let nameLabel: BooltiUILabel = {
@@ -127,16 +123,16 @@ extension SelectedSalesTicketView {
         self.nameLabel.text = entity.ticketName
         self.inventoryLabel.text = "\(entity.quantity)매 남음"
         self.priceLabel.text = "\(entity.price.formattedCurrency())원"
-        self.maxBuyCount = entity.quantity
+        self.setCount(price: entity.price, count: 1, maxCount: entity.quantity)
     }
     
-    func setCount(with entity: SelectedTicketEntity) {
-        self.countLabel.text = "\(entity.count)"
+    func setCount(price: Int, count: Int, maxCount: Int) {
+        self.countLabel.text = "\(count)"
         
-        self.minusButton.isEnabled = entity.count > 1
-        self.plusButton.isEnabled = entity.count < self.maxBuyCount
+        self.minusButton.isEnabled = count > 1
+        self.plusButton.isEnabled = count < maxCount
         
-        self.totalPriceLabel.text = "\((entity.price * entity.count).formattedCurrency())원"
+        self.totalPriceLabel.text = "\((price * count).formattedCurrency())원"
     }
     
     var didMinusButtonTap: ControlEvent<Void> {


### PR DESCRIPTION
## 작업한 내용
- 티켓 선택하고 x로 뒤로 가기한 후 다른 티켓을 선택해도 이전 데이터가 남아있는 오류를 수정했어요.
- 티켓 선택시 바텀시트 detent를 변경하는데 설정되어있던 애니메이션을 제거했어요.

## 스크린샷
![RPReplay_Final1712282054](https://github.com/Nexters/Boolti-iOS/assets/58043306/578e03c7-1ab2-497b-bc7f-7a47cf363545)

## 관련 이슈
- Resolved: #187 
