### PR TITLE
Chore/#261 티켓 디테일 매수별 인디케이터 및 간격 수정 / 네이밍 수정

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingCompletion/TicketingCompletionViewController.swift
@@ -39,15 +39,15 @@ final class TicketingCompletionViewController: BooltiViewController {
     private lazy var reservationInfoLabel = self.makeLabel()
     private lazy var reservationStackView = self.makeInfoRowStackView(title: reservationTitleLabel, info: reservationInfoLabel)
     
-    private lazy var ticketHolderTitleLabel = self.makeLabel(text: "예매자 정보")
-    private lazy var ticketHolderInfoLabel = self.makeLabel()
-    private lazy var ticketHolderStackView = self.makeInfoRowStackView(title: ticketHolderTitleLabel, info: ticketHolderInfoLabel)
+    private lazy var visitorTitleLabel = self.makeLabel(text: "방문자 정보")
+    private lazy var visitorInfoLabel = self.makeLabel()
+    private lazy var visitorStackView = self.makeInfoRowStackView(title: visitorTitleLabel, info: visitorInfoLabel)
     
     private lazy var payerTitleLabel = self.makeLabel(text: "결제자 정보")
     private lazy var payerInfoLabel = self.makeLabel()
     private lazy var payerStackView = self.makeInfoRowStackView(title: payerTitleLabel, info: payerInfoLabel)
     
-    private lazy var firstInfoStackView = self.makeInfoGroupStackView(with: [reservationStackView, ticketHolderStackView, payerStackView])
+    private lazy var firstInfoStackView = self.makeInfoGroupStackView(with: [reservationStackView, visitorStackView, payerStackView])
     
     private let secondUnderlineView: UIView = {
         let view = UIView()
@@ -68,7 +68,7 @@ final class TicketingCompletionViewController: BooltiViewController {
     private let reservedTicketView = ReservedTicketView()
     
     private let openReservationButton: BooltiButton = {
-        let button = BooltiButton(title: "예매 내역보기")
+        let button = BooltiButton(title: "결제 내역보기")
         button.backgroundColor = .grey80
         return button
     }()
@@ -210,7 +210,7 @@ extension TicketingCompletionViewController {
             .compactMap { $0 }
             .bind(with: self) { owner, entity in
                 owner.reservationInfoLabel.text = entity.csReservationID
-                owner.ticketHolderInfoLabel.text = "\(entity.purchaseName) / \(entity.purchaserPhoneNumber.formatPhoneNumber())"
+                owner.visitorInfoLabel.text = "\(entity.purchaseName) / \(entity.purchaserPhoneNumber.formatPhoneNumber())"
                 owner.ticketInfoLabel.text = "\(entity.salesTicketName) / \(entity.ticketCount)매"
                 owner.reservedTicketView.setData(
                     concertName: entity.concertTitle,

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingConfirm/TicketingConfirmViewController.swift
@@ -54,9 +54,9 @@ final class TicketingConfirmViewController: BooltiViewController {
         return stackView
     }()
     
-    private lazy var ticketHolderTitle = self.makeLabel(with: "예매자")
-    private lazy var ticketHolderInfo = self.makeLabel()
-    private lazy var ticketHolderStackView = self.makeHorizontalStackView(with: [self.ticketHolderTitle, self.ticketHolderInfo])
+    private lazy var visitorTitle = self.makeLabel(with: "방문자")
+    private lazy var visitorInfo = self.makeLabel()
+    private lazy var visitorStackView = self.makeHorizontalStackView(with: [self.visitorTitle, self.visitorInfo])
     
     private lazy var depositorTitle = self.makeLabel(with: "결제자")
     private lazy var depositorInfo = self.makeLabel()
@@ -121,8 +121,8 @@ extension TicketingConfirmViewController {
     private func setData() {
         let entity = self.viewModel.ticketingEntity
         
-        self.ticketHolderInfo.text = "\(entity.ticketHolder.name)\n\(entity.ticketHolder.phoneNumber.formatPhoneNumber())"
-        self.ticketHolderInfo.setAlignment(.right)
+        self.visitorInfo.text = "\(entity.ticketHolder.name)\n\(entity.ticketHolder.phoneNumber.formatPhoneNumber())"
+        self.visitorInfo.setAlignment(.right)
         
         self.ticketInfo.text = "\(entity.selectedTicket.ticketName)\n\(entity.selectedTicket.count)매 / \((entity.selectedTicket.count * entity.selectedTicket.price).formattedCurrency())원"
         self.ticketInfo.setAlignment(.right)
@@ -198,7 +198,7 @@ extension TicketingConfirmViewController {
                                                 self.infoStackView,
                                                 self.payButton])
         
-        self.infoStackView.addArrangedSubviews([self.ticketHolderStackView,
+        self.infoStackView.addArrangedSubviews([self.visitorStackView,
                                                 self.depositorStackView,
                                                 self.ticketStackView,
                                                 self.methodStackView])

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
@@ -68,7 +68,7 @@ final class UserInfoInputView: UIView {
         var config = UIButton.Configuration.plain()
         config.imagePadding = 4
         config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-        config.title = "예매자와 결제자가 같아요"
+        config.title = "방문자와 결제자가 같아요"
         config.attributedTitle?.font = .body2
         config.baseForegroundColor = .orange01
         config.baseBackgroundColor = .clear
@@ -150,7 +150,7 @@ extension UserInfoInputView {
     private func configureTicketHolderUI() {
         self.configureDefaultUI()
         
-        self.titleLabel.text = "예매자 정보"
+        self.titleLabel.text = "방묹 정보"
     }
     
     private func configureDepositorUI() {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
@@ -150,7 +150,7 @@ extension UserInfoInputView {
     private func configureTicketHolderUI() {
         self.configureDefaultUI()
         
-        self.titleLabel.text = "방묹 정보"
+        self.titleLabel.text = "방문자 정보"
     }
     
     private func configureDepositorUI() {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Main/MypageViewController.swift
@@ -24,7 +24,7 @@ final class MyPageViewController: BooltiViewController {
     private let viewModel: MyPageViewModel
 
     private let profileView = MypageProfileView()
-    private let ticketingReservationsNavigationView = MypageContentView(title: "예매 내역")
+    private let ticketingReservationsNavigationView = MypageContentView(title: "결제 내역")
     private let registerConcertView = MypageContentView(title: "공연 등록")
     private let qrScannerListNavigationView = MypageContentView(title: "QR 스캔")
     private let logoutNavigationView = MypageContentView(title: "로그아웃")

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -20,7 +20,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
     private let viewModel: TicketReservationDetailViewModel
     private let disposeBag = DisposeBag()
 
-    private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "예매 내역 상세"))
+    private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "결제 내역 상세"))
 
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -90,12 +90,12 @@ final class TicketReservationDetailViewController: BooltiViewController {
         isHidden: false
     )
 
-    private let purchasernNameView = ReservationHorizontalStackView(title: "이름", alignment: .right)
-    private let purchaserPhoneNumberView = ReservationHorizontalStackView(title: "연락처", alignment: .right)
+    private let visitorNameView = ReservationHorizontalStackView(title: "이름", alignment: .right)
+    private let visitorPhoneNumberView = ReservationHorizontalStackView(title: "연락처", alignment: .right)
 
-    private lazy var purchaserInformationStackView = ReservationCollapsableStackView(
-        title: "예매자 정보",
-        contentViews: [self.purchasernNameView, self.purchaserPhoneNumberView],
+    private lazy var visitorInformationStackView = ReservationCollapsableStackView(
+        title: "방문자 정보",
+        contentViews: [self.visitorNameView, self.visitorPhoneNumberView],
         isHidden: true
     )
 
@@ -208,7 +208,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.contentStackView.addArrangedSubviews([
             self.reservationUpperStackView,
             self.concertInformationView,
-            self.purchaserInformationStackView,
+            self.visitorInformationStackView,
             self.depositorInformationStackView,
             self.ticketInformationStackView,
             self.paymentInformationStackView,
@@ -286,9 +286,9 @@ final class TicketReservationDetailViewController: BooltiViewController {
         self.ticketTypeView.setData(entity.salesTicketName)
         self.ticketCountView.setData("\(entity.ticketCount)매")
 
-        // 예매자 정보
-        self.purchasernNameView.setData(entity.purchaseName)
-        self.purchaserPhoneNumberView.setData(entity.purchaserPhoneNumber)
+        // 방문자 정보
+        self.visitorNameView.setData(entity.purchaseName)
+        self.visitorPhoneNumberView.setData(entity.purchaserPhoneNumber)
 
         // 결제자 정보
         self.depositorNameView.setData(entity.depositorName)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/TicketReservationsViewController.swift
@@ -39,7 +39,7 @@ final class TicketReservationsViewController: BooltiViewController {
         return stackView
     }()
 
-    private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "예매 내역"))
+    private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "결제 내역"))
 
     init(ticketReservationDetailViewControllerFactory: @escaping (ReservationID) -> TicketReservationDetailViewController,viewModel: TicketReservationsViewModel) {
         self.viewModel = viewModel

--- a/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/Views/EmptyReservationsView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/TicketReservations/Views/EmptyReservationsView.swift
@@ -13,7 +13,7 @@ final class EmptyReservationsStackView: UIStackView {
         let label = BooltiUILabel()
         label.font = .headline1
         label.textColor = .grey05
-        label.text = "예매 내역이 없어요"
+        label.text = "결제 내역이 없어요"
 
         return label
     }()

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -388,7 +388,8 @@ final class TicketDetailViewController: BooltiViewController {
 
     private func setCustomStackViewSpacing() {
         if QRCodePageControl.numberOfPages == 1 {
-            self.concertDetailStackView.setCustomSpacing(60, after: self.QRCodeCollectionView)
+            self.concertDetailStackView.setCustomSpacing(50, after: self.QRCodeCollectionView)
+            self.concertDetailBackgroundView.updateUIComponentsForSingleTicket()
         } else {
             self.concertDetailStackView.setCustomSpacing(10, after: self.QRCodeCollectionView)
             self.concertDetailStackView.setCustomSpacing(30, after: self.QRCodePageControl)
@@ -400,7 +401,8 @@ final class TicketDetailViewController: BooltiViewController {
         self.organizerInfoView.setData(hostName: entity.hostName)
         self.concertDetailBackgroundView.setData(
             with: entity.posterURLPath,
-            concertName: entity.title
+            concertName: entity.title,
+            ticketCount: entity.ticketInformations.count
         )
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/GradientBackgroundView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/GradientBackgroundView.swift
@@ -89,17 +89,6 @@ final class GradientBackgroundView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setData(with posterImageURL: String, concertName: String) {
-        self.posterImageView.setImage(with: posterImageURL)
-        self.tagLabel.text = concertName
-
-        let path = CGMutablePath()
-        path.move(to: CGPoint(x: 20, y: 445))
-        path.addLine(to: CGPoint(x: self.frame.width - 20, y: 445))
-
-        self.shapeLayer.path = path
-    }
-
     func setData(with posterImageURL: String, concertName: String, ticketCount: Int) {
         self.posterImageView.setImage(with: posterImageURL)
         self.tagLabel.text = concertName

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/GradientBackgroundView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/GradientBackgroundView.swift
@@ -92,13 +92,34 @@ final class GradientBackgroundView: UIView {
     func setData(with posterImageURL: String, concertName: String) {
         self.posterImageView.setImage(with: posterImageURL)
         self.tagLabel.text = concertName
+
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 20, y: 445))
+        path.addLine(to: CGPoint(x: self.frame.width - 20, y: 445))
+
+        self.shapeLayer.path = path
+    }
+
+    func setData(with posterImageURL: String, concertName: String, ticketCount: Int) {
+        self.posterImageView.setImage(with: posterImageURL)
+        self.tagLabel.text = concertName
+        self.configurePath(ticketCount: ticketCount)
+    }
+
+    private func configurePath(ticketCount: Int) {
+        let path = CGMutablePath()
+        let pointY = ticketCount == 1 ? CGFloat(445) : CGFloat(465)
+
+        path.move(to: CGPoint(x: 20, y: pointY))
+        path.addLine(to: CGPoint(x: self.frame.width - 20, y: pointY))
+
+        self.shapeLayer.path = path
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         self.gradientLayer.frame = self.posterImageView.bounds
         self.configureCircleViews()
-        self.updateSeperateLinePoint()
         self.configureGradientBorder()
     }
 
@@ -184,12 +205,18 @@ final class GradientBackgroundView: UIView {
         self.rightCircleView.layer.cornerRadius = self.rightCircleView.bounds.width / 2
     }
 
-    private func updateSeperateLinePoint() {
-        let path = CGMutablePath()
-        path.move(to: CGPoint(x: 20, y: 465))
-        path.addLine(to: CGPoint(x: self.frame.width - 20, y: 465))
+    func updateUIComponentsForSingleTicket() {
+        self.leftCircleView.snp.updateConstraints { make in
+            make.centerX.equalTo(self.snp.left)
+            make.width.height.equalTo(20)
+            make.centerY.equalTo(self.snp.top).offset(445)
+        }
 
-        self.shapeLayer.path = path
+        self.rightCircleView.snp.updateConstraints { make in
+            make.centerX.equalTo(self.snp.right)
+            make.width.height.equalTo(20)
+            make.centerY.equalTo(self.snp.top).offset(445)
+        }
     }
 
     private func configureGradientBorder() {


### PR DESCRIPTION
## 작업한 내용
- 티켓 디테일에서 매수 별 인디케이터 유무 및 간격을 수정했어요. 
  - 1매 or 1매 이상
- 예매자 -> 방문자로 네이밍 수정 및 예매 -> 결제로 네이밍 변경했어요. 

## 스크린샷
<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/267d9686-4d67-4783-b9b5-4e5a6b872e4f" width="250"/>
<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/7b8927dd-3e4f-46b6-b4eb-d46c747282d0" width="250"/>

## 관련 이슈
- Resolved: #261 
