### PR TITLE
Feat/#223 환불 정책 Remote Config 연동

### DIFF
--- a/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
@@ -16,6 +16,15 @@ enum AppInfo {
     static let booltiAppStoreLink = "itms-apps://itunes.apple.com/app/app-store/\(appId)"
     static let booltiShareLink = "https://apps.apple.com/kr/app/id\(appId)"
     static let booltiDeepLinkPrefix = "https://boolti.page.link"
+    static var reversalPolicy =
+        """
+        • 서비스 내 발권 취소 및 환불은 주최자가 지정한 티켓 판매 기간 내에만 가능하며, 판매 기간 이후 환불은 주최자에게 직접 문의해 주시기 바랍니다.
+        • 초청 티켓의 경우 발권 취소가 불가합니다.
+        • 취소 요청 즉시 취소 완료 처리 및 환불이 진행됩니다.
+        • 환불은 기존 결제 수단으로 진행되며 계좌이체의 경우 결제하신 계좌로 환불이 진행됩니다.
+        • 결제 수단에 따라 환불 완료까지 약 1~5 영업일이 소요될 수 있습니다.
+        • 기타 사항은 카카오톡 채널 @스튜디오불티로 문의해 주시기 바랍니다.
+        """
 
     static let termsPolicyLink = "https://boolti.notion.site/b4c5beac61c2480886da75a1f3afb982"
     static let privacyPolicyLink = "https://boolti.notion.site/5f73661efdcd4507a1e5b6827aa0da70"

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewController.swift
@@ -46,7 +46,7 @@ final class SplashViewController: UIViewController {
         self.configureUI()
         self.configureConstraints()
         self.bind()
-        self.viewModel.checkUpdateRequired()
+        self.viewModel.checkRemoteConfig()
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -42,15 +42,24 @@ final class SplashViewModel {
         navigationDelegate.splashViewModel(self)
     }
     
-    func checkUpdateRequired() {
+    func checkRemoteConfig() {
         self.remoteConfig.fetchAndActivate(completionHandler: { status, error in
             if status == .error { return }
             
             guard let minVersion = self.remoteConfig.configValue(forKey: "MinVersion").stringValue else { return }
             let updateRequired = self.remoteConfig.configValue(forKey: "UpdateRequired").boolValue
-            
+            let jsonReversalPolicy = self.remoteConfig.configValue(forKey: "RefundPolicy").jsonValue
+            self.configureReversalPolicy(jsonStatements: jsonReversalPolicy)
+
             self.output.updateRequired.accept(updateRequired &&
                                        AppInfo.appVersion?.compare(minVersion, options: .numeric) == .orderedAscending)
         })
+    }
+
+    private func configureReversalPolicy(jsonStatements: Any?) {
+        guard let revesalPolicyStatements = jsonStatements as? [String] else { return }
+        let bulletAddedStatements = revesalPolicyStatements.map { "• \($0)" }
+        let reversalPolicy = bulletAddedStatements.joined(separator: "\n")
+        AppInfo.reversalPolicy = reversalPolicy
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -37,7 +37,6 @@ final class SplashViewModel {
         setting.minimumFetchInterval = 0
         #endif
         remoteConfig.configSettings = setting
-        remoteConfig.setDefaults(fromPlist: "GoogleService-Info") // 없어도 되지 않나?
     }
 
     func navigateToHomeTab() {

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -33,7 +33,9 @@ final class SplashViewModel {
     
     func initRemoteConfig() {
         let setting = RemoteConfigSettings()
+        #if DEBUG
         setting.minimumFetchInterval = 0
+        #endif
         remoteConfig.configSettings = setting
         remoteConfig.setDefaults(fromPlist: "GoogleService-Info") // 없어도 되지 않나?
     }

--- a/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Splash/SplashViewModel.swift
@@ -35,7 +35,7 @@ final class SplashViewModel {
         let setting = RemoteConfigSettings()
         setting.minimumFetchInterval = 0
         remoteConfig.configSettings = setting
-        remoteConfig.setDefaults(fromPlist: "GoogleService-Info")
+        remoteConfig.setDefaults(fromPlist: "GoogleService-Info") // 없어도 되지 않나?
     }
 
     func navigateToHomeTab() {

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
@@ -47,7 +47,7 @@ final class ReversalPolicyView: UIStackView {
     }()
 
     private lazy var reversalPolicyLabel: BooltiPaddingLabel = {
-        let label = BooltiPaddingLabel(padding: UIEdgeInsets(top: 0, left: 30, bottom: 24, right: 20))
+        let label = BooltiPaddingLabel(padding: UIEdgeInsets(top: 0, left: 25, bottom: 24, right: 20))
         label.text = AppInfo.reversalPolicy
         label.numberOfLines = 0
         label.setHeadIndent()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/ReversalPolicyView.swift
@@ -13,6 +13,10 @@ import RxRelay
 
 final class ReversalPolicyView: UIStackView {
 
+    private enum Constants {
+        static let booltiDomain = "@스튜디오불티"
+    }
+
     private let disposeBag = DisposeBag()
     private var isCollapsed: Bool = false {
         didSet {
@@ -43,16 +47,11 @@ final class ReversalPolicyView: UIStackView {
     }()
 
     private lazy var reversalPolicyLabel: BooltiPaddingLabel = {
-        let label = BooltiPaddingLabel(padding: UIEdgeInsets(top: 0, left: 20, bottom: 24, right: 20))
-        label.text = """
-        • 티켓 판매 기간 내 발권 취소 및 환불은 서비스 내 처리가 가능하며, 판매 기간 이후에는 주최자에게 직접 연락 바랍니다.
-        • 티켓 판매 기간 내 환불 신청은 발권 후 마이 > 예매 내역 > 예매 상세에서 가능합니다.
-        • 계좌 이체를 통한 환불은 환불 계좌 정보가 필요하며 영업일 기준 약 1~2일이 소요됩니다.
-        • 환불 수수료는 부과되지 않습니다.
-        • 기타 사항은 카카오톡 채널 @스튜디오불티로 문의 부탁드립니다.
-        """
+        let label = BooltiPaddingLabel(padding: UIEdgeInsets(top: 0, left: 30, bottom: 24, right: 20))
+        label.text = AppInfo.reversalPolicy
         label.numberOfLines = 0
         label.setHeadIndent()
+        label.setUnderLine(to: Constants.booltiDomain)
         label.font = .body1
         label.textColor = .grey50
         label.isHidden = true


### PR DESCRIPTION
## 작업한 내용
- 환불 정책 Remote Config 연동을 진행했어요.
  - 어디서 fetch할 지 고민했는데, 이미 app version을 확인할 때 fetch를 해와서 그때 같이 환불 정책을 fetch해오도록 구현했어요.
  - default 환불 정책 value은 AppInfo에 전역변수로 넣어두었어요.(따로 앱에서 활용하는 전역 변수를 만들까 고민했었어요.)
  - minimumFetchInterval = 0 값을 debug 모드일 때만 활용하도록 변경했어요. [링크](https://firebase.google.com/docs/remote-config/get-started?platform=ios&hl=ko&_gl=1*3cr6gl*_up*MQ..*_ga*MTAyMzQxNzU5MC4xNzEzNTEyOTc1*_ga_CW55HF8NVT*MTcxMzUxMjk3NS4xLjAuMTcxMzUxMjk3NS4wLjAuMA..#throttling)
  - 기본적으로 12시간에 한번씩 fetch해오기로 되어있는데, 여러 유저가 너무 짧은 시간안에 여러 번 fetch를 해오면 안된다고 해서 일단 debug 모드에서만 짧은 시간안에 update를 할 수도 있도록 구현했어요. 근데, 이렇게 구현하는 게 맞는 지는 주현이랑 한번 크로스 체크를 해봐야될 거 같아요.(개발 문서만 보고는 확실치가 않아서..)
 
### ⁉️ 궁금한 점
- plist에 있는 값을 default 값으로 설정하기?
  - 공식문서를 보면 plist에 있는 값으로 백엔드에 값을 fetch해오기 전에 기본 값으로 해놓는다고 하는데 현재 상황에서 필요한 값인 지가 궁금해요! 
  - 아마 받아오지 못할 경우, plist에 있는 값으로 기본 값으로 설정을 한다는 거 같은데, Plist에 있는 key과 console의 key 값이 달라서 주현이는 처음 plist를 만들었을 때 어떤 의도 구현한 건 지 궁금해요!
```swift
// in SplashViewModel
remoteConfig.setDefaults(fromPlist: "GoogleService-Info")
```
## 스크린샷
<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/416ca41f-e2c1-44c3-b763-5a1fce333772" height="500">


## 관련 이슈

- Resolved: #223 
