### PR TITLE
Chore/#207 close 버튼 위치 변경

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/PosterExpand/PosterExpandViewController.swift
@@ -125,7 +125,7 @@ extension PosterExpandViewController {
     private func configureConstraints() {
         self.closeButton.snp.makeConstraints { make in
             make.size.equalTo(24)
-            make.left.equalToSuperview().inset(20)
+            make.right.equalToSuperview().inset(20)
             make.top.equalTo(view.safeAreaLayoutGuide).inset(10)
         }
         

--- a/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Login/Main/LoginViewController.swift
@@ -195,7 +195,7 @@ extension LoginViewController {
 
         self.closeButton.snp.makeConstraints { make in
             make.top.equalTo(self.view.safeAreaLayoutGuide).inset(10)
-            make.left.equalToSuperview().inset(20)
+            make.right.equalToSuperview().inset(20)
         }
         
         self.headerTitleLabel.snp.makeConstraints { make in


### PR DESCRIPTION
## 작업한 내용
close 버튼 위치를 우측으로 변경했어요!

## 스크린샷
| 포스터 확대 | 로그인 |
|-|-|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-06 at 21 01 29](https://github.com/Nexters/Boolti-iOS/assets/58043306/3071e9af-ae17-4ddf-b1f3-2343f84e4b6a) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-06 at 21 02 41](https://github.com/Nexters/Boolti-iOS/assets/58043306/78d4ad05-6b21-400f-9061-2fa427f1fa51) |
## 관련 이슈
- Resolved: #207 
