### PR TITLE
Feature/#227 결제 완료뷰 버튼으로 탭 이동 & 취소/환불 remote config연결 & 결제 상세 url 연결

### DIFF
--- a/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/AppInfo.swift
@@ -29,4 +29,6 @@ enum AppInfo {
     static let termsPolicyLink = "https://boolti.notion.site/b4c5beac61c2480886da75a1f3afb982"
     static let privacyPolicyLink = "https://boolti.notion.site/5f73661efdcd4507a1e5b6827aa0da70"
     static let refundPolicyLink = "https://boolti.notion.site/d2a89e2c19824c60bb1e928370d16989"
+    static let informationCollectionPolicyLink = "https://boolti.notion.site/00259d85983c4ba8a987a374e2615396"
+    static let informationOfferPolicyLink = "https://boolti.notion.site/3-354880c7d75e424486b7974e5cc8bcad?pvs=4"
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
@@ -101,6 +101,7 @@ final class TicketingCompletionViewController: BooltiViewController {
         super.viewDidLoad()
         self.configureUI()
         self.configureConstraints()
+        self.bindComponents()
         self.bindInput()
         self.bindOutput()
     }
@@ -150,6 +151,34 @@ extension TicketingCompletionViewController {
         stackView.spacing = 16
         stackView.addArrangedSubviews(stackViews)
         return stackView
+    }
+    
+    private func bindComponents() {
+        self.openReservationButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.changeTab(to: .myPage)
+                
+                UserDefaults.landingDestination = .reservationList
+                NotificationCenter.default.post(
+                    name: Notification.Name.LandingDestination.reservationList,
+                    object: nil
+                )
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.openTicketButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.changeTab(to: .ticket)
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func changeTab(to tab: HomeTab) {
+        NotificationCenter.default.post(
+            name: Notification.Name.didTabBarSelectedIndexChanged,
+            object: nil,
+            userInfo: ["tabBarIndex" : tab.rawValue]
+        )
     }
     
     private func bindInput() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
@@ -178,6 +178,10 @@ extension TicketingDetailViewController {
             .map { $0.replacingOccurrences(of: "-", with: "") }
             .bind(to: self.viewModel.input.depositorPhoneNumber)
             .disposed(by: self.disposeBag)
+        
+        self.invitationCodeView.codeTextField.rx.text.orEmpty
+            .bind(to: self.viewModel.input.invitationCode)
+            .disposed(by: self.disposeBag)
     }
     
     private func bindOutputs() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
@@ -287,23 +287,18 @@ extension TicketingDetailViewController {
             .disposed(by: self.disposeBag)
     }
     
-    // TODO: - 보기 버튼 눌렀을 때 각각의 url로 이동
     private func bindAgreeView() {
         self.agreeView.didCollectionOpenButtonTap()
             .emit(with: self) { owner, _ in
-                debugPrint("collection")
+                guard let url = URL(string: AppInfo.informationCollectionPolicyLink) else { return }
+                owner.openSafari(with: url)
             }
             .disposed(by: self.disposeBag)
         
         self.agreeView.didOfferOpenButtonTap()
             .emit(with: self) { owner, _ in
-                debugPrint("offer")
-            }
-            .disposed(by: self.disposeBag)
-        
-        self.agreeView.didAgenciesOpenButtonTap()
-            .emit(with: self) { owner, _ in
-                debugPrint("agencies")
+                guard let url = URL(string: AppInfo.informationOfferPolicyLink) else { return }
+                owner.openSafari(with: url)
             }
             .disposed(by: self.disposeBag)
         

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/AgreeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/AgreeView.swift
@@ -32,9 +32,6 @@ final class AgreeView: UIView {
     private lazy var offerButton = self.makeAgreeRowButton(type: .check, title: "[필수] 개인정보 제 3자 정보 제공 동의")
     private lazy var offerOpenButton = self.makeOpenButton()
     
-    private lazy var agenciesButton = self.makeAgreeRowButton(type: .check, title: "[필수] 결제대행 서비스 이용약관 동의")
-    private lazy var agenciesOpenButton = self.makeOpenButton()
-    
     // MARK: Initailizer
     
     override init(frame: CGRect) {
@@ -93,7 +90,6 @@ extension AgreeView {
                 owner.allAgreeButton.isSelected.toggle()
                 owner.collectionButton.isSelected.toggle()
                 owner.offerButton.isSelected.toggle()
-                owner.agenciesButton.isSelected.toggle()
                 
                 owner.isAllAgreeButtonSelected.accept(owner.allAgreeButton.isSelected)
             })
@@ -108,10 +104,6 @@ extension AgreeView {
         return self.offerOpenButton.rx.tap.asSignal()
     }
     
-    func didAgenciesOpenButtonTap() -> Signal<Void> {
-        return self.agenciesOpenButton .rx.tap.asSignal()
-    }
-    
 }
 
 // MARK: - UI
@@ -123,9 +115,7 @@ extension AgreeView {
                           self.collectionButton,
                           self.collectionOpenButton,
                           self.offerButton,
-                          self.offerOpenButton,
-                          self.agenciesButton,
-                          self.agenciesOpenButton])
+                          self.offerOpenButton])
         
         self.backgroundColor = .grey90
     }
@@ -133,7 +123,7 @@ extension AgreeView {
     
     private func configureConstraints() {
         self.snp.makeConstraints { make in
-            make.height.equalTo(164)
+            make.height.equalTo(136)
         }
       
         self.allAgreeButton.snp.makeConstraints { make in
@@ -158,17 +148,6 @@ extension AgreeView {
         self.offerOpenButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(20)
             make.centerY.equalTo(self.offerButton)
-        }
-        
-        self.agenciesButton.snp.makeConstraints { make in
-            make.leading.equalTo(self.allAgreeButton)
-            make.top.equalTo(self.offerButton.snp.bottom).offset(4)
-            make.bottom.equalToSuperview().inset(20)
-        }
-        
-        self.agenciesOpenButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(20)
-            make.centerY.equalTo(self.agenciesButton)
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/PolicyView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/PolicyView.swift
@@ -33,18 +33,11 @@ final class PolicyView: UIView {
         return button
     }()
     
-    // TODO: - remote config로 변경
     private let policyLabel: BooltiUILabel = {
         let label = BooltiUILabel()
         label.font = .body1
         label.textColor = .grey50
-        label.text = """
-        • 티켓 판매 기간 내 발권 취소 및 환불은 서비스 내 처리가 가능하며, 판매 기간 이후에는 주최자에게 직접 연락 바랍니다.
-        • 티켓 판매 기간 내 환불 신청은 발권 후 마이 > 예매 내역 > 예매 상세에서 가능합니다.
-        • 계좌 이체를 통한 환불은 환불 계좌 정보가 필요하며 영업일 기준 약 1~2일이 소요됩니다.
-        • 환불 수수료는 부과되지 않습니다.
-        • 기타 사항은 카카오톡 채널 @스튜디오불티로 문의 부탁드립니다.
-        """
+        label.text = AppInfo.reversalPolicy
         label.setHeadIndent()
         label.isHidden = true
         label.numberOfLines = 0

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketList/TicketListViewController.swift
@@ -92,7 +92,7 @@ final class TicketListViewController: BooltiViewController {
         self.configureUI()
         self.configureLoadingIndicatorView()
         self.configureCollectionViewDatasource()
-        self.bindUIComponenets()
+        self.bindUIComponents()
         self.bindViewModel()
     }
 
@@ -193,7 +193,7 @@ final class TicketListViewController: BooltiViewController {
         }
     }
 
-    private func bindUIComponenets() {
+    private func bindUIComponents() {
         self.collectionView.rx
             .itemSelected
             .asDriver()


### PR DESCRIPTION
## 작업한 내용
> Feat
- 결제 상세의 동의 항목 '보기'를 눌렀을 때 노션 페이지가 열리도록 url을 넣었어요.
- 결제 완료뷰에서 하단의 예매내역보기 / 티켓 보기 버튼 각각 눌렀을 때의 navigate를 연결했어요
- 결제 상세의 취소/환불 규정 remote config로 변경했어요.

> Fix
- 기존에 초대코드 binding이 되고있지 않았던 오류를 수정했어요.

지금 올라와있는 Pr 머지되면 컨플릭트까지 해결하고 다시 노티줄게요~!!

## 스크린샷
| 노션 페이지 연결 | 예매 내역보기 | 티켓 보기 |
|-|-|-|
| ![RPReplay_Final1714404825](https://github.com/Nexters/Boolti-iOS/assets/58043306/84977f20-be8e-40fb-950f-8e35b9dda5ab) |  ![RPReplay_Final1714404862](https://github.com/Nexters/Boolti-iOS/assets/58043306/1df1fd29-b454-4053-b0b5-01848f81d796) | ![RPReplay_Final1714404999](https://github.com/Nexters/Boolti-iOS/assets/58043306/d9a67001-1712-44fd-b039-c692bf76444d) |

## 관련 이슈
- Resolved: #227 
