### PR TITLE
Chore/#192 딥링크 네비게이션 랜딩 로직 수정 & '환불 내역' 수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		877CAFC92B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CAFC82B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift */; };
 		877CAFCB2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CAFCA2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift */; };
 		877CAFCE2B7BD281004799C8 /* RefundConfirmContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CAFCD2B7BD281004799C8 /* RefundConfirmContentView.swift */; };
+		87826AEE2BBFF7F2005176D4 /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87826AED2BBFF7F2005176D4 /* NavigationDestination.swift */; };
 		878AF4692B60EC3A00C8838C /* ASAuthorizationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */; };
 		87A3716D2B76497B0061814E /* TicketReservationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */; };
 		87A3716F2B76534B0061814E /* TicketReservationItemEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */; };
@@ -560,6 +561,7 @@
 		877CAFC82B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketRefundConfirmViewModel.swift; sourceTree = "<group>"; };
 		877CAFCA2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketRefundConfirmDIContainer.swift; sourceTree = "<group>"; };
 		877CAFCD2B7BD281004799C8 /* RefundConfirmContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmContentView.swift; sourceTree = "<group>"; };
+		87826AED2BBFF7F2005176D4 /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
 		878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASAuthorizationController+Rx.swift"; sourceTree = "<group>"; };
 		87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationsTableViewCell.swift; sourceTree = "<group>"; };
 		87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationItemEntity.swift; sourceTree = "<group>"; };
@@ -1719,6 +1721,7 @@
 			isa = PBXGroup;
 			children = (
 				87C7594B2BA93EA40009A83E /* NotificationMessage.swift */,
+				87826AED2BBFF7F2005176D4 /* NavigationDestination.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2085,6 +2088,7 @@
 				84A713392B7BD504000BABCB /* QRScanRequestDTO.swift in Sources */,
 				87FB0D3A2B6BE97F00B42AF9 /* IdentityTokenDTO.swift in Sources */,
 				84781BE82B5BE17400D37921 /* Enviroment.swift in Sources */,
+				87826AEE2BBFF7F2005176D4 /* NavigationDestination.swift in Sources */,
 				84DF59DC2B722EA0000816DA /* UpdatePopupDIContainer.swift in Sources */,
 				84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */,
 				8730F0162B7B29EC00D4F339 /* TicketRefundRequestViewController.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 		877CAFC92B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CAFC82B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift */; };
 		877CAFCB2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CAFCA2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift */; };
 		877CAFCE2B7BD281004799C8 /* RefundConfirmContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877CAFCD2B7BD281004799C8 /* RefundConfirmContentView.swift */; };
-		87826AEE2BBFF7F2005176D4 /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87826AED2BBFF7F2005176D4 /* NavigationDestination.swift */; };
+		87826AEE2BBFF7F2005176D4 /* LandingDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87826AED2BBFF7F2005176D4 /* LandingDestination.swift */; };
 		878AF4692B60EC3A00C8838C /* ASAuthorizationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */; };
 		87A3716D2B76497B0061814E /* TicketReservationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */; };
 		87A3716F2B76534B0061814E /* TicketReservationItemEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */; };
@@ -561,7 +561,7 @@
 		877CAFC82B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketRefundConfirmViewModel.swift; sourceTree = "<group>"; };
 		877CAFCA2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketRefundConfirmDIContainer.swift; sourceTree = "<group>"; };
 		877CAFCD2B7BD281004799C8 /* RefundConfirmContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmContentView.swift; sourceTree = "<group>"; };
-		87826AED2BBFF7F2005176D4 /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
+		87826AED2BBFF7F2005176D4 /* LandingDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingDestination.swift; sourceTree = "<group>"; };
 		878AF4682B60EC3A00C8838C /* ASAuthorizationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASAuthorizationController+Rx.swift"; sourceTree = "<group>"; };
 		87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationsTableViewCell.swift; sourceTree = "<group>"; };
 		87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationItemEntity.swift; sourceTree = "<group>"; };
@@ -1721,7 +1721,7 @@
 			isa = PBXGroup;
 			children = (
 				87C7594B2BA93EA40009A83E /* NotificationMessage.swift */,
-				87826AED2BBFF7F2005176D4 /* NavigationDestination.swift */,
+				87826AED2BBFF7F2005176D4 /* LandingDestination.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2088,7 +2088,7 @@
 				84A713392B7BD504000BABCB /* QRScanRequestDTO.swift in Sources */,
 				87FB0D3A2B6BE97F00B42AF9 /* IdentityTokenDTO.swift in Sources */,
 				84781BE82B5BE17400D37921 /* Enviroment.swift in Sources */,
-				87826AEE2BBFF7F2005176D4 /* NavigationDestination.swift in Sources */,
+				87826AEE2BBFF7F2005176D4 /* LandingDestination.swift in Sources */,
 				84DF59DC2B722EA0000816DA /* UpdatePopupDIContainer.swift in Sources */,
 				84781CD02B5C006500D37921 /* ConcertViewModel.swift in Sources */,
 				8730F0162B7B29EC00D4F339 /* TicketRefundRequestViewController.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -288,7 +288,7 @@
 		87A3716D2B76497B0061814E /* TicketReservationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */; };
 		87A3716F2B76534B0061814E /* TicketReservationItemEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */; };
 		87B18FE72BB15A3C005A4800 /* ReversalPolicyConfirmButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B18FE62BB15A3C005A4800 /* ReversalPolicyConfirmButton.swift */; };
-		87C7594C2BA93EA40009A83E /* NotificationMessageTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C7594B2BA93EA40009A83E /* NotificationMessageTitle.swift */; };
+		87C7594C2BA93EA40009A83E /* NotificationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C7594B2BA93EA40009A83E /* NotificationMessage.swift */; };
 		87CE4F6A2B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */; };
 		87CE4F6C2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */; };
 		87CE4F6F2B8DDA59007A0C8F /* PushNotificationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */; };
@@ -564,7 +564,7 @@
 		87A3716C2B76497B0061814E /* TicketReservationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationsTableViewCell.swift; sourceTree = "<group>"; };
 		87A3716E2B76534B0061814E /* TicketReservationItemEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketReservationItemEntity.swift; sourceTree = "<group>"; };
 		87B18FE62BB15A3C005A4800 /* ReversalPolicyConfirmButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReversalPolicyConfirmButton.swift; sourceTree = "<group>"; };
-		87C7594B2BA93EA40009A83E /* NotificationMessageTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMessageTitle.swift; sourceTree = "<group>"; };
+		87C7594B2BA93EA40009A83E /* NotificationMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMessage.swift; sourceTree = "<group>"; };
 		87CE4F692B8DD9A8007A0C8F /* DeviceTokenRegisterRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterRequestDTO.swift; sourceTree = "<group>"; };
 		87CE4F6B2B8DD9BB007A0C8F /* DeviceTokenRegisterResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRegisterResponseDTO.swift; sourceTree = "<group>"; };
 		87CE4F6E2B8DDA59007A0C8F /* PushNotificationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationAPI.swift; sourceTree = "<group>"; };
@@ -1718,7 +1718,7 @@
 		87C7594A2BA93E800009A83E /* Enums */ = {
 			isa = PBXGroup;
 			children = (
-				87C7594B2BA93EA40009A83E /* NotificationMessageTitle.swift */,
+				87C7594B2BA93EA40009A83E /* NotificationMessage.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2112,7 +2112,7 @@
 				840B39592B7670FC00E7F8C8 /* ConcertEntity.swift in Sources */,
 				8453D7FE2B7539770048F103 /* SalesTicketRequestDTO.swift in Sources */,
 				8710D9502B74FA9A00309FBF /* TicketReservationsDIContainer.swift in Sources */,
-				87C7594C2BA93EA40009A83E /* NotificationMessageTitle.swift in Sources */,
+				87C7594C2BA93EA40009A83E /* NotificationMessage.swift in Sources */,
 				84EF916C2B8C4B5F0073C89A /* AppleOAuthUserInfo.swift in Sources */,
 				22CF3A312BB586B50094711C /* SelectedInvitationTicketView.swift in Sources */,
 				84A7134A2B7C8999000BABCB /* QRExpandViewController.swift in Sources */,

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -36,9 +36,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         /// 자동 초기화 방지
         Messaging.messaging().isAutoInitEnabled = true
 
-        /// 탭 Bar index 초기화하기/concertID 초기화하기
+        /// 탭 Bar index 초기화하기/destination 초기화하기
         UserDefaults.tabBarIndex = 0
-        UserDefaults.concertID = nil
+        UserDefaults.navigationDestination = nil
 
         return true
     }
@@ -76,11 +76,11 @@ extension AppDelegate: MessagingDelegate {
         /// 주제 구독
         let defaultTopic: String
 
-#if DEBUG
+        #if DEBUG
         defaultTopic = "dev"
-#elseif RELEASE
+        #elseif RELEASE
         defaultTopic = "prod"
-#endif
+        #endif
 
         Messaging.messaging().subscribe(toTopic: defaultTopic) { error in
             if let error {
@@ -104,12 +104,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
 
         if let notificationMessage = titleData(from: userInfo) {
-            UserDefaults.tabBarIndex = notificationMessage.tabBarIndex
-            NotificationCenter.default.post(
-                name: Notification.Name.didTabBarSelectedIndexChanged,
-                object: nil,
-                userInfo: ["tabBarIndex" : notificationMessage.tabBarIndex]
-            )
+            self.configureDestination(with: notificationMessage)
         }
         completionHandler()
     }
@@ -125,9 +120,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     private func configureDestination(with notificationMessage: NotificationMessage) {
-
+        UserDefaults.tabBarIndex = notificationMessage.tabBarIndex
+        NotificationCenter.default.post(
+            name: Notification.Name.didTabBarSelectedIndexChanged,
+            object: nil,
+            userInfo: ["tabBarIndex" : notificationMessage.tabBarIndex]
+        )
         switch notificationMessage {
         case .didRefundCompleted:
+            UserDefaults.navigationDestination = .reservationList
             NotificationCenter.default.post(
                 name: Notification.Name.NavigationDestination.reservationList,
                 object: nil

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -76,11 +76,11 @@ extension AppDelegate: MessagingDelegate {
         /// 주제 구독
         let defaultTopic: String
 
-        #if DEBUG
+#if DEBUG
         defaultTopic = "dev"
-        #elseif RELEASE
+#elseif RELEASE
         defaultTopic = "prod"
-        #endif
+#endif
 
         Messaging.messaging().subscribe(toTopic: defaultTopic) { error in
             if let error {
@@ -103,12 +103,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         let userInfo = response.notification.request.content.userInfo
 
-        if let notificationMessageTitle = titleData(from: userInfo) {
-            UserDefaults.tabBarIndex = notificationMessageTitle.tabBarIndex
+        if let notificationMessage = titleData(from: userInfo) {
+            UserDefaults.tabBarIndex = notificationMessage.tabBarIndex
             NotificationCenter.default.post(
                 name: Notification.Name.didTabBarSelectedIndexChanged,
                 object: nil,
-                userInfo: ["tabBarIndex" : notificationMessageTitle.tabBarIndex]
+                userInfo: ["tabBarIndex" : notificationMessage.tabBarIndex]
             )
         }
         completionHandler()
@@ -119,8 +119,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler([.badge, .sound, .list, .banner])
     }
 
-    private func titleData(from userInfo: [AnyHashable : Any]) -> NotificationMessageTitle? {
+    private func titleData(from userInfo: [AnyHashable : Any]) -> NotificationMessage? {
         guard let messageType = userInfo["type"] as? String else { return nil }
-        return NotificationMessageTitle(messageType)
+        return NotificationMessage(messageType)
+    }
+
+    private func configureDestination(with notificationMessage: NotificationMessage) {
+
+        switch notificationMessage {
+        case .didRefundCompleted:
+            NotificationCenter.default.post(
+                name: Notification.Name.NavigationDestination.reservationList,
+                object: nil
+            )
+        default:
+            break
+        }
     }
 }

--- a/Boolti/Boolti/Application/AppDelegate.swift
+++ b/Boolti/Boolti/Application/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         /// 탭 Bar index 초기화하기/destination 초기화하기
         UserDefaults.tabBarIndex = 0
-        UserDefaults.navigationDestination = nil
+        UserDefaults.landingDestination = nil
 
         return true
     }
@@ -128,9 +128,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         )
         switch notificationMessage {
         case .didRefundCompleted:
-            UserDefaults.navigationDestination = .reservationList
+            UserDefaults.landingDestination = .reservationList
             NotificationCenter.default.post(
-                name: Notification.Name.NavigationDestination.reservationList,
+                name: Notification.Name.LandingDestination.reservationList,
                 object: nil
             )
         default:

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -51,7 +51,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
                 guard let lastComponent = components.last else { return }
                 guard let concertID = Int(lastComponent) else { return }
-                UserDefaults.navigationDestination = .concertDetail(concertId: concertID)
+                UserDefaults.landingDestination = .concertDetail(concertId: concertID)
                 
                 // active인지 아닌 지를 확인해서 둘 메소드 다 실행되지는 않게 구현하기
                 NotificationCenter.default.post(
@@ -60,7 +60,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     userInfo: ["tabBarIndex" : HomeTab.concert.rawValue]
                 )
                 NotificationCenter.default.post(
-                    name: Notification.Name.NavigationDestination.concertDetail,
+                    name: Notification.Name.LandingDestination.concertDetail,
                     object: nil
                 )
             }

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -60,7 +60,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     userInfo: ["tabBarIndex" : HomeTab.concert.rawValue]
                 )
                 NotificationCenter.default.post(
-                    name: Notification.Name.DynamicDestination.concertDetail,
+                    name: Notification.Name.NavigationDestination.concertDetail,
                     object: nil
                 )
             }

--- a/Boolti/Boolti/Application/SceneDelegate.swift
+++ b/Boolti/Boolti/Application/SceneDelegate.swift
@@ -51,8 +51,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
                 guard let lastComponent = components.last else { return }
                 guard let concertID = Int(lastComponent) else { return }
-                UserDefaults.concertID = concertID
-
+                UserDefaults.navigationDestination = .concertDetail(concertId: concertID)
+                
                 // active인지 아닌 지를 확인해서 둘 메소드 다 실행되지는 않게 구현하기
                 NotificationCenter.default.post(
                     name: Notification.Name.didTabBarSelectedIndexChanged,

--- a/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
@@ -12,9 +12,9 @@ enum AppInfo {
 
     static let appId = "6476589322"
     static let bundleID = "com.nexters.boolti"
+    static let androidDebugPackageName = "com.nexters.boolti.debug"
     static let booltiAppStoreLink = "itms-apps://itunes.apple.com/app/app-store/\(appId)"
     static let booltiShareLink = "https://apps.apple.com/kr/app/id\(appId)"
-    // 변경될 예정
     static let booltiDeepLinkPrefix = "https://boolti.page.link"
 
     static let termsPolicyLink = "https://boolti.notion.site/b4c5beac61c2480886da75a1f3afb982"

--- a/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
@@ -15,5 +15,5 @@ enum UserDefaultsKey: String, CaseIterable {
     case oauthProvider
     case tabBarIndex
     case concertID
-    case navigationDestination
+    case landingDestination
 }

--- a/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/UserDefaultsKey.swift
@@ -15,4 +15,5 @@ enum UserDefaultsKey: String, CaseIterable {
     case oauthProvider
     case tabBarIndex
     case concertID
+    case navigationDestination
 }

--- a/Boolti/Boolti/Sources/Global/Enums/LandingDestination.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/LandingDestination.swift
@@ -1,5 +1,5 @@
 //
-//  NavigationDestination.swift
+//  LandingDestination.swift
 //  Boolti
 //
 //  Created by Miro on 4/5/24.
@@ -7,8 +7,7 @@
 
 import Foundation
 
-// 이름도 변경해야될듯?!..
- enum NavigationDestination: Codable {
+ enum LandingDestination: Codable {
      case reservationList
      case concertDetail(concertId: Int)
      // 추가될 예정

--- a/Boolti/Boolti/Sources/Global/Enums/NavigationDestination.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/NavigationDestination.swift
@@ -1,0 +1,15 @@
+//
+//  NavigationDestination.swift
+//  Boolti
+//
+//  Created by Miro on 4/5/24.
+//
+
+import Foundation
+
+// 이름도 변경해야될듯?!..
+ enum NavigationDestination: Codable {
+     case reservationList
+     case concertDetail(concertId: Int)
+     // 추가될 예정
+ }

--- a/Boolti/Boolti/Sources/Global/Enums/NotificationMessage.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/NotificationMessage.swift
@@ -1,5 +1,5 @@
 //
-//  NotificationMessageTitle.swift
+//  NotificationMessage.swift
 //  Boolti
 //
 //  Created by Miro on 3/19/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum NotificationMessageTitle {
+enum NotificationMessage {
 
     case didTicketIssued
     case concertWillStart

--- a/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
@@ -12,7 +12,7 @@ extension Notification.Name {
     static let serverError = Notification.Name("serverError")
     static let didTabBarSelectedIndexChanged = Notification.Name("didTabBarSelectedIndexChanged")
 
-    enum NavigationDestination {
+    enum LandingDestination {
         static let concertDetail = Notification.Name("concertDetail")
         static let reservationList = Notification.Name("reservationList")
     }

--- a/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
@@ -12,7 +12,8 @@ extension Notification.Name {
     static let serverError = Notification.Name("serverError")
     static let didTabBarSelectedIndexChanged = Notification.Name("didTabBarSelectedIndexChanged")
 
-    enum DynamicDestination {
+    enum NavigationDestination {
         static let concertDetail = Notification.Name("concertDetail")
+        static let reservationList = Notification.Name("reservationList")
     }
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -37,8 +37,8 @@ extension UserDefaults {
     @UserDefault<Int?>(key: UserDefaultsKey.concertID.rawValue, defaultValue: nil)
     static var concertID
 
-    @UserDefault<NavigationDestination?>(key: UserDefaultsKey.navigationDestination.rawValue, defaultValue: nil)
-      static var navigationDestination
+    @UserDefault<LandingDestination?>(key: UserDefaultsKey.landingDestination.rawValue, defaultValue: nil)
+      static var landingDestination
 
     // MARK: - Custom Methods
 

--- a/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UserDefaults+.swift
@@ -37,6 +37,9 @@ extension UserDefaults {
     @UserDefault<Int?>(key: UserDefaultsKey.concertID.rawValue, defaultValue: nil)
     static var concertID
 
+    @UserDefault<NavigationDestination?>(key: UserDefaultsKey.navigationDestination.rawValue, defaultValue: nil)
+      static var navigationDestination
+
     // MARK: - Custom Methods
 
     static func removeAllUserInfo() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -303,7 +303,11 @@ extension ConcertDetailViewController {
 
         linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: AppInfo.bundleID)
         linkBuilder.iOSParameters?.appStoreID = AppInfo.appId
+        #if DEBUG
+        linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.androidDebugPackageName)
+        #elseif RELEASE
         linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.bundleID)
+        #endif
 
         return linkBuilder.url
     }

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -256,12 +256,12 @@ extension ConcertListViewController {
     }
 
     func configureDynamicLinkDestination() {
-        guard let navigationDestination = UserDefaults.navigationDestination else { return }
+        guard let landingDestination = UserDefaults.landingDestination else { return }
         
-        if case .concertDetail(let concertID) = navigationDestination {
+        if case .concertDetail(let concertID) = landingDestination {
             let viewController = concertDetailViewControllerFactory(concertID)
             self.navigationController?.pushViewController(viewController, animated: true)
-            UserDefaults.navigationDestination = nil
+            UserDefaults.landingDestination = nil
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -256,10 +256,12 @@ extension ConcertListViewController {
     }
 
     func configureDynamicLinkDestination() {
-        if let concertID = UserDefaults.concertID {
+        guard let navigationDestination = UserDefaults.navigationDestination else { return }
+        
+        if case .concertDetail(let concertID) = navigationDestination {
             let viewController = concertDetailViewControllerFactory(concertID)
             self.navigationController?.pushViewController(viewController, animated: true)
-            UserDefaults.concertID = nil // 바로 초기화
+            UserDefaults.navigationDestination = nil
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -231,4 +231,9 @@ final class MyPageViewController: BooltiViewController {
         case .ticketReservations: return ticketReservationsViewControllerFactory()
         }
     }
+
+    func configureNavigationDestination() {
+         let viewController = self.ticketReservationsViewControllerFactory()
+         self.navigationController?.pushViewController(viewController, animated: true)
+     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -52,7 +52,7 @@ final class MyPageViewController: BooltiViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-          self.configureNavigationDestination()
+          self.configureLandingDestination()
       }
 
     init(
@@ -236,13 +236,13 @@ final class MyPageViewController: BooltiViewController {
         }
     }
 
-    func configureNavigationDestination() {
-        guard let navigationDestination = UserDefaults.navigationDestination else { return }
+    func configureLandingDestination() {
+        guard let landingDestination = UserDefaults.landingDestination else { return }
 
-        if case .reservationList = navigationDestination {
+        if case .reservationList = landingDestination {
             let viewController = self.ticketReservationsViewControllerFactory()
             self.navigationController?.pushViewController(viewController, animated: true)
-            UserDefaults.navigationDestination = nil
+            UserDefaults.landingDestination = nil
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -51,6 +51,10 @@ final class MyPageViewController: BooltiViewController {
         self.tabBarController?.tabBar.isHidden = false
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+          self.configureNavigationDestination()
+      }
+
     init(
         viewModel: MyPageViewModel,
         loginViewControllerFactory: @escaping () -> LoginViewController,
@@ -233,7 +237,12 @@ final class MyPageViewController: BooltiViewController {
     }
 
     func configureNavigationDestination() {
-         let viewController = self.ticketReservationsViewControllerFactory()
-         self.navigationController?.pushViewController(viewController, animated: true)
-     }
+        guard let navigationDestination = UserDefaults.navigationDestination else { return }
+
+        if case .reservationList = navigationDestination {
+            let viewController = self.ticketReservationsViewControllerFactory()
+            self.navigationController?.pushViewController(viewController, animated: true)
+            UserDefaults.navigationDestination = nil
+        }
+    }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketRefund/TicketRefundConfirm/TicketRefundConfirmViewController.swift
@@ -214,11 +214,11 @@ final class TicketRefundConfirmViewController: BooltiViewController {
             .drive(with: self) { owner, _ in
                 guard let refundRequestViewController = owner.presentingViewController as? TicketRefundRequestViewController else { return }
                 guard let viewControllers = refundRequestViewController.navigationController?.viewControllers else { return }
-                guard let reservationListViewControllers = viewControllers.filter({ $0 is TicketReservationsViewController }).first as? TicketReservationsViewController else { return }
+                guard let reservationDetailViewController = viewControllers.filter({ $0 is TicketReservationDetailViewController }).first as? TicketReservationDetailViewController else { return }
 
                 owner.showToast(message: "취소 요청이 완료되었어요")
                 owner.dismiss(animated: true) {
-                    refundRequestViewController.navigationController?.popToViewController(reservationListViewControllers, animated: true)
+                    refundRequestViewController.navigationController?.popToViewController(reservationDetailViewController, animated: true)
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -119,6 +119,15 @@ final class TicketReservationDetailViewController: BooltiViewController {
         isHidden: true
     )
 
+    private let refundMethodView = ReservationHorizontalStackView(title: "환불 수단", alignment: .right)
+    private let totalRefundAmountView = ReservationHorizontalStackView(title: "총 환불 금액", alignment: .right)
+
+    private lazy var refundInformationStackView = ReservationCollapsableStackView(
+        title: "환불 내역",
+        contentViews: [self.totalRefundAmountView, self.refundMethodView],
+        isHidden: false
+    )
+
     private let reversalPolicyView = ReversalPolicyView(isWithoutBorder: true)
 
     private let requestRefundButton: UIButton = {
@@ -216,6 +225,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
             self.depositorInformationStackView,
             self.ticketInformationStackView,
             self.paymentInformationStackView,
+            self.refundInformationStackView,
             self.reversalPolicyView,
             self.blankSpaceView,
             self.requestRefundButton,
@@ -293,6 +303,8 @@ final class TicketReservationDetailViewController: BooltiViewController {
 
         // 결제 정보
         self.totalPaymentAmountView.setData("\(entity.totalPaymentAmount)원")
+        self.totalRefundAmountView.setData("\(entity.totalPaymentAmount)원") // 환불 총액도 결제 정보와 동일하게
+
         self.configureRefundButton(with: entity)
 
         // 티켓 정보
@@ -302,6 +314,8 @@ final class TicketReservationDetailViewController: BooltiViewController {
         // 예매자 정보
         self.purchasernNameView.setData(entity.purchaseName)
         self.purchaserPhoneNumberView.setData(entity.purchaserPhoneNumber)
+
+        self.configureRefundCase(with: entity)
 
         let ticketType = entity.ticketType
 
@@ -316,6 +330,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
     private func setAdditionalDataForSale(with entity: TicketReservationDetailEntity) {
         let paymentMethod = PaymentMethod(rawValue: entity.paymentMethod)!
         self.paymentMethodView.setData(paymentMethod.description)
+        self.refundMethodView.setData(paymentMethod.description) // payment와 동일하게 진행 -> 결제 시스템 붙히면 바뀔 예정
 
         // 입금 계좌 정보
         self.bankNameView.setData(entity.bankName)
@@ -339,6 +354,15 @@ final class TicketReservationDetailViewController: BooltiViewController {
             }
         default:
             self.requestRefundButton.isHidden = true
+        }
+    }
+
+    private func configureRefundCase(with entity: TicketReservationDetailEntity) {
+        if entity.reservationStatus == .refundCompleted {
+            self.refundInformationStackView.isHidden = false
+            self.depositorInformationStackView.changeTitle("결제자 정보")
+        } else {
+            self.refundInformationStackView.isHidden = true
         }
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/Views/ReservationCollapsableStackView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/Views/ReservationCollapsableStackView.swift
@@ -121,4 +121,8 @@ final class ReservationCollapsableStackView: UIStackView {
             self.viewCollapseImageView.image = .chevronDown
         }
     }
+
+    func changeTitle(_ title: String) {
+         self.titleLabel.text = title
+     }
 }

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -42,7 +42,7 @@ final class HomeTabBarController: UITabBarController {
 // MARK: - Methods
 
 extension HomeTabBarController {
-    
+
     private func bind() {
 
         self.rx.didSelect
@@ -83,7 +83,7 @@ extension HomeTabBarController {
             }
             .disposed(by: self.disposeBag)
 
-        self.viewModel.dynamicLinkDestination
+        self.viewModel.navigationDestination
             .subscribe(with: self) { owner, viewControllerType in
                 // 아래 코드 정리하기!.. - 타입 캐스팅 일일이 하지 않고, 제네릭타입으로 할 수 있게 구현해보기
                 if let _ = viewControllerType as? ConcertListViewController.Type {
@@ -92,6 +92,12 @@ extension HomeTabBarController {
                     guard let concertListViewController = viewController.topViewController as? ConcertListViewController
                     else { return }
                     concertListViewController.configureDynamicLinkDestination()
+                } else if let _ = viewControllerType as? TicketReservationsViewController.Type {
+                    guard let viewController = owner.viewControllers?[HomeTab.myPage.rawValue] as? UINavigationController
+                    else { return }
+                    guard let myPageViewController = viewController.topViewController as? MyPageViewController
+                    else { return }
+                    myPageViewController.configureNavigationDestination()
                 }
             }
             .disposed(by: self.disposeBag)
@@ -101,7 +107,7 @@ extension HomeTabBarController {
 // MARK: - UI
 
 extension HomeTabBarController {
-    
+
     private func configureUI() {
         let appearance = UITabBarAppearance()
         appearance.backgroundColor = .grey95

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -83,7 +83,7 @@ extension HomeTabBarController {
             }
             .disposed(by: self.disposeBag)
 
-        self.viewModel.navigationDestination
+        self.viewModel.landingDestination
             .subscribe(with: self) { owner, viewControllerType in
                 // 아래 코드 정리하기!.. - 타입 캐스팅 일일이 하지 않고, 제네릭타입으로 할 수 있게 구현해보기
                 if let _ = viewControllerType as? ConcertListViewController.Type {
@@ -97,7 +97,7 @@ extension HomeTabBarController {
                     else { return }
                     guard let myPageViewController = viewController.topViewController as? MyPageViewController
                     else { return }
-                    myPageViewController.configureNavigationDestination()
+                    myPageViewController.configureLandingDestination()
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -20,7 +20,7 @@ final class HomeTabBarViewModel {
     let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
     let currentTab = BehaviorRelay<HomeTab>(value: .concert)
     let popToRootViewController = PublishRelay<HomeTab>()
-    let navigationDestination = PublishRelay<BooltiViewController.Type>()
+    let landingDestination = PublishRelay<BooltiViewController.Type>()
 
     func selectTab(index: Int) {
         guard let selectedTab = HomeTab(rawValue: index) else { return }
@@ -43,14 +43,14 @@ final class HomeTabBarViewModel {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(navigateToConcertDetail),
-            name: Notification.Name.NavigationDestination.concertDetail,
+            name: Notification.Name.LandingDestination.concertDetail,
             object: nil
         )
 
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(navigateToReservationList),
-            name: Notification.Name.NavigationDestination.reservationList,
+            name: Notification.Name.LandingDestination.reservationList,
             object: nil
         )
     }
@@ -66,10 +66,10 @@ final class HomeTabBarViewModel {
     }
 
     @objc func navigateToConcertDetail() {
-        self.navigationDestination.accept(ConcertListViewController.self)
+        self.landingDestination.accept(ConcertListViewController.self)
     }
 
     @objc func navigateToReservationList() {
-        self.navigationDestination.accept(TicketReservationsViewController.self)
+        self.landingDestination.accept(TicketReservationsViewController.self)
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -20,7 +20,7 @@ final class HomeTabBarViewModel {
     let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
     let currentTab = BehaviorRelay<HomeTab>(value: .concert)
     let popToRootViewController = PublishRelay<HomeTab>()
-    let dynamicLinkDestination = PublishRelay<BooltiViewController.Type>()
+    let navigationDestination = PublishRelay<BooltiViewController.Type>()
 
     func selectTab(index: Int) {
         guard let selectedTab = HomeTab(rawValue: index) else { return }
@@ -43,7 +43,14 @@ final class HomeTabBarViewModel {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(navigateToConcertDetail),
-            name: Notification.Name.DynamicDestination.concertDetail,
+            name: Notification.Name.NavigationDestination.concertDetail,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(navigateToReservationList),
+            name: Notification.Name.NavigationDestination.reservationList,
             object: nil
         )
     }
@@ -59,6 +66,10 @@ final class HomeTabBarViewModel {
     }
 
     @objc func navigateToConcertDetail() {
-        self.dynamicLinkDestination.accept(ConcertListViewController.self)
+        self.navigationDestination.accept(ConcertListViewController.self)
+    }
+
+    @objc func navigateToReservationList() {
+        self.navigationDestination.accept(TicketReservationsViewController.self)
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 환불 내역 필드를 추가했어요.
- 환불 신청 후, 환불 세부 내역으로 pop되게 구현했어요.
- 환불 완료 앱푸시 클릭 시 환불 내역 리스트로 이동하게 구현했어요.
- 안드로이드 패키지명 debug/release 분기처리

푸시/딥링크 탭 시, 목적지까지가는 로직을 수정했어요.
- 각 tab에 한 depth 더 들어가야될 경우, 아래의 enum을 활용하여 모든 정보를 저장하도록 구현했어요.
```swift
 enum NavigationDestination: Codable {
     case reservationList
     case concertDetail(concertId: Int)
     // 추가될 예정
 }
```
- 그리고 실제 push되는 곳에서는 아래와 같이 enum의 값을 통해서 VC를 만들고 push를 해요.
```swift
guard let navigationDestination = UserDefaults.navigationDestination else { return }

if case .concertDetail(let concertID) = navigationDestination {
    let viewController = concertDetailViewControllerFactory(concertID)
    self.navigationController?.pushViewController(viewController, animated: true)
    UserDefaults.navigationDestination = nil
}
```

UserDefaults를 활용하는 이유는 앱이 꺼져있을 경우를 대비해서 구현했어요.

## 관련 이슈
- Resolved: #192
- Resolved: #188 
