### PR TITLE
Fix/#231 이미지뷰 영역 오류 수정

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/Views/ConcertPosterView.swift
@@ -73,6 +73,7 @@ extension ConcertPosterView {
             let imageView = UIImageView()
             imageView.setImage(with: images[index].path)
             imageView.contentMode = .scaleAspectFill
+            imageView.clipsToBounds = true
 
             let positionX = self.scrollViewWidth * CGFloat(index)
             imageView.frame = CGRect(x: positionX, y: 0, width: self.scrollViewWidth, height: self.scrollViewHeight)


### PR DESCRIPTION
## 작업한 내용
- 이미지 비율에 따라 영역이 제대로 잡히지 않는 오류를 수정했어요.

## 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2024-05-01 at 15 19 06](https://github.com/Nexters/Boolti-iOS/assets/58043306/7451591a-bec9-4023-bfed-c5b2dde180f7)


## 관련 이슈
- Resolved: #231
