### PR TITLE
Chore/#240 TicketCompletion에서 예매 상세 내역으로 넘어가는 로직 추가

### DIFF
--- a/Boolti/Boolti/Sources/Global/Enums/LandingDestination.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/LandingDestination.swift
@@ -9,6 +9,7 @@ import Foundation
 
  enum LandingDestination: Codable {
      case reservationList
+     case reservationDetail(reservationID: Int)
      case concertDetail(concertId: Int)
      // 추가될 예정
  }

--- a/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Notification.Name+.swift
@@ -15,5 +15,6 @@ extension Notification.Name {
     enum LandingDestination {
         static let concertDetail = Notification.Name("concertDetail")
         static let reservationList = Notification.Name("reservationList")
+        static let reservationDetail = Notification.Name("reservationDetail")
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
@@ -284,7 +284,7 @@ extension TicketingCompletionViewController {
     private func setAccountTransferPaymentTicketCase(with entity: TicketReservationDetailEntity) {
         self.setPayerInfoLabel(with: entity)
         guard let accountTransferBank = entity.accountTransferBank else { return }
-        self.amountInfoLabel.text = "\(entity.totalPaymentAmount)원\n(\(accountTransferBank) / 계좌이체)"
+        self.amountInfoLabel.text = "\(entity.totalPaymentAmount)원 (계좌이체)"
     }
 
     private func setSimplePaymentTicketCase(with entity: TicketReservationDetailEntity) {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
@@ -283,7 +283,6 @@ extension TicketingCompletionViewController {
 
     private func setAccountTransferPaymentTicketCase(with entity: TicketReservationDetailEntity) {
         self.setPayerInfoLabel(with: entity)
-        guard let accountTransferBank = entity.accountTransferBank else { return }
         self.amountInfoLabel.text = "\(entity.totalPaymentAmount)원 (계좌이체)"
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
@@ -158,10 +158,10 @@ extension TicketingCompletionViewController {
         self.openReservationButton.rx.tap
             .bind(with: self) { owner, _ in
                 owner.changeTab(to: .myPage)
-                
-                UserDefaults.landingDestination = .reservationList
+
+                UserDefaults.landingDestination = .reservationDetail(reservationID: owner.viewModel.reservationId)
                 NotificationCenter.default.post(
-                    name: Notification.Name.LandingDestination.reservationList,
+                    name: Notification.Name.LandingDestination.reservationDetail,
                     object: nil
                 )
             }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -50,7 +50,6 @@ final class MyPageViewController: BooltiViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = false
-        self.isAlreadyNavigated = false
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -239,7 +238,10 @@ final class MyPageViewController: BooltiViewController {
     }
 
     func configureLandingDestination() {
-        guard !self.isAlreadyNavigated else { return }
+        if self.isAlreadyNavigated {
+            self.isAlreadyNavigated = false
+            return
+        }
         guard let landingDestination = UserDefaults.landingDestination else { return }
 
         if case .reservationList = landingDestination {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -38,6 +38,8 @@ final class MyPageViewController: BooltiViewController {
         return button
     }()
 
+    private var isAlreadyNavigated = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
@@ -52,8 +54,8 @@ final class MyPageViewController: BooltiViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-          self.configureLandingDestination()
-      }
+        self.configureLandingDestination()
+    }
 
     init(
         viewModel: MyPageViewModel,
@@ -237,12 +239,15 @@ final class MyPageViewController: BooltiViewController {
     }
 
     func configureLandingDestination() {
+        guard !self.isAlreadyNavigated else { return }
         guard let landingDestination = UserDefaults.landingDestination else { return }
 
         if case .reservationList = landingDestination {
-            let viewController = self.ticketReservationsViewControllerFactory()
-            self.navigationController?.pushViewController(viewController, animated: true)
-            UserDefaults.landingDestination = nil
+            UserDefaults.landingDestination = nil // reservationList가 destination이면 Userdefaults 초기화해주기
         }
+ 
+        let viewController = self.ticketReservationsViewControllerFactory()
+        self.navigationController?.pushViewController(viewController, animated: true)
+        self.isAlreadyNavigated = true
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -50,6 +50,7 @@ final class MyPageViewController: BooltiViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = false
+        self.isAlreadyNavigated = false
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -238,11 +239,7 @@ final class MyPageViewController: BooltiViewController {
     }
 
     func configureLandingDestination() {
-        if self.isAlreadyNavigated {
-            self.isAlreadyNavigated = false
-            return
-        }
-
+        guard !self.isAlreadyNavigated else { return }
         guard let landingDestination = UserDefaults.landingDestination else { return }
 
         if case .reservationList = landingDestination {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -49,7 +49,6 @@ final class MyPageViewController: BooltiViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
         self.tabBarController?.tabBar.isHidden = false
     }
 
@@ -239,7 +238,11 @@ final class MyPageViewController: BooltiViewController {
     }
 
     func configureLandingDestination() {
-        guard !self.isAlreadyNavigated else { return }
+        if self.isAlreadyNavigated {
+            self.isAlreadyNavigated = false
+            return
+        }
+
         guard let landingDestination = UserDefaults.landingDestination else { return }
 
         if case .reservationList = landingDestination {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -334,7 +334,6 @@ final class TicketReservationDetailViewController: BooltiViewController {
     }
 
     private func configureAccountTransferPayment(with accountTransferBank: String?) {
-        guard let accountTransferBank else { return }
         self.paymentMethodView.setData("계좌이체")
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -313,7 +313,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         guard let paymentMethod = entity.paymentMethod else { return }
         switch paymentMethod {
         case .accountTransfer:
-            self.configureAccountTransferPayment(with: entity.accountTransferBank)
+            self.configureAccountTransferPayment()
         case .card:
             self.configurePaymentCardDetail(with: entity.paymentCardDetail)
         case .simplePayment:
@@ -333,7 +333,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.paymentMethodView.setData("\(paymentCardDetail.issuer) / \(paymentCardDetail.installmentPlanMonths)")
     }
 
-    private func configureAccountTransferPayment(with accountTransferBank: String?) {
+    private func configureAccountTransferPayment() {
         self.paymentMethodView.setData("계좌이체")
     }
 
@@ -365,8 +365,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         guard let paymentMethod = entity.paymentMethod else { return }
         switch paymentMethod {
         case .accountTransfer:
-            guard let accountTransferBank = entity.accountTransferBank else { return }
-            self.refundMethodView.setData("\(accountTransferBank)")
+            self.refundMethodView.setData("계좌이체")
         case .card:
             guard let paymentCardDetail = entity.paymentCardDetail else { return }
             self.refundMethodView.setData("\(paymentCardDetail.issuer)")

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -335,7 +335,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
 
     private func configureAccountTransferPayment(with accountTransferBank: String?) {
         guard let accountTransferBank else { return }
-        self.paymentMethodView.setData("계좌이체 / \(accountTransferBank)")
+        self.paymentMethodView.setData("계좌이체")
     }
 
     private func configureFreeTicket() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsViewController.swift
@@ -51,6 +51,10 @@ final class TicketReservationsViewController: BooltiViewController {
         self.tabBarController?.tabBar.isHidden = true
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        self.configureLandingDestination()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
@@ -141,6 +145,16 @@ final class TicketReservationsViewController: BooltiViewController {
                 cell.setData(with: item)
             }
             .disposed(by: self.disposeBag)
+    }
+
+    func configureLandingDestination() {
+        guard let landingDestination = UserDefaults.landingDestination else { return }
+
+        if case .reservationDetail(let reservationID) = landingDestination {
+            UserDefaults.landingDestination = nil // 할일 다하면 nil로 설정하기
+            let viewController = self.ticketReservationDetailViewControllerFactory("\(reservationID)")
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }
 

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarController.swift
@@ -83,21 +83,24 @@ extension HomeTabBarController {
             }
             .disposed(by: self.disposeBag)
 
-        self.viewModel.landingDestination
-            .subscribe(with: self) { owner, viewControllerType in
-                // 아래 코드 정리하기!.. - 타입 캐스팅 일일이 하지 않고, 제네릭타입으로 할 수 있게 구현해보기
-                if let _ = viewControllerType as? ConcertListViewController.Type {
+        self.viewModel.initialLandingTab
+            .subscribe(with: self) { owner, startingTab in
+                // 처음 시작점을 설정해주기
+                switch startingTab {
+                case .concert:
                     guard let viewController = owner.viewControllers?[HomeTab.concert.rawValue] as? UINavigationController
                     else { return }
                     guard let concertListViewController = viewController.topViewController as? ConcertListViewController
                     else { return }
                     concertListViewController.configureDynamicLinkDestination()
-                } else if let _ = viewControllerType as? TicketReservationsViewController.Type {
+                case .myPage:
                     guard let viewController = owner.viewControllers?[HomeTab.myPage.rawValue] as? UINavigationController
                     else { return }
                     guard let myPageViewController = viewController.topViewController as? MyPageViewController
                     else { return }
                     myPageViewController.configureLandingDestination()
+                default:
+                    break
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/TabBar/HomeTabBarViewModel.swift
@@ -20,7 +20,7 @@ final class HomeTabBarViewModel {
     let tabItems = BehaviorRelay<[HomeTab]>(value: HomeTab.allCases)
     let currentTab = BehaviorRelay<HomeTab>(value: .concert)
     let popToRootViewController = PublishRelay<HomeTab>()
-    let landingDestination = PublishRelay<BooltiViewController.Type>()
+    let initialLandingTab = PublishRelay<HomeTab>() // Landing이 시작되는 처음 진입점
 
     func selectTab(index: Int) {
         guard let selectedTab = HomeTab(rawValue: index) else { return }
@@ -53,6 +53,13 @@ final class HomeTabBarViewModel {
             name: Notification.Name.LandingDestination.reservationList,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(navigateToReservationDetail),
+            name: Notification.Name.LandingDestination.reservationDetail,
+            object: nil
+        )
     }
 
     @objc func changeTabBarSelectedIndex(_ notification:Notification) {
@@ -66,10 +73,14 @@ final class HomeTabBarViewModel {
     }
 
     @objc func navigateToConcertDetail() {
-        self.landingDestination.accept(ConcertListViewController.self)
+        self.initialLandingTab.accept(HomeTab.concert)
     }
 
     @objc func navigateToReservationList() {
-        self.landingDestination.accept(TicketReservationsViewController.self)
+        self.initialLandingTab.accept(HomeTab.myPage)
+    }
+
+    @objc func navigateToReservationDetail() {
+        self.initialLandingTab.accept(HomeTab.myPage)
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 결제 완료 뷰에서 예매 상세 내역으로 넘어가는 로직을 추가했어요.
  - 현재 다이나믹 링크를 통한 코드랑 함께 겹쳐져있어서 로직이 조금 복잡해지긴 했는데 혹시 궁금한 점 있으면 바로 알려주세요!
- 결제수단이 계좌이체 시, 은행 명 제거

## 스크린샷

<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/81d0595e-2e2e-4b20-bebb-0fb5e81d45fd" width="250"/>

## 관련 이슈
- Resolved: #240 
