### PR TITLE
Chore/#186 일반 티켓 - 결제 완료 화면 계좌번호만 복사되도록 변경

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewModel.swift
@@ -64,7 +64,7 @@ extension TicketingCompletionViewModel {
     
     private func fetchReservationDetail() {
         self.ticketReservationsRepository.ticketReservationDetail(with: String(self.ticketingData.value.reservationId))
-            .do { self.copyData = "\($0.bankName) \($0.accountNumber) \($0.accountHolderName)" }
+            .do { self.copyData = $0.accountNumber }
             .asObservable()
             .bind(to: self.output.reservationDetail)
             .disposed(by: self.disposeBag)


### PR DESCRIPTION
## 작업한 내용
- 일반 티켓 - 결제 완료 화면 계좌번호만 복사되도록 변경했어요.

## 관련 이슈
- Resolved: #186 
