### PR TITLE
Feature/#226 결제 에러 핸들링

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		220013D92BE39F62007FF9E6 /* TicketingErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */; };
 		221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */; };
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
@@ -315,6 +316,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorType.swift; sourceTree = "<group>"; };
 		221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
@@ -1752,6 +1754,7 @@
 			children = (
 				87C7594B2BA93EA40009A83E /* NotificationMessage.swift */,
 				87826AED2BBFF7F2005176D4 /* LandingDestination.swift */,
+				220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2074,6 +2077,7 @@
 				87D2FAC02B7003970027FBE1 /* ReversalPolicyView.swift in Sources */,
 				84975BF82B611EA500F903E7 /* UIFont+.swift in Sources */,
 				84625A0E2B63B2E600CC9077 /* TicketSelectionDIContainer.swift in Sources */,
+				220013D92BE39F62007FF9E6 /* TicketingErrorType.swift in Sources */,
 				84D1C3872B7A14F300527998 /* CheckInvitationCodeResponseDTO.swift in Sources */,
 				22DD8C992BD499E90083622C /* OrderPaymentRequestDTO.swift in Sources */,
 				8757BAA02B5FDDAB008503B5 /* LoginViewDIContainer.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2328,7 +2328,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2345,7 +2345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2369,7 +2369,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2386,7 +2386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */; };
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
+		2233EAAF2BE142C900A315BF /* ErrorResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAE2BE142C900A315BF /* ErrorResponseDTO.swift */; };
 		226D42BF2B9EBA3E00680198 /* BooltiBusinessInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */; };
 		22CDB2C62BA2635E00D2077D /* BusinessInfoDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB2C52BA2635E00D2077D /* BusinessInfoDIContainer.swift */; };
 		22CF3A2F2BB51A710094711C /* SelectedSalesTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF3A2E2BB51A710094711C /* SelectedSalesTicketView.swift */; };
@@ -317,6 +318,7 @@
 		221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
+		2233EAAE2BE142C900A315BF /* ErrorResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseDTO.swift; sourceTree = "<group>"; };
 		226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiBusinessInfoView.swift; sourceTree = "<group>"; };
 		22CDB2C52BA2635E00D2077D /* BusinessInfoDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoDIContainer.swift; sourceTree = "<group>"; };
 		22CF3A2E2BB51A710094711C /* SelectedSalesTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSalesTicketView.swift; sourceTree = "<group>"; };
@@ -975,6 +977,7 @@
 		84781C792B5BEBDA00D37921 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				2233EAAE2BE142C900A315BF /* ErrorResponseDTO.swift */,
 				87CE4F662B8DD93A007A0C8F /* PushNotification */,
 				84781C7A2B5BEBE500D37921 /* Auth */,
 				84DC6F632B728792001F9576 /* Concert */,
@@ -1962,6 +1965,7 @@
 				848CBF032B65458900239303 /* Int+.swift in Sources */,
 				84886E902B70A7D4005D2329 /* ContentInfoView.swift in Sources */,
 				84975BE92B60E04500F903E7 /* AuthAPI.swift in Sources */,
+				2233EAAF2BE142C900A315BF /* ErrorResponseDTO.swift in Sources */,
 				8730F0142B7B10A300D4F339 /* TicketRefundReasonDIContainer.swift in Sources */,
 				840B39552B7667D500E7F8C8 /* ConcertCollectionViewCell.swift in Sources */,
 				84781CA32B5BF6BF00D37921 /* RootViewModel.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Enums/TicketingErrorType.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/TicketingErrorType.swift
@@ -1,0 +1,20 @@
+//
+//  TicketingErrorType.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 5/2/24.
+//
+
+enum TicketingErrorType {
+    case noQuantity
+    case tossError
+
+    init?(rawValue: String) {
+        switch rawValue {
+        case "NO_REMAINING_QUANTITY":
+            self = .noQuantity
+        default:
+            self = .tossError
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/Network/DTO/ErrorResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/ErrorResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  ErrorResponseDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 5/1/24.
+//
+
+struct ErrorResponseDTO: Decodable {
+    let errorTraceId: String
+    let type: String
+    let detail: String
+}

--- a/Boolti/Boolti/Sources/UILayer/Common/BooltiPopupView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Common/BooltiPopupView.swift
@@ -14,10 +14,43 @@ final class BooltiPopupView: UIView {
     
     // MARK: Properties
     
-    enum PopupType: String {
-        case networkError = "네트워크 오류가 발생했습니다\n잠시후 다시 시도해주세요"
-        case refreshTokenHasExpired = "로그인 세션이 만료되었습니다\n앱을 다시 시작해주세요"
-        case accountRemoveCancelled = "탈퇴 후 30일 이내에 로그인하여,\n계정 삭제가 취소되었어요\n불티를 다시 찾아주셔서 감사해요!"
+    enum PopupType {
+        case networkError
+        case refreshTokenHasExpired
+        case accountRemoveCancelled
+        case soldoutBeforePayment
+        case ticketingFailed
+        
+        var title: String {
+            switch self {
+            case .networkError: 
+                "네트워크 오류가 발생했습니다\n잠시후 다시 시도해주세요"
+            case .refreshTokenHasExpired: 
+                "로그인 세션이 만료되었습니다\n앱을 다시 시작해주세요"
+            case .accountRemoveCancelled: 
+                "탈퇴 후 30일 이내에 로그인하여,\n계정 삭제가 취소되었어요\n불티를 다시 찾아주셔서 감사해요!"
+            case .soldoutBeforePayment, .ticketingFailed:
+                "결제에 실패했어요"
+            }
+        }
+        
+        var description: String? {
+            switch self {
+            case .soldoutBeforePayment, .ticketingFailed:
+                "예매 진행 중 오류가 발생하였습니다.\n다시 시도해 주세요"
+            default:
+                nil
+            }
+        }
+        
+        var buttonTitle: String {
+            switch self {
+            case .soldoutBeforePayment, .ticketingFailed:
+                "다시 예매하기"
+            default:
+                "확인"
+            }
+        }
     }
     
     let disposeBag = DisposeBag()
@@ -46,6 +79,14 @@ final class BooltiPopupView: UIView {
         return label
     }()
     
+    private let descriptionLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .body1
+        label.numberOfLines = 0
+        label.textColor = .grey50
+        return label
+    }()
+    
     private let confirmButton = BooltiButton(title: "확인")
 
     init() {
@@ -64,8 +105,11 @@ final class BooltiPopupView: UIView {
 extension BooltiPopupView {
     
     func showPopup(with type: PopupType) {
-        self.titleLabel.text = type.rawValue
+        self.titleLabel.text = type.title
         self.titleLabel.setAlignment(.center)
+        self.descriptionLabel.text = type.description
+        self.descriptionLabel.setAlignment(.center)
+        self.confirmButton.setTitle(type.buttonTitle, for: .normal)
     
         self.popupType = type
         self.isHidden = false
@@ -84,6 +128,7 @@ extension BooltiPopupView {
         self.addSubviews([self.dimmedBackgroundView,
                           self.popupBackgroundView,
                           self.titleLabel,
+                          self.descriptionLabel,
                           self.confirmButton])
         self.isHidden = true
     }
@@ -103,8 +148,13 @@ extension BooltiPopupView {
             make.horizontalEdges.equalTo(self.popupBackgroundView).inset(20)
         }
         
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(4)
+            make.horizontalEdges.equalTo(self.titleLabel)
+        }
+        
         self.confirmButton.snp.makeConstraints { make in
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(24)
+            make.top.equalTo(self.descriptionLabel.snp.bottom).offset(20)
             make.horizontalEdges.bottom.equalTo(self.popupBackgroundView).inset(20)
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
@@ -17,6 +17,7 @@ final class TicketingConfirmViewController: BooltiViewController {
     private let viewModel: TicketingConfirmViewModel
     private let disposeBag = DisposeBag()
     var onDismiss: ((TicketingEntity) -> ())?
+    var onDismissOrderFailure: (() -> ())?
     
     // MARK: UI Component
     
@@ -160,6 +161,13 @@ extension TicketingConfirmViewController {
             }
             .disposed(by: self.disposeBag)
             
+        self.viewModel.output.didFreeOrderPaymentFailed
+            .subscribe(with: self) { owner, _ in
+                owner.dismiss(animated: true) {
+                    self.onDismissOrderFailure?()
+                }
+            }
+            .disposed(by: self.disposeBag)
     }
     
     private func bindUIComponents() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewModel.swift
@@ -24,6 +24,7 @@ final class TicketingConfirmViewModel {
     struct Output {
         let navigateToTossPayments = PublishSubject<Void>()
         let navigateToCompletion = PublishSubject<Void>()
+        let didFreeOrderPaymentFailed = PublishSubject<Void>()
     }
 
     var input: Input
@@ -81,10 +82,12 @@ extension TicketingConfirmViewModel {
         self.ticketingRepository.freeTicketing(selectedTicket: self.ticketingEntity.selectedTicket,
                                                ticketHolderName: self.ticketingEntity.ticketHolder.name,
                                                ticketHolderPhoneNumber: self.ticketingEntity.ticketHolder.phoneNumber)
-        .do { self.ticketingEntity.reservationId = $0.reservationId }
-        .subscribe(with: self) { owner, _ in
+        .subscribe(with: self, onSuccess: { owner, response in
+            owner.ticketingEntity.reservationId = response.reservationId
             owner.output.navigateToCompletion.onNext(())
-        }
+        }, onFailure: { owner, error in
+            owner.output.didFreeOrderPaymentFailed.onNext(())
+        })
         .disposed(by: self.disposeBag)
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
@@ -220,6 +220,11 @@ extension TicketingDetailViewController {
                         owner.present(tossVC, animated: true)
                     }
                 }
+                
+                ticketingConfirmVC.onDismissOrderFailure = {
+                    owner.popupView.showPopup(with: .soldoutBeforePayment)
+                }
+                
                 owner.present(ticketingConfirmVC, animated: true)
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
@@ -88,6 +88,8 @@ final class TicketingDetailViewController: BooltiViewController {
     
     private let payButton = BooltiButton(title: "\(0.formattedCurrency())원 결제하기")
     
+    private let popupView = BooltiPopupView()
+    
     // MARK: Init
     
     init(
@@ -154,6 +156,7 @@ extension TicketingDetailViewController {
         self.bindUserInputView()
         self.bindAgreeView()
         self.bindBusinessInfoView()
+        self.bindPopupView()
     }
     
     private func bindInputs() {
@@ -188,10 +191,10 @@ extension TicketingDetailViewController {
         self.viewModel.output.navigateToConfirm
             .bind(with: self) { owner, _ in
                 guard let ticketingEntity = owner.viewModel.output.ticketingEntity else { return }
-                
+
                 let ticketingConfirmVC = owner.ticketingConfirmViewControllerFactory(ticketingEntity)
                 ticketingConfirmVC.modalPresentationStyle = .overFullScreen
-                
+
                 ticketingConfirmVC.onDismiss = { ticketingEntity in
                     if ticketingEntity.selectedTicket.price == 0 {
                         let viewController = owner.ticketingCompletionViewControllerFactory(ticketingEntity.reservationId)
@@ -199,20 +202,24 @@ extension TicketingDetailViewController {
                     } else {
                         let tossVC = owner.tossPayementsViewControllerFactory(ticketingEntity)
                         tossVC.modalPresentationStyle = .overFullScreen
-    
+
                         tossVC.onDismissOrderSuccess = { ticketingEntity in
                             let viewController = owner.ticketingCompletionViewControllerFactory(ticketingEntity.reservationId)
                             owner.navigationController?.pushViewController(viewController, animated: true)
                         }
-    
-                        tossVC.onDismissOrderFailure = {
-                            // TODO: - 실패 팝업창 띄우기
+
+                        tossVC.onDismissOrderFailure = { error in
+                            switch error {
+                            case .noQuantity:
+                                owner.popupView.showPopup(with: .soldoutBeforePayment)
+                            case .tossError:
+                                owner.popupView.showPopup(with: .ticketingFailed)
+                            }
                         }
-    
+
                         owner.present(tossVC, animated: true)
                     }
                 }
-                
                 owner.present(ticketingConfirmVC, animated: true)
             }
             .disposed(by: self.disposeBag)
@@ -317,6 +324,21 @@ extension TicketingDetailViewController {
             .disposed(by: self.disposeBag)
     }
     
+    private func bindPopupView() {
+        self.popupView.didConfirmButtonTap()
+            .emit(with: self) { owner, _ in
+                switch owner.popupView.popupType {
+                case .soldoutBeforePayment:
+                    owner.navigationController?.popViewController(animated: true)
+                case .ticketingFailed:
+                    owner.popupView.isHidden = true
+                default:
+                    break
+                }
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
     private func configureKeyboardNotification() {
         NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: nil) { notification in
             guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
@@ -367,7 +389,11 @@ extension TicketingDetailViewController: UIScrollViewDelegate {
 extension TicketingDetailViewController {
     
     private func configureUI() {
-        self.view.addSubviews([self.scrollView, self.navigationBar, self.buttonBackgroundView, self.payButton])
+        self.view.addSubviews([self.scrollView,
+                               self.navigationBar,
+                               self.buttonBackgroundView,
+                               self.payButton,
+                               self.popupView])
         self.scrollView.addSubviews([self.stackView])
         
         self.view.backgroundColor = .grey95
@@ -400,6 +426,10 @@ extension TicketingDetailViewController {
         self.payButton.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(20)
             make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-8)
+        }
+        
+        self.popupView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TossPayments/TossPaymentViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TossPayments/TossPaymentViewController.swift
@@ -56,7 +56,7 @@ final class TossPaymentViewController: BooltiViewController {
         
         self.widget = PaymentWidget(
             clientKey: Environment.TOSS_PAYMENTS_KEY,
-            customerKey: self.viewModel.ticketingEntity.orderId ?? ""
+            customerKey: "user-\(UserDefaults.userId)"
         )
         
         super.init()

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TossPayments/TossPaymentViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TossPayments/TossPaymentViewController.swift
@@ -19,7 +19,7 @@ final class TossPaymentViewController: BooltiViewController {
     private let widget: PaymentWidget
     
     var onDismissOrderSuccess: ((TicketingEntity) -> ())?
-    var onDismissOrderFailure: (() -> ())?
+    var onDismissOrderFailure: ((TicketingErrorType) -> ())?
     
     // MARK: UI Component
     
@@ -125,6 +125,14 @@ extension TossPaymentViewController {
                 }
             }
             .disposed(by: self.disposeBag)
+        
+        self.viewModel.output.didOrderPaymentFailed
+            .bind(with: self) { owner, error in
+                owner.dismiss(animated: true) {
+                    owner.onDismissOrderFailure?(error)
+                }
+            }
+            .disposed(by: self.disposeBag)
     }
     
 }
@@ -139,7 +147,7 @@ extension TossPaymentViewController: TossPaymentsDelegate {
     
     func handleFailResult(_ fail: TossPaymentsResult.Fail) {
         self.dismiss(animated: true) {
-            self.onDismissOrderFailure?()
+            self.onDismissOrderFailure?(.tossError)
         }
     }
     
@@ -151,10 +159,6 @@ extension TossPaymentViewController: TossPaymentsWidgetStatusDelegate {
     
     func didReceivedLoad(_ name: String) {
         self.payButton.isHidden = false
-    }
-    
-    func didReceiveFail(_ name: String, fail: TossPaymentsResult.Fail) {
-        self.showToast(message: "결제 정보를 입력해주세요")
     }
     
 }


### PR DESCRIPTION
## 작업한 내용
- 결제 에러 핸들링을 진행했어요.
    - 성공 / 실패에 따라 클로저를 만들어주었어요.
- 공통 popupView에 subTitle이 들어갈 수 있도록 수정했어요.
    - 나중에 popupView를 직접 만들고 있는 뷰들 리팩토링 하면 좋을 것 같아요~!!

## 스크린샷
<img src=https://github.com/Nexters/Boolti-iOS/assets/58043306/6db824d7-d485-4e3b-9fcc-925d6dc2a69f width=300 height=650>

## 관련 이슈
- Resolved: #226 
