### PR TITLE
Chore/#265 티켓 상세 티켓 상태 별 입장 코드 입력하기 미노출 처리

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "b4bcdc7df98f577bffcbddb1df65b82054ab928819a9835e37e6abb4a04f8830",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -317,5 +316,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -222,11 +222,18 @@ final class TicketDetailViewController: BooltiViewController {
 
         self.QRCodeCollectionView.rx.didScroll
             .subscribe(with: self) { owner, _ in
-                let offSet = owner.QRCodeCollectionView.contentOffset.x
-                let width = owner.QRCodeCollectionView.frame.width
-                let horizontalCenter = width / 2
+                let cellIndex = owner.calculateCollectionViewItemIndex()
+                owner.QRCodePageControl.rx.currentPage.onNext(cellIndex)
+            }
+            .disposed(by: self.disposeBag)
 
-                owner.QRCodePageControl.rx.currentPage.onNext(Int(offSet + horizontalCenter) / Int(width))
+        self.QRCodeCollectionView.rx.didEndDecelerating
+            .subscribe(with: self) { owner, _ in
+                guard let ticketDetail = owner.viewModel.output.fetchedTicketDetail.value else { return }
+                let currentTicketIndex = owner.QRCodePageControl.currentPage
+                let currentTicket = ticketDetail.ticketInformations[currentTicketIndex]
+
+                owner.entryCodeButton.isHidden = currentTicket.ticketStatus != .notUsed
             }
             .disposed(by: self.disposeBag)
     }
@@ -416,8 +423,21 @@ final class TicketDetailViewController: BooltiViewController {
         self.scrollView.setContentOffset(bottomOffset, animated: true)
     }
 
+    private func calculateCollectionViewItemIndex() -> Int {
+        let offSet = self.QRCodeCollectionView.contentOffset.x
+        let width = self.QRCodeCollectionView.frame.width
+        let horizontalCenter = width / 2
+        let cellIndex = Int(offSet + horizontalCenter) / Int(width)
+
+        return cellIndex
+    }
+
     // Rx로 뺄 계획!
     @objc func handleRefresh(_ refreshControl: UIRefreshControl) {
+        self.refetchTicketInformations()
+    }
+
+    func refetchTicketInformations() {
         self.viewModel.input.refreshControlEvent.onNext(())
     }
 

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewModel.swift
@@ -61,7 +61,6 @@ final class TicketDetailViewModel {
         self.input.refreshControlEvent
             .flatMap { self.fetchTicketDetailItem() }
             .subscribe(with: self) { owner, ticketDetailItem in
-                let ticketCount = ticketDetailItem.ticketInformations.count
                 owner.output.fetchedTicketDetail.accept(ticketDetailItem)
                 owner.output.isLoading.accept(false)
             }

--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketEntryCode/TicketEntryCodeViewController.swift
@@ -76,6 +76,7 @@ final class TicketEntryCodeViewController: BooltiViewController {
                     owner.dismiss(animated: true) {
                         detailViewController.showToast(message: "사용되었어요")
                         detailViewController.hideEntryCodeButton()
+                        detailViewController.refetchTicketInformations()
                     }
                 default:
                     owner.entryCodeInputView.setData(with: response)


### PR DESCRIPTION
## 작업한 내용
-  티켓 상세 티켓 상태 별 입장 코드 입력하기 미노출 처리했어요.
   - 콜렉션 뷰에서 scroll이 끝난 후, currentPage를 통해서 해당 티켓을 미노출/노출 처리했어요.
- 입장 코드 입력한 후, 다시 정보를 fetching해오는 코드를 추가했어요.
## 스크린샷
https://github.com/Nexters/Boolti-iOS/assets/85781941/643d139b-d51e-4341-b88f-a8b7abe3cbba



## 관련 이슈
- Resolved: #265 
