### PR TITLE
Chore/#263 종료된 공연 DIM 처리 변경 및 티켓 상세페이지 자동 하이라이팅 적용

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/ConcertCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/ConcertCollectionViewCell.swift
@@ -51,8 +51,8 @@ final class ConcertCollectionViewCell: UICollectionViewCell {
         
         var backgroundAlpha: CGFloat {
             switch self {
-            case .onSale, .endSale: 1
-            default: 0.4
+            case .onSale, .endSale, .endConcert: 1
+            case .beforeSale: 0.4
             }
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class TicketNoticeView: UIView {
 
-    let titleLabel: BooltiUILabel = {
+    private let titleLabel: BooltiUILabel = {
         let label = BooltiUILabel()
         label.font = .subhead2
         label.text = "안내사항 for 주최자"
@@ -18,13 +18,17 @@ final class TicketNoticeView: UIView {
         return label
     }()
 
-    let noticeLabel: BooltiUILabel = {
-        let label = BooltiUILabel()
-        label.font = .body1
-        label.numberOfLines = 0
-        label.textColor = .grey50
+    private let noticeTextView: UITextView = {
+        let textView = UITextView()
+        textView.font = .body1
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.dataDetectorTypes = .link
+        textView.backgroundColor = .clear
+        textView.textColor = .grey50
+        textView.linkTextAttributes = [.underlineStyle: 1, .foregroundColor: UIColor.init("#46A6FF")]
 
-        return label
+        return textView
     }()
 
     init() {
@@ -40,7 +44,7 @@ final class TicketNoticeView: UIView {
     private func configureUI() {
         self.addSubviews([
             self.titleLabel,
-            self.noticeLabel
+            self.noticeTextView
         ])
 
         self.titleLabel.snp.makeConstraints { make in
@@ -48,14 +52,14 @@ final class TicketNoticeView: UIView {
             make.horizontalEdges.equalToSuperview()
         }
 
-        self.noticeLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(12)
+        self.noticeTextView.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(10)
             make.horizontalEdges.equalTo(self.titleLabel)
             make.bottom.equalToSuperview().inset(20)
         }
     }
 
     func setData(with text: String) {
-        self.noticeLabel.text = text
+        self.noticeTextView.text = text
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/Views/TicketNoticeView.swift
@@ -61,5 +61,6 @@ final class TicketNoticeView: UIView {
 
     func setData(with text: String) {
         self.noticeTextView.text = text
+        self.noticeTextView.setLineSpacing(lineSpacing: 6)
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 종료된 공연 DIM 처리 변경 및 티켓 상세페이지 자동 하이라이팅 적용

## 스크린샷
<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/6710092c-21c6-49f8-b848-0fcd1283a7e9" width="250"/>
<img src="https://github.com/Nexters/Boolti-iOS/assets/85781941/90267eb1-f238-49e9-bc5a-ec95039172f7" width="250"/>

## 관련 이슈
- Resolved: #263 
