### PR TITLE
Fix/#237 품절 에러 핸들링 오류 수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */; };
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
-		2233EAAF2BE142C900A315BF /* ErrorResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAE2BE142C900A315BF /* ErrorResponseDTO.swift */; };
+		2233EAAF2BE142C900A315BF /* TicketingErrorResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */; };
 		226D42BF2B9EBA3E00680198 /* BooltiBusinessInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */; };
 		22CDB2C62BA2635E00D2077D /* BusinessInfoDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB2C52BA2635E00D2077D /* BusinessInfoDIContainer.swift */; };
 		22CF3A2F2BB51A710094711C /* SelectedSalesTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF3A2E2BB51A710094711C /* SelectedSalesTicketView.swift */; };
@@ -320,7 +320,7 @@
 		221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
-		2233EAAE2BE142C900A315BF /* ErrorResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseDTO.swift; sourceTree = "<group>"; };
+		2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorResponseDTO.swift; sourceTree = "<group>"; };
 		226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiBusinessInfoView.swift; sourceTree = "<group>"; };
 		22CDB2C52BA2635E00D2077D /* BusinessInfoDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoDIContainer.swift; sourceTree = "<group>"; };
 		22CF3A2E2BB51A710094711C /* SelectedSalesTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSalesTicketView.swift; sourceTree = "<group>"; };
@@ -672,6 +672,7 @@
 		22DD8C862BD288DD0083622C /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */,
 				8453D7FB2B7539270048F103 /* SalesTicketResponseDTO.swift */,
 				84D1C3802B7938CB00527998 /* TicketingResponseDTO.swift */,
 				84D1C3862B7A14F300527998 /* CheckInvitationCodeResponseDTO.swift */,
@@ -979,7 +980,6 @@
 		84781C792B5BEBDA00D37921 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
-				2233EAAE2BE142C900A315BF /* ErrorResponseDTO.swift */,
 				87CE4F662B8DD93A007A0C8F /* PushNotification */,
 				84781C7A2B5BEBE500D37921 /* Auth */,
 				84DC6F632B728792001F9576 /* Concert */,
@@ -1968,7 +1968,7 @@
 				848CBF032B65458900239303 /* Int+.swift in Sources */,
 				84886E902B70A7D4005D2329 /* ContentInfoView.swift in Sources */,
 				84975BE92B60E04500F903E7 /* AuthAPI.swift in Sources */,
-				2233EAAF2BE142C900A315BF /* ErrorResponseDTO.swift in Sources */,
+				2233EAAF2BE142C900A315BF /* TicketingErrorResponseDTO.swift in Sources */,
 				8730F0142B7B10A300D4F339 /* TicketRefundReasonDIContainer.swift in Sources */,
 				840B39552B7667D500E7F8C8 /* ConcertCollectionViewCell.swift in Sources */,
 				84781CA32B5BF6BF00D37921 /* RootViewModel.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Enums/TicketingErrorType.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/TicketingErrorType.swift
@@ -11,7 +11,7 @@ enum TicketingErrorType {
 
     init?(rawValue: String) {
         switch rawValue {
-        case "NO_REMAINING_QUANTITY":
+        case "No remaining quantity":
             self = .noQuantity
         default:
             self = .tossError

--- a/Boolti/Boolti/Sources/Network/DTO/Ticketing/Response/TicketingErrorResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Ticketing/Response/TicketingErrorResponseDTO.swift
@@ -5,7 +5,9 @@
 //  Created by Juhyeon Byun on 5/1/24.
 //
 
-struct ErrorResponseDTO: Decodable {
+struct TicketingErrorResponseDTO: Decodable {
+    let tossMessage: String
+    let orderId: String
     let errorTraceId: String
     let type: String
     let detail: String

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/Cells/TicketTypeTableViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/Cells/TicketTypeTableViewCell.swift
@@ -56,7 +56,7 @@ final class TicketTypeTableViewCell: UITableViewCell {
     }
     
     override func prepareForReuse() {
-        self.resetData()
+        self.resetCell()
     }
 }
 
@@ -82,11 +82,15 @@ extension TicketTypeTableViewCell {
         }
     }
     
-    func resetData() {
+    func resetCell() {
         self.nameLabel.text = nil
-        self.inventoryLabel.text = nil
+        self.nameLabel.textColor = .grey05
+        
         self.priceLabel.text = nil
-        self.inventoryLabel.isHidden = true
+        self.priceLabel.textColor = .grey05
+        
+        self.inventoryLabel.text = nil
+        self.inventoryLabel.isHidden = false
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TossPayments/TossPaymentsViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TossPayments/TossPaymentsViewModel.swift
@@ -66,9 +66,12 @@ extension TossPaymentsViewModel {
             }, onFailure: { owner, error in
                 guard let error = error as? MoyaError else { return }
                 guard let response = error.response else { return }
-                guard let decodedData = try? JSONDecoder().decode(ErrorResponseDTO.self, from: response.data) else { return }
-
-                guard let ticketingError = TicketingErrorType(rawValue: decodedData.type) else { return }
+                guard let decodedData = try? JSONDecoder().decode(TicketingErrorResponseDTO.self, from: response.data) else {
+                    owner.output.didOrderPaymentFailed.onNext(.tossError)
+                    return
+                }
+                
+                guard let ticketingError = TicketingErrorType(rawValue: decodedData.tossMessage) else { return }
                 owner.output.didOrderPaymentFailed.onNext(ticketingError)
             })
             .disposed(by: self.disposeBag)


### PR DESCRIPTION
## 작업한 내용
- api 디코딩 오류를 수정했어요. 실패 시 확인해보니 이런 json이 오고있어서 DTO를 수정했어요.

```json
{
  "tossMessage" : "No remaining quantity",
  "orderId" : "3178d264-139e-40ee-bee6-0b2b6ac91e15",
  "detail" : "payment approval failed",
  "errorTraceId" : "1b6a0921-cd28-41fa-929e-3d1e459c20f3",
  "type" : "APPROVE_PAYMENT_FAILED"
}
```

- 티켓 선택 뷰에서 cell 재사용 이슈가 있어서 cell의 초기화 함수를 수정했어요.

## 스크린샷
https://github.com/Nexters/Boolti-iOS/assets/58043306/b25ad0a6-3673-49df-9dee-a422f5ce6198


## 관련 이슈
- Resolved: #237 
