### PR TITLE
Chore/#198 환불 정보 뷰 spacing 변경

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
@@ -137,7 +137,6 @@ final class TicketRefundConfirmViewController: BooltiViewController {
 
         self.refundInformationContentBackgroundView.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(self.contentBackGroundView).inset(20)
-            make.height.equalTo(220)
             make.top.equalTo(self.titleLabel.snp.bottom).offset(24)
         }
 
@@ -150,19 +149,19 @@ final class TicketRefundConfirmViewController: BooltiViewController {
         self.accountHolderPhoneNumberView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
-            make.top.equalTo(self.accountHolderNameView.snp.bottom).offset(16)
+            make.top.equalTo(self.accountHolderNameView.snp.bottom).offset(12)
         }
 
         self.accountBankNameView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
-            make.top.equalTo(self.accountHolderPhoneNumberView.snp.bottom).offset(16)
+            make.top.equalTo(self.accountHolderPhoneNumberView.snp.bottom).offset(12)
         }
 
         self.accountNumberView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
-            make.top.equalTo(self.accountBankNameView.snp.bottom).offset(16)
+            make.top.equalTo(self.accountBankNameView.snp.bottom).offset(12)
         }
 
         self.seperateLineView.snp.makeConstraints { make in
@@ -176,12 +175,13 @@ final class TicketRefundConfirmViewController: BooltiViewController {
             make.centerX.equalToSuperview()
             make.horizontalEdges.equalTo(self.accountHolderNameView)
             make.top.equalTo(self.seperateLineView.snp.bottom).offset(12)
+            make.bottom.equalTo(self.refundInformationContentBackgroundView).inset(16)
         }
 
         self.requestRefundButton.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(self.contentBackGroundView).inset(20)
             make.top.equalTo(self.refundInformationContentBackgroundView.snp.bottom).offset(28)
-            make.bottom.equalTo(self.contentBackGroundView).offset(-20)
+            make.bottom.equalTo(self.contentBackGroundView).inset(20)
         }
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/TicketRefundRequestViewController.swift
@@ -106,7 +106,6 @@ final class TicketRefundRequestViewController: BooltiViewController {
     }()
     private let reversalPolicyConfirmButton = ReversalPolicyConfirmButton()
 
-
     private lazy var reversalPolicyStackView = self.makeContentStackView([
         self.reversalPolicyTitlelabel,
         self.reversalPolicyLabel,
@@ -197,7 +196,6 @@ final class TicketRefundRequestViewController: BooltiViewController {
 
         [
             self.concertInformationView,
-            self.accountHolderStackView,
             self.accountHolderStackView,
             self.refundAccountInformationView,
             self.refundInformationStackView,

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/Views/AccountContentView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/Views/AccountContentView.swift
@@ -57,13 +57,7 @@ final class AccountContentView: UIView {
             self.errorCommentLabel
         ])
 
-        guard let window = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
-            return
-        }
-        let screenWidth = window.screen.bounds.width
-
         self.snp.makeConstraints { make in
-            make.width.equalTo(screenWidth)
             make.height.equalTo(48)
         }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/Views/RefundAccountNumberView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundRequest/Views/RefundAccountNumberView.swift
@@ -79,8 +79,4 @@ final class RefundAccountNumberView: UIView {
         }
         self.layoutIfNeeded()
     }
-
-
-
-
 }


### PR DESCRIPTION
## 작업한 내용
- 환불 정보 뷰에서 spacing을 16 -> 12로 변경했어요.

## 스크린샷
<img src="https://github.com/Nexters/Boolti-iOS/assets/58043306/aecd6053-1a29-44ff-b565-7179a80975a9" width="375" height="812">

## 관련 이슈
- Resolved: #198 
