### PR TITLE
Fix/#267 현재 티켓 입장 코드 뷰 isHidden 수정

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Ticket/TicketDetail/TicketDetailViewController.swift
@@ -309,6 +309,7 @@ final class TicketDetailViewController: BooltiViewController {
                 cellType: TicketCollectionViewCell.self)
             ) { index, entity, cell in
                 cell.setData(with: entity)
+                self.setInitialEntryCodeViewIsHidden()
             }
             .disposed(by: self.disposeBag)
 
@@ -430,6 +431,14 @@ final class TicketDetailViewController: BooltiViewController {
         let cellIndex = Int(offSet + horizontalCenter) / Int(width)
 
         return cellIndex
+    }
+
+    private func setInitialEntryCodeViewIsHidden() {
+        guard let ticketDetail = self.viewModel.output.fetchedTicketDetail.value else { return }
+        let currentTicketIndex = self.QRCodePageControl.currentPage
+        let currentTicket = ticketDetail.ticketInformations[currentTicketIndex]
+
+        self.entryCodeButton.isHidden = currentTicket.ticketStatus != .notUsed
     }
 
     // Rx로 뺄 계획!


### PR DESCRIPTION
## 작업한 내용
- 현재 티켓 입장 코드 뷰 isHidden 수정
  - 처음 API 통신을 통해서 Response를 받아온 후, 현재 페이지의 티켓이 활용되었는 지 판단하는 로직 추가


## 관련 이슈
- Resolved: #267 
