### PR TITLE
Feat/#217 딥링크 Android fallBackURL 파라미터 추가

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -292,21 +292,23 @@ extension ConcertDetailViewController {
     }
 
     private func concerDetailDeepLinkURL(_ concertID: Int) -> URL? {
-        // 변경될 예정
-        // https://preview.boolti.in/show/$showId
         guard let link = URL(string: "https://preview.boolti.in/show/\(concertID)") else { return nil }
         let dynamicLinksDomainURIPrefix = AppInfo.booltiDeepLinkPrefix
         guard let linkBuilder = DynamicLinkComponents(
             link: link,
             domainURIPrefix: dynamicLinksDomainURIPrefix
         ) else { return nil }
-
+        
+        // iOS
         linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: AppInfo.bundleID)
+
+        // Android
         #if DEBUG
         linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.androidDebugPackageName)
         #elseif RELEASE
         linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.bundleID)
         #endif
+        linkBuilder.androidParameters?.fallbackURL = link
 
         return linkBuilder.url
     }


### PR DESCRIPTION
## 작업한 내용
- 딥링크 Android fallBackURL 파라미터 추가
  - 안드로이드 폰에서 앱이 없이 링크를 들어가면 플레이스토어가 아니라 웹으로 이동하도록 fallBackURL 파리미터를 추가

## 관련 이슈
- Resolved: #217 
