### PR TITLE
Chore/#236 초청티켓 결제 시 팝업 창 불필요한 값 수정 및 결제 완료 Scene API 호출 시점 변경

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import RxSwift
+import RxAppState
 
 final class TicketingCompletionViewController: BooltiViewController {
     
@@ -194,11 +195,19 @@ extension TicketingCompletionViewController {
                 self.navigationController?.popToViewController(viewControllers[viewControllers.count - 3], animated: true)
             }
             .disposed(by: self.disposeBag)
+
+        self.rx.viewWillAppear
+            .asDriver(onErrorDriveWith: .never())
+            .drive(with: self) { owner, _ in
+                owner.viewModel.input.viewWillAppearEvent.onNext(())
+            }
+            .disposed(by: self.disposeBag)
     }
 
     private func bindOutput() {
         self.viewModel.output.reservationDetail
             .take(1)
+            .compactMap { $0 }
             .bind(with: self) { owner, entity in
                 owner.reservationInfoLabel.text = entity.csReservationID
                 owner.ticketHolderInfoLabel.text = "\(entity.purchaseName) / \(entity.purchaserPhoneNumber.formatPhoneNumber())"

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewModel.swift
@@ -16,11 +16,16 @@ final class TicketingCompletionViewModel {
     
     private let disposeBag = DisposeBag()
     private let ticketReservationsRepository: TicketReservationsRepositoryType
-    
+
+    struct Input {
+        let viewWillAppearEvent = PublishSubject<Void>()
+    }
+
     struct Output {
         let reservationDetail = PublishRelay<TicketReservationDetailEntity>()
     }
-    
+
+    let input: Input
     let output: Output
     let reservationId: Int
 
@@ -28,24 +33,30 @@ final class TicketingCompletionViewModel {
     
     init(reservationId: Int,
          ticketReservationsRepository: TicketReservationsRepositoryType) {
-        self.output = Output()
         self.reservationId = reservationId
         self.ticketReservationsRepository = ticketReservationsRepository
-        self.fetchReservationDetail()
+
+        self.input = Input()
+        self.output = Output()
+
+        self.bindInputs()
     }
-    
+
+    private func bindInputs() {
+        self.input.viewWillAppearEvent
+            .flatMap { self.fetchReservationDetail() }
+            .subscribe(with: self, onNext: { owner, ticketReservationDetail in
+                owner.output.reservationDetail.accept(ticketReservationDetail)
+            })
+            .disposed(by: self.disposeBag)
+    }
 }
 
 // MARK: - Network
 
 extension TicketingCompletionViewModel {
-    
-    private func fetchReservationDetail() {
-        self.ticketReservationsRepository.ticketReservationDetail(with: "\(self.reservationId)")
-            .subscribe(with: self) { owner, response in
-                owner.output.reservationDetail.accept(response)
-            }
-            .disposed(by: self.disposeBag)
+
+    private func fetchReservationDetail() -> Single<TicketReservationDetailEntity> {
+        return self.ticketReservationsRepository.ticketReservationDetail(with: "\(self.reservationId)")
     }
-    
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
@@ -140,6 +140,7 @@ extension TicketingConfirmViewController {
         case .invitation:
             self.depositorStackView.isHidden = true
             self.methodInfo.text = "초청 코드"
+            self.methodStackView.isHidden = true
         }
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 import RxSwift
 import RxCocoa
-import RxAppState
 
 final class TicketingConfirmViewController: BooltiViewController {
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import RxSwift
 import RxCocoa
+import RxAppState
 
 final class TicketingConfirmViewController: BooltiViewController {
     


### PR DESCRIPTION
## 작업한 내용
- 초청티켓 결제 시 팝업 창 불필요한 값 수정
  - 초청티켓 결제 팝업 창에서 결제 수단 값을 없앴어요.
- 결제 완료 Scene API 호출 시점 변경
  - 기존에 있던 코드에서는 결제를 완료하고 결제 완료 Scene에 돌아가서 예매 상세 API를 호출했어요.
  - 해당 로직은
    -  VC init ->  VM init -> VM init 메소드 속 API 호출 -> VC에 binding된 subscriber가 해당 API의 result 값을 받아요.
  - 근데, VC init이 되는 시점이 결제 승인 API를 던진 시점이랑 맞물려있기에 토스 payment VC에서 결제 승인을 받으면 completionVC를 init해버려요.(아직 navigation push는 안하고)
  - 이렇게 될 경우, VC가 init되고 VM이 init되어 API 호출을 했지만, 아직 VC에서 해당 result를 binding하지 못했기에(유저는 불티 앱을 안보고있음) 빈 데이터 만을 VC에서 보여주게 되어요.

이러한 문제점의 해결책으로는 두 가지를 생각했어요.
- Relay를 활용해서 subscribe를 한 시점에 VM의 result 값을 가져온다.
- viewWillAppear가 된 이후에 API를 호출한다.

저는 굳이 Relay로 변경할 필요가 없이 화면의 흐름에 맞게 뷰가 띄어지기 전에 API 호출을 시켜주는 방식으로 문제를 해결했어요.

## 관련 이슈
- Resolved: #235 
- Resolved: #236 