### PR TITLE
Feature/#255 티켓 상세뷰, 인디케이터 최대 갯수 설정 및 기타 UI 수정

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Ticket/QRExpand/QRExpandViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/QRExpand/QRExpandViewController.swift
@@ -151,6 +151,7 @@ extension QRExpandViewController {
 
         self.QRCodeExpandPageControl.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
+            make.width.equalToSuperview()
             make.bottom.equalToSuperview().inset(50)
         }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/Cells/TicketCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/Cells/TicketCollectionViewCell.swift
@@ -13,8 +13,8 @@ final class TicketCollectionViewCell: UICollectionViewCell {
 
     private let qrCodeImageView = UIImageView()
 
-    private let ticketNameLabel: UILabel = {
-        let label = UILabel()
+    private let ticketNameLabel: BooltiPaddingLabel = {
+        let label = BooltiPaddingLabel()
         label.textColor = .grey70
         label.font = .subhead1
         label.textAlignment = .center
@@ -104,7 +104,6 @@ final class TicketCollectionViewCell: UICollectionViewCell {
         }
 
         self.ticketNameLabel.snp.makeConstraints { make in
-            make.width.equalTo(105)
             make.height.equalTo(30)
             make.centerX.equalToSuperview()
             make.bottom.equalTo(self.qrCodeImageView.snp.top).offset(-16)


### PR DESCRIPTION
## 작업한 내용
- 인디케이터의 최대 갯수를 설정했어요.
  - 확인해보니까, 기본 UIPageControl은 화면에 보이는 max dot의 갯수를 설정하는 게 없는 거 같더라구요?..
  - 그래서, UIPageControl의 사이즈를 고정하는 방식으로 max dot의 갯수를 설정했어요. 최대 갯수는 10개여서 PageControl의 너비를 최대로 늘려 화면 보이는 PageControl이 10개 초과가 되면 10개가 보이도록 구현했어요.

- 티켓 이름을 나타내는 Ticket Name Label을 BooltPaddingLabel로 변경했어요.

## 스크린샷
- numberOfPages가 10개 이상이면 최대 page control dot이 10개 보이고, 10개 이하이면 10개 이하로 dot의 갯수가 보이게 했어요.
<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/7a418945-e5f5-4611-9ba4-48d33defdae5" width="250"/>

## 관련 이슈
- Resolved: #255
