### PR TITLE
Feature/#254 선물하기 상세 UI 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
 		2233EAAF2BE142C900A315BF /* TicketingErrorResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */; };
+		224FE70F2C3E520A00C09D28 /* GiftCardImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FE70E2C3E520A00C09D28 /* GiftCardImageEntity.swift */; };
 		2250FABD2C020BA100CCF487 /* ContactDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250FABC2C020BA100CCF487 /* ContactDIContainer.swift */; };
 		2250FABF2C020BC400CCF487 /* ContactViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250FABE2C020BC400CCF487 /* ContactViewController.swift */; };
 		2250FAC12C020BE800CCF487 /* ContactViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250FAC02C020BE800CCF487 /* ContactViewModel.swift */; };
@@ -331,6 +332,7 @@
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
 		2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorResponseDTO.swift; sourceTree = "<group>"; };
+		224FE70E2C3E520A00C09D28 /* GiftCardImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardImageEntity.swift; sourceTree = "<group>"; };
 		2250FABC2C020BA100CCF487 /* ContactDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDIContainer.swift; sourceTree = "<group>"; };
 		2250FABE2C020BC400CCF487 /* ContactViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactViewController.swift; sourceTree = "<group>"; };
 		2250FAC02C020BE800CCF487 /* ContactViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactViewModel.swift; sourceTree = "<group>"; };
@@ -1318,6 +1320,7 @@
 				84FEF6182B68ACDD00EBB64F /* TicketingEntity.swift */,
 				84625A102B63B48D00CC9077 /* SelectedTicketEntity.swift */,
 				84D1C3882B7A17C500527998 /* InvitationCodeStateEntity.swift */,
+				224FE70E2C3E520A00C09D28 /* GiftCardImageEntity.swift */,
 			);
 			path = Concert;
 			sourceTree = "<group>";
@@ -2079,6 +2082,7 @@
 				84FBB2CA2B80D0E8001F4211 /* BooltiUILabel.swift in Sources */,
 				8726054D2B79CDF3005CD0D4 /* ConcertInformationView.swift in Sources */,
 				8757BA9E2B5FD7D3008503B5 /* LoginEnterView.swift in Sources */,
+				224FE70F2C3E520A00C09D28 /* GiftCardImageEntity.swift in Sources */,
 				840D84042B6F5C610078D352 /* TicketingPeriodView.swift in Sources */,
 				84781CA82B5BF71900D37921 /* SplashViewController.swift in Sources */,
 				843918FE2B7A82E700CC62AA /* ReportViewModel.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		22DEF7812C28396100EA492A /* GiftingDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEF7802C28396100EA492A /* GiftingDetailDIContainer.swift */; };
 		22DEF7832C28396D00EA492A /* GiftingDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEF7822C28396D00EA492A /* GiftingDetailViewController.swift */; };
 		22DEF7852C28397600EA492A /* GiftingDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEF7842C28397600EA492A /* GiftingDetailViewModel.swift */; };
+		22FA98232C3D0BE500831F64 /* ConcertTicketInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FA98222C3D0BE500831F64 /* ConcertTicketInfoView.swift */; };
 		840B39552B7667D500E7F8C8 /* ConcertCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */; };
 		840B39572B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39562B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift */; };
 		840B39592B7670FC00E7F8C8 /* ConcertEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39582B7670FC00E7F8C8 /* ConcertEntity.swift */; };
@@ -350,6 +351,7 @@
 		22DEF7802C28396100EA492A /* GiftingDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingDetailDIContainer.swift; sourceTree = "<group>"; };
 		22DEF7822C28396D00EA492A /* GiftingDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingDetailViewController.swift; sourceTree = "<group>"; };
 		22DEF7842C28397600EA492A /* GiftingDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingDetailViewModel.swift; sourceTree = "<group>"; };
+		22FA98222C3D0BE500831F64 /* ConcertTicketInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertTicketInfoView.swift; sourceTree = "<group>"; };
 		840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertCollectionViewCell.swift; sourceTree = "<group>"; };
 		840B39562B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		840B39582B7670FC00E7F8C8 /* ConcertEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertEntity.swift; sourceTree = "<group>"; };
@@ -656,6 +658,7 @@
 			isa = PBXGroup;
 			children = (
 				2201AC932C2A8AD600CEBD31 /* SelectCardView.swift */,
+				22FA98222C3D0BE500831F64 /* ConcertTicketInfoView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2089,6 +2092,7 @@
 				22DEF7812C28396100EA492A /* GiftingDetailDIContainer.swift in Sources */,
 				8730F0202B7B520A00D4F339 /* SelectRefundBankView.swift in Sources */,
 				84FBBE0B2B6888CB009462E9 /* InvitationCodeView.swift in Sources */,
+				22FA98232C3D0BE500831F64 /* ConcertTicketInfoView.swift in Sources */,
 				841FA6412B8326BD00441848 /* BooltiPopupView.swift in Sources */,
 				8769BF982B625DBF00DA9A67 /* TermsAgreementViewModel.swift in Sources */,
 				842C1C662B7DA8C800EFE5A0 /* ResignInfoViewController.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		220013D92BE39F62007FF9E6 /* TicketingErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */; };
+		2201AC942C2A8AD600CEBD31 /* SelectCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201AC932C2A8AD600CEBD31 /* SelectCardView.swift */; };
 		221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */; };
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
@@ -30,6 +31,9 @@
 		22DD8C952BD408200083622C /* TossPaymentsDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD8C942BD408200083622C /* TossPaymentsDIContainer.swift */; };
 		22DD8C972BD4082A0083622C /* TossPaymentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD8C962BD4082A0083622C /* TossPaymentsViewModel.swift */; };
 		22DD8C992BD499E90083622C /* OrderPaymentRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD8C982BD499E90083622C /* OrderPaymentRequestDTO.swift */; };
+		22DEF7812C28396100EA492A /* GiftingDetailDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEF7802C28396100EA492A /* GiftingDetailDIContainer.swift */; };
+		22DEF7832C28396D00EA492A /* GiftingDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEF7822C28396D00EA492A /* GiftingDetailViewController.swift */; };
+		22DEF7852C28397600EA492A /* GiftingDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEF7842C28397600EA492A /* GiftingDetailViewModel.swift */; };
 		840B39552B7667D500E7F8C8 /* ConcertCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */; };
 		840B39572B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39562B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift */; };
 		840B39592B7670FC00E7F8C8 /* ConcertEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39582B7670FC00E7F8C8 /* ConcertEntity.swift */; };
@@ -319,6 +323,7 @@
 
 /* Begin PBXFileReference section */
 		220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorType.swift; sourceTree = "<group>"; };
+		2201AC932C2A8AD600CEBD31 /* SelectCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCardView.swift; sourceTree = "<group>"; };
 		221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
@@ -340,6 +345,9 @@
 		22DD8C942BD408200083622C /* TossPaymentsDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TossPaymentsDIContainer.swift; sourceTree = "<group>"; };
 		22DD8C962BD4082A0083622C /* TossPaymentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TossPaymentsViewModel.swift; sourceTree = "<group>"; };
 		22DD8C982BD499E90083622C /* OrderPaymentRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentRequestDTO.swift; sourceTree = "<group>"; };
+		22DEF7802C28396100EA492A /* GiftingDetailDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingDetailDIContainer.swift; sourceTree = "<group>"; };
+		22DEF7822C28396D00EA492A /* GiftingDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingDetailViewController.swift; sourceTree = "<group>"; };
+		22DEF7842C28397600EA492A /* GiftingDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingDetailViewModel.swift; sourceTree = "<group>"; };
 		840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertCollectionViewCell.swift; sourceTree = "<group>"; };
 		840B39562B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		840B39582B7670FC00E7F8C8 /* ConcertEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertEntity.swift; sourceTree = "<group>"; };
@@ -642,6 +650,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2201AC922C2A8AC400CEBD31 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				2201AC932C2A8AD600CEBD31 /* SelectCardView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		2250FABB2C020B8A00CCF487 /* Contact */ = {
 			isa = PBXGroup;
 			children = (
@@ -704,6 +720,17 @@
 				22DD8C962BD4082A0083622C /* TossPaymentsViewModel.swift */,
 			);
 			path = TossPayments;
+			sourceTree = "<group>";
+		};
+		22DEF77F2C2838E100EA492A /* GiftingDetail */ = {
+			isa = PBXGroup;
+			children = (
+				2201AC922C2A8AC400CEBD31 /* Views */,
+				22DEF7802C28396100EA492A /* GiftingDetailDIContainer.swift */,
+				22DEF7822C28396D00EA492A /* GiftingDetailViewController.swift */,
+				22DEF7842C28397600EA492A /* GiftingDetailViewModel.swift */,
+			);
+			path = GiftingDetail;
 			sourceTree = "<group>";
 		};
 		840B39532B7667B100E7F8C8 /* Cells */ = {
@@ -1251,6 +1278,7 @@
 			children = (
 				84625A0C2B63B2D100CC9077 /* TicketSelection */,
 				848CBF042B6547DB00239303 /* TicketingDetail */,
+				22DEF77F2C2838E100EA492A /* GiftingDetail */,
 				84BAB8242B8CA8BD00DEA35C /* TicketingConfirm */,
 				22DD8C932BD405800083622C /* TossPayments */,
 				84896A412B6A57B100CB3E33 /* TicketingCompletion */,
@@ -1959,6 +1987,7 @@
 				84A713432B7C6DEA000BABCB /* EntranceCodeViewModel.swift in Sources */,
 				84E512532B6E9E0B002658D1 /* ConcertPosterView.swift in Sources */,
 				872605422B793223005CD0D4 /* TicketReservationDetailDIContainer.swift in Sources */,
+				22DEF7832C28396D00EA492A /* GiftingDetailViewController.swift in Sources */,
 				8769BF962B625DB200DA9A67 /* TermsAgreementViewController.swift in Sources */,
 				84A024902B7B99830095A56E /* QRScannerViewModel.swift in Sources */,
 				877CAFCB2B7BC30A004799C8 /* TicketRefundConfirmDIContainer.swift in Sources */,
@@ -2045,6 +2074,7 @@
 				849FBD512B5E920A006EB865 /* AppInfo.swift in Sources */,
 				221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */,
 				870C33362BBC29B600ED212C /* UICollectionReusableView+.swift in Sources */,
+				22DEF7812C28396100EA492A /* GiftingDetailDIContainer.swift in Sources */,
 				8730F0202B7B520A00D4F339 /* SelectRefundBankView.swift in Sources */,
 				84FBBE0B2B6888CB009462E9 /* InvitationCodeView.swift in Sources */,
 				841FA6412B8326BD00441848 /* BooltiPopupView.swift in Sources */,
@@ -2084,6 +2114,7 @@
 				842C1C642B7DA8A700EFE5A0 /* ResignInfoDIContainer.swift in Sources */,
 				8730F0182B7B29FE00D4F339 /* TicketRefundRequestViewModel.swift in Sources */,
 				87101EFC2B5DFC60004BD418 /* NetworkProvider.swift in Sources */,
+				2201AC942C2A8AD600CEBD31 /* SelectCardView.swift in Sources */,
 				84781CBA2B5BF90C00D37921 /* HomeTabBarViewModel.swift in Sources */,
 				8710D94C2B74FA7D00309FBF /* TicketReservationsViewController.swift in Sources */,
 				840B395D2B768B0800E7F8C8 /* CheckingTicketCollectionViewCell.swift in Sources */,
@@ -2191,6 +2222,7 @@
 				877CAFC72B7BC2ED004799C8 /* TicketRefundConfirmViewController.swift in Sources */,
 				8746AD122B680A3E0037A1B1 /* TicketTypeView.swift in Sources */,
 				872605512B79FDE8005CD0D4 /* TicketReservationDetailResponseDTO.swift in Sources */,
+				22DEF7852C28397600EA492A /* GiftingDetailViewModel.swift in Sources */,
 				84A7134C2B7C89A1000BABCB /* QRExpandViewModel.swift in Sources */,
 				2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */,
 				877563DA2B6E0CDA001504FE /* TicketListFooterView.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		220013D92BE39F62007FF9E6 /* TicketingErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */; };
 		2201AC942C2A8AD600CEBD31 /* SelectCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201AC932C2A8AD600CEBD31 /* SelectCardView.swift */; };
+		2201AC972C2AB35100CEBD31 /* CardImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201AC962C2AB35100CEBD31 /* CardImageCollectionViewCell.swift */; };
 		221D09FC2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */; };
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
@@ -324,6 +325,7 @@
 /* Begin PBXFileReference section */
 		220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorType.swift; sourceTree = "<group>"; };
 		2201AC932C2A8AD600CEBD31 /* SelectCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCardView.swift; sourceTree = "<group>"; };
+		2201AC962C2AB35100CEBD31 /* CardImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		221D09FB2BA1E49B0035B0E6 /* BusinessInfoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
@@ -658,6 +660,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		2201AC952C2AB33B00CEBD31 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				2201AC962C2AB35100CEBD31 /* CardImageCollectionViewCell.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
 		2250FABB2C020B8A00CCF487 /* Contact */ = {
 			isa = PBXGroup;
 			children = (
@@ -726,6 +736,7 @@
 			isa = PBXGroup;
 			children = (
 				2201AC922C2A8AC400CEBD31 /* Views */,
+				2201AC952C2AB33B00CEBD31 /* Cells */,
 				22DEF7802C28396100EA492A /* GiftingDetailDIContainer.swift */,
 				22DEF7822C28396D00EA492A /* GiftingDetailViewController.swift */,
 				22DEF7842C28397600EA492A /* GiftingDetailViewModel.swift */,
@@ -2045,6 +2056,7 @@
 				84DF59DA2B722E5B000816DA /* UpdatePopupViewController.swift in Sources */,
 				876C65E02B73907D000F2746 /* TicketType.swift in Sources */,
 				84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */,
+				2201AC972C2AB35100CEBD31 /* CardImageCollectionViewCell.swift in Sources */,
 				876E414F2B5F915E006BEEB7 /* BooltiViewController.swift in Sources */,
 				847AA70E2B62B55500E5B55C /* BooltiNavigationBar.swift in Sources */,
 				8453D7FC2B7539270048F103 /* SalesTicketResponseDTO.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2400,7 +2400,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2417,7 +2417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2441,7 +2441,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2458,7 +2458,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Boolti/Boolti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "b4bcdc7df98f577bffcbddb1df65b82054ab928819a9835e37e6abb4a04f8830",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -59,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "e57841b296d04370ea23580f908881b0ccab17b9",
-        "version" : "10.28.1"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -122,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk.git",
       "state" : {
-        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940",
-        "version" : "2.22.3"
+        "revision" : "08089eeffc9b442da1c7343a70bf66c6de1a72c9",
+        "version" : "2.22.4"
       }
     },
     {
@@ -132,7 +133,7 @@
       "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
       "state" : {
         "branch" : "master",
-        "revision" : "37ac7e289fea5f62b3b1f62d06290a18a202a5b0"
+        "revision" : "bdcb118183ef59a75753a69ac5d3cc93def0baa3"
       }
     },
     {
@@ -311,10 +312,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
-        "version" : "1.26.0"
+        "revision" : "d57a5aecf24a25b32ec4a74be2f5d0a995a47c4b",
+        "version" : "1.27.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Boolti/Boolti/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Boolti/Boolti/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x68",
+          "red" : "0xFF"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/Boolti/Boolti/Sources/Entities/Concert/GiftCardImageEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Concert/GiftCardImageEntity.swift
@@ -1,0 +1,14 @@
+//
+//  GiftCardImageEntity.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 7/10/24.
+//
+
+import Foundation
+
+struct GiftCardImageEntity {
+    let id: Int
+    let path: String
+    let thumbnailPath: String
+}

--- a/Boolti/Boolti/Sources/Global/Extensions/UITextView+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/UITextView+.swift
@@ -8,22 +8,22 @@
 import UIKit
 
 extension UITextView {
-
+    
     /// 행간 조정 메서드
     func setLineSpacing(lineSpacing: CGFloat) {
         if let attributedText = self.attributedText, let font = self.font, let textColor = self.textColor {
             let mutableAttributedText = NSMutableAttributedString(attributedString: attributedText)
-
+            
             let style = NSMutableParagraphStyle()
             style.lineSpacing = lineSpacing
             style.lineBreakStrategy = .hangulWordPriority
-
+            
             mutableAttributedText
                 .addAttributes([.paragraphStyle: style,
-                                                 .font: font,
-                                                 .foregroundColor: textColor],
+                                .font: font,
+                                .foregroundColor: textColor],
                                range: NSMakeRange(0, mutableAttributedText.length))
-
+            
             self.attributedText = mutableAttributedText
         }
     }
@@ -31,6 +31,54 @@ extension UITextView {
     /// 현재 textView의 전체 높이를 반환하는 함수
     func getTextViewHeight() -> CGFloat {
         return self.sizeThatFits(CGSize(width: self.frame.width, height: CGFloat.greatestFiniteMagnitude)).height
+    }
+    
+    // lineHeight 조정 메서드
+    func setLineHeight(alignment: NSTextAlignment) {
+        guard let text = self.text, let font = self.font, let color = self.textColor else { return }
+        let attributedString = NSMutableAttributedString(string: text)
+        
+        attributedString.addAttribute(
+            .font,
+            value: font,
+            range: (text as NSString).range(of: text)
+        )
+        
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: color,
+            range: (text as NSString).range(of: text)
+        )
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakStrategy = .hangulWordPriority
+        paragraphStyle.alignment = alignment
+        
+        switch font {
+        case .caption:
+            paragraphStyle.minimumLineHeight = font.pointSize + 6
+            paragraphStyle.maximumLineHeight = font.pointSize + 6
+        default:
+            paragraphStyle.minimumLineHeight = font.pointSize + 8
+            paragraphStyle.maximumLineHeight = font.pointSize + 8
+        }
+        
+        attributedString.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: NSRange(location: 0, length: attributedString.length)
+        )
+        
+        switch font {
+        case .caption:
+            attributedString.addAttribute(.baselineOffset, value: (font.pointSize + 6 - font.lineHeight) / 2,
+                                          range: NSRange(location: 0, length: attributedString.length))
+        default:
+            attributedString.addAttribute(.baselineOffset, value: (font.pointSize + 8 - font.lineHeight) / 2,
+                                          range: NSRange(location: 0, length: attributedString.length))
+        }
+        
+        self.attributedText = attributedString
     }
     
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Cells/CardImageCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Cells/CardImageCollectionViewCell.swift
@@ -42,6 +42,12 @@ final class CardImageCollectionViewCell: UICollectionViewCell {
         }
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.cardImageView.image = nil
+    }
+    
 }
 
 // MARK: - Methods

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Cells/CardImageCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Cells/CardImageCollectionViewCell.swift
@@ -1,0 +1,61 @@
+//
+//  CardImageCollectionViewCell.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 6/25/24.
+//
+
+import UIKit
+
+final class CardImageCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: UI Component
+    
+    private let cardImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .grey50
+        imageView.layer.cornerRadius = 4
+        return imageView
+    }()
+    
+    // MARK: Initailizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+}
+
+// MARK: - Methods
+
+extension CardImageCollectionViewCell {
+    
+    func setData(with urlString: String) {
+        self.cardImageView.setImage(with: urlString)
+    }
+    
+}
+
+// MARK: - UI
+
+extension CardImageCollectionViewCell {
+    
+    private func configureUI() {
+        self.addSubview(self.cardImageView)
+        
+        self.configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        self.cardImageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Cells/CardImageCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Cells/CardImageCollectionViewCell.swift
@@ -14,7 +14,6 @@ final class CardImageCollectionViewCell: UICollectionViewCell {
     private let cardImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .grey50
-        imageView.layer.cornerRadius = 4
         return imageView
     }()
     
@@ -25,9 +24,22 @@ final class CardImageCollectionViewCell: UICollectionViewCell {
         
         self.configureUI()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError()
+    }
+    
+    // MARK: Override
+    
+    override var isSelected: Bool{
+        didSet {
+            if isSelected {
+                self.layer.borderColor = UIColor.orange01.cgColor
+                self.layer.borderWidth = 1
+            } else {
+                self.layer.borderWidth = 0
+            }
+        }
     }
     
 }
@@ -47,6 +59,8 @@ extension CardImageCollectionViewCell {
 extension CardImageCollectionViewCell {
     
     private func configureUI() {
+        self.layer.cornerRadius = 4
+        self.clipsToBounds = true
         self.addSubview(self.cardImageView)
         
         self.configureConstraints()

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailDIContainer.swift
@@ -9,8 +9,15 @@ final class GiftingDetailDIContainer {
 
     func createGiftingDetailViewController() -> GiftingDetailViewController {
         let viewModel = createGiftingDetailViewModel()
+        
+        let businessInfoViewControllerFactory = {
+            let DIContainer = BusinessInfoDIContainer()
+            let viewController = DIContainer.createBusinessInfoViewController()
 
-        let viewController = GiftingDetailViewController(viewModel: viewModel)
+            return viewController
+        }
+
+        let viewController = GiftingDetailViewController(viewModel: viewModel, businessInfoViewControllerFactory: businessInfoViewControllerFactory)
         
         return viewController
     }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailDIContainer.swift
@@ -1,0 +1,22 @@
+//
+//  GiftingDetailDIContainer.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 6/23/24.
+//
+
+final class GiftingDetailDIContainer {
+
+    func createGiftingDetailViewController() -> GiftingDetailViewController {
+        let viewModel = createGiftingDetailViewModel()
+
+        let viewController = GiftingDetailViewController(viewModel: viewModel)
+        
+        return viewController
+    }
+
+    private func createGiftingDetailViewModel() -> GiftingDetailViewModel {
+        return GiftingDetailViewModel()
+    }
+
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailDIContainer.swift
@@ -6,9 +6,15 @@
 //
 
 final class GiftingDetailDIContainer {
+    
+    private let concertRepository: ConcertRepository
+    
+    init(concertRepository: ConcertRepository) {
+        self.concertRepository = concertRepository
+    }
 
-    func createGiftingDetailViewController() -> GiftingDetailViewController {
-        let viewModel = createGiftingDetailViewModel()
+    func createGiftingDetailViewController(selectedTicket: SelectedTicketEntity) -> GiftingDetailViewController {
+        let viewModel = createGiftingDetailViewModel(selectedTicket: selectedTicket)
         
         let businessInfoViewControllerFactory = {
             let DIContainer = BusinessInfoDIContainer()
@@ -22,8 +28,9 @@ final class GiftingDetailDIContainer {
         return viewController
     }
 
-    private func createGiftingDetailViewModel() -> GiftingDetailViewModel {
-        return GiftingDetailViewModel()
+    private func createGiftingDetailViewModel(selectedTicket: SelectedTicketEntity) -> GiftingDetailViewModel {
+        return GiftingDetailViewModel(concertRepository: self.concertRepository,
+                                      selectedTicket: selectedTicket)
     }
 
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
@@ -1,0 +1,144 @@
+//
+//  GiftingDetailViewController.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 6/23/24.
+//
+
+import UIKit
+
+import RxSwift
+
+final class GiftingDetailViewController: BooltiViewController {
+    
+    // MARK: Properties
+    
+    private let viewModel: GiftingDetailViewModel
+    private let disposeBag = DisposeBag()
+    
+    // MARK: UI Component
+    
+    private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "선물하기"))
+    
+    private lazy var scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.showsVerticalScrollIndicator = false
+        view.contentInset = .init(top: 0, left: 0, bottom: 24, right: 0)
+//        view.keyboardDismissMode = .onDrag
+//        view.delegate = self
+        return view
+    }()
+    
+    private let selectCardView = SelectCardView()
+    
+    private lazy var stackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 12
+        
+        view.addArrangedSubviews([self.selectCardView])
+        return view
+    }()
+    
+    private lazy var buttonBackgroundView: UIView = {
+        let view = UIView()
+        
+        let gradient = CAGradientLayer()
+        gradient.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width, height: 24)
+        gradient.colors = [UIColor.grey95.withAlphaComponent(0.0).cgColor, UIColor.grey95.cgColor]
+        gradient.locations = [0.1, 0.7]
+        view.layer.insertSublayer(gradient, at: 0)
+        
+        return view
+    }()
+    
+    
+    private let payButton = BooltiButton(title: "\(0.formattedCurrency())원 결제하기")
+    
+    // MARK: Initailizer
+    
+    init(viewModel: GiftingDetailViewModel) {
+        self.viewModel = viewModel
+        
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.configureUI()
+        self.bindUIComponents()
+    }
+    
+}
+
+// MARK: - Methods
+
+extension GiftingDetailViewController {
+    
+    private func bindUIComponents() {
+        self.bindNavigationBar()
+    }
+    
+    private func bindNavigationBar() {
+        self.navigationBar.didBackButtonTap()
+            .emit(with: self, onNext: { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+}
+
+// MARK: - UI
+
+extension GiftingDetailViewController {
+    
+    private func configureUI() {
+        self.view.backgroundColor = .grey95
+        
+        self.view.addSubviews([self.navigationBar,
+                               self.scrollView,
+                               self.buttonBackgroundView,
+                               self.payButton])
+        self.scrollView.addSubviews([self.stackView])
+        
+        self.view.backgroundColor = .grey95
+        self.configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        self.navigationBar.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+        }
+        
+        self.scrollView.snp.makeConstraints { make in
+            make.top.equalTo(self.navigationBar.snp.bottom)
+            make.width.equalToSuperview()
+            make.bottom.equalTo(self.payButton.snp.top).offset(-8)
+        }
+        
+        self.stackView.snp.makeConstraints { make in
+            make.verticalEdges.equalTo(self.scrollView)
+            make.width.equalTo(self.scrollView)
+        }
+        
+        self.buttonBackgroundView.snp.makeConstraints { make in
+            make.bottom.equalTo(self.scrollView.snp.bottom)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(24)
+        }
+        
+        self.payButton.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-8)
+        }
+    }
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
@@ -26,8 +26,8 @@ final class GiftingDetailViewController: BooltiViewController {
         let view = UIScrollView()
         view.showsVerticalScrollIndicator = false
         view.contentInset = .init(top: 0, left: 0, bottom: 24, right: 0)
-//        view.keyboardDismissMode = .onDrag
-//        view.delegate = self
+        //        view.keyboardDismissMode = .onDrag
+        //        view.delegate = self
         return view
     }()
     
@@ -36,6 +36,8 @@ final class GiftingDetailViewController: BooltiViewController {
     private let receiverInputView = UserInfoInputView(type: .receiver)
     
     private let senderInputView = UserInfoInputView(type: .sender)
+    
+    private let concertTicketInfoView = ConcertTicketInfoView()
     
     private let policyView = PolicyView()
     
@@ -53,6 +55,7 @@ final class GiftingDetailViewController: BooltiViewController {
         view.addArrangedSubviews([self.selectCardView,
                                   self.receiverInputView,
                                   self.senderInputView,
+                                  self.concertTicketInfoView,
                                   self.policyView,
                                   self.agreeView,
                                   self.middlemanPolicyView,
@@ -105,6 +108,7 @@ extension GiftingDetailViewController {
     
     private func bindUIComponents() {
         self.bindNavigationBar()
+        self.bindConcertTicketInfoView()
         self.bindBusinessInfoView()
         self.bindAgreeView()
     }
@@ -114,6 +118,21 @@ extension GiftingDetailViewController {
             .emit(with: self, onNext: { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
             })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func bindConcertTicketInfoView() {
+        self.viewModel.output.concertDetail
+            .bind(with: self) { owner, entity in
+                guard let concertInfo = entity else { return }
+                let ticketInfo = owner.viewModel.selectedTicket
+
+                owner.concertTicketInfoView.setData(posterURL: concertInfo.posters.first!.thumbnailPath,
+                                                    title: concertInfo.name,
+                                                    datetime: concertInfo.date,
+                                                    ticketInfo: ticketInfo)
+                owner.payButton.setTitle("\((ticketInfo.count * ticketInfo.price).formattedCurrency())원 결제하기", for: .normal)
+            }
             .disposed(by: self.disposeBag)
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
@@ -138,7 +138,8 @@ extension GiftingDetailViewController {
         self.view.addGestureRecognizer(tapGesture)
         
         tapGesture.rx.event
-            .bind(with: self, onNext: { owner, _ in
+            .asDriver()
+            .drive(with: self, onNext: { owner, _ in
                 owner.view.endEditing(true)
                 if owner.isScrollViewOffsetChanged {
                     owner.scrollView.setContentOffset(CGPoint(x: 0, y: owner.scrollView.contentOffset.y - owner.changedScrollViewOffsetY), animated: true)
@@ -216,7 +217,7 @@ extension GiftingDetailViewController {
     
     private func bindConcertTicketInfoView() {
         self.viewModel.output.concertDetail
-            .bind(with: self) { owner, entity in
+            .subscribe(with: self) { owner, entity in
                 guard let concertInfo = entity else { return }
                 let ticketInfo = owner.viewModel.selectedTicket
                 

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
@@ -109,6 +109,7 @@ extension GiftingDetailViewController {
     
     private func bindUIComponents() {
         self.bindNavigationBar()
+        self.bindSelectCardView()
         self.bindUserInputView()
         self.bindConcertTicketInfoView()
         self.bindBusinessInfoView()
@@ -120,6 +121,16 @@ extension GiftingDetailViewController {
             .emit(with: self, onNext: { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
             })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func bindSelectCardView() {
+        self.selectCardView.messageTextView.rx.text.orEmpty
+            .bind(to: self.viewModel.input.message)
+            .disposed(by: self.disposeBag)
+        
+        self.selectCardView.cardImageCollectionView.rx.itemSelected
+            .bind(to: self.viewModel.input.selectedImageIndex)
             .disposed(by: self.disposeBag)
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewController.swift
@@ -36,9 +36,9 @@ final class GiftingDetailViewController: BooltiViewController {
     
     private let selectCardView = SelectCardView()
     
-    private let receiverInputView = UserInfoInputView(type: .receiver)
+    private let senderInputView = UserInfoInputView(title: "보내는 분 정보", showEqualButton: false, showInfoLabel: false)
     
-    private let senderInputView = UserInfoInputView(type: .sender)
+    private let receiverInputView = UserInfoInputView(title: "받는 분 정보", showEqualButton: false, showInfoLabel: true)
     
     private let concertTicketInfoView = ConcertTicketInfoView()
     
@@ -188,11 +188,9 @@ extension GiftingDetailViewController {
         self.selectCardView.cardImageCollectionView.rx.willDisplayCell
             .take(1)
             .bind(with: self) { owner, item in
-                if item.at == .init(item: 0, section: 0) {
-                    item.cell.isSelected = true
-                    owner.selectCardView.cardImageCollectionView.selectItem(at: item.at, animated: false, scrollPosition: .left)
-                    owner.viewModel.input.selectedImageIndex.accept(item.at.item)
-                }
+                item.cell.isSelected = true
+                owner.selectCardView.cardImageCollectionView.selectItem(at: item.at, animated: false, scrollPosition: .left)
+                owner.viewModel.input.selectedImageIndex.accept(item.at.item)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -19,7 +19,7 @@ final class GiftingDetailViewModel {
     
     struct Input {
         let message = BehaviorRelay<String>(value: "")
-        let selectedImageIndex = BehaviorRelay<IndexPath>(value: .init(index: 0))
+        let selectedImageIndex = BehaviorRelay<Int?>(value: nil)
         let receiverName = BehaviorRelay<String>(value: "")
         let receiverPhoneNumber = BehaviorRelay<String>(value: "")
         let senderName = BehaviorRelay<String>(value: "")
@@ -31,6 +31,8 @@ final class GiftingDetailViewModel {
     struct Output {
         let concertDetail = BehaviorRelay<ConcertDetailEntity?>(value: nil)
         let isPaybuttonEnable = PublishSubject<Bool>()
+        let cardImages = BehaviorRelay<[GiftCardImageEntity]>(value: [.init(id: 0, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2F736x%2F84%2Fd7%2F76%2F84d776850719e7f5dcd8d6014d7f5445--lego-birthday-birthday-cards.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2F736x%2F84%2Fd7%2F76%2F84d776850719e7f5dcd8d6014d7f5445--lego-birthday-birthday-cards.jpg&type=a340"), .init(id: 1, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F7c%2Ff3%2F18%2F7cf318aaea37cc8e0d5467e2d35ea02c.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F7c%2Ff3%2F18%2F7cf318aaea37cc8e0d5467e2d35ea02c.jpg&type=a340"), .init(id: 2, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F01%2Fc2%2Fdd%2F01c2dd030a5103d3d5f43befd267ccc9.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F01%2Fc2%2Fdd%2F01c2dd030a5103d3d5f43befd267ccc9.jpg&type=a340"), .init(id: 3, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 4, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 5, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 6, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 7, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 8, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b")])
+        let selectedCardImageURL = PublishRelay<String>()
     }
     
     let input: Input
@@ -64,6 +66,14 @@ extension GiftingDetailViewModel {
         .distinctUntilChanged()
         .bind(to: self.output.isPaybuttonEnable)
         .disposed(by: self.disposeBag)
+        
+        self.input.selectedImageIndex
+            .bind(with: self) { owner, index in
+                guard let index = index else { return }
+                let selectedImage = owner.output.cardImages.value[index].path
+                owner.output.selectedCardImageURL.accept(selectedImage)
+            }
+            .disposed(by: self.disposeBag)
     }
     
     private func checkInputViewTextFieldFilled() -> Observable<Bool> {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import RxSwift
+import RxRelay
 
 final class GiftingDetailViewModel {
     
@@ -15,4 +16,16 @@ final class GiftingDetailViewModel {
     
     private let disposeBag = DisposeBag()
     
+    struct Input {
+        let isAllAgreeButtonSelected = BehaviorRelay<Bool>(value: false)
+    }
+    
+    let input: Input
+    
+    // MARK: Initailizer
+    
+    init() {
+        self.input = Input()
+    }
+
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -15,17 +15,44 @@ final class GiftingDetailViewModel {
     // MARK: Properties
     
     private let disposeBag = DisposeBag()
+    private let concertRepository: ConcertRepositoryType
     
     struct Input {
         let isAllAgreeButtonSelected = BehaviorRelay<Bool>(value: false)
     }
     
+    struct Output {
+        let concertDetail = BehaviorRelay<ConcertDetailEntity?>(value: nil)
+    }
+    
     let input: Input
+    let output: Output
+    
+    let selectedTicket: SelectedTicketEntity
     
     // MARK: Initailizer
     
-    init() {
+    init(concertRepository: ConcertRepositoryType,
+         selectedTicket: SelectedTicketEntity) {
+        self.concertRepository = concertRepository
+        self.selectedTicket = selectedTicket
         self.input = Input()
+        self.output = Output()
+        
+        self.fetchConcertDetail()
     }
 
+}
+
+// MARK: - Network
+
+extension GiftingDetailViewModel {
+    
+    private func fetchConcertDetail() {
+        self.concertRepository.concertDetail(concertId: self.selectedTicket.concertId)
+            .asObservable()
+            .bind(to: self.output.concertDetail)
+            .disposed(by: self.disposeBag)
+    }
+    
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -25,13 +25,13 @@ final class GiftingDetailViewModel {
         let senderName = BehaviorRelay<String>(value: "")
         let senderPhoneNumber = BehaviorRelay<String>(value: "")
         let isAllAgreeButtonSelected = BehaviorRelay<Bool>(value: false)
-        let didPayButtonTap = PublishSubject<Void>()
+        let didPayButtonTap = PublishRelay<Void>()
     }
     
     struct Output {
-        let concertDetail = BehaviorRelay<ConcertDetailEntity?>(value: nil)
-        let isPaybuttonEnable = PublishSubject<Bool>()
-        let cardImages = BehaviorRelay<[GiftCardImageEntity]>(value: [.init(id: 0, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2F736x%2F84%2Fd7%2F76%2F84d776850719e7f5dcd8d6014d7f5445--lego-birthday-birthday-cards.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2F736x%2F84%2Fd7%2F76%2F84d776850719e7f5dcd8d6014d7f5445--lego-birthday-birthday-cards.jpg&type=a340"), .init(id: 1, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F7c%2Ff3%2F18%2F7cf318aaea37cc8e0d5467e2d35ea02c.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F7c%2Ff3%2F18%2F7cf318aaea37cc8e0d5467e2d35ea02c.jpg&type=a340"), .init(id: 2, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F01%2Fc2%2Fdd%2F01c2dd030a5103d3d5f43befd267ccc9.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F01%2Fc2%2Fdd%2F01c2dd030a5103d3d5f43befd267ccc9.jpg&type=a340"), .init(id: 3, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 4, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 5, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 6, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 7, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 8, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b")])
+        let concertDetail = BehaviorSubject<ConcertDetailEntity?>(value: nil)
+        let isPaybuttonEnable = PublishRelay<Bool>()
+        let cardImages = BehaviorSubject<[GiftCardImageEntity]>(value: [.init(id: 0, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2F736x%2F84%2Fd7%2F76%2F84d776850719e7f5dcd8d6014d7f5445--lego-birthday-birthday-cards.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2F736x%2F84%2Fd7%2F76%2F84d776850719e7f5dcd8d6014d7f5445--lego-birthday-birthday-cards.jpg&type=a340"), .init(id: 1, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F7c%2Ff3%2F18%2F7cf318aaea37cc8e0d5467e2d35ea02c.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F7c%2Ff3%2F18%2F7cf318aaea37cc8e0d5467e2d35ea02c.jpg&type=a340"), .init(id: 2, path: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F01%2Fc2%2Fdd%2F01c2dd030a5103d3d5f43befd267ccc9.jpg&type=a340", thumbnailPath: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F01%2Fc2%2Fdd%2F01c2dd030a5103d3d5f43befd267ccc9.jpg&type=a340"), .init(id: 3, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 4, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 5, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 6, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 7, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b"), .init(id: 8, path: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b", thumbnailPath: "https://yobwhuwlrftg22440152.gcdn.ntruss.com/show-images/005c8303-c210-48ca-a7de-adc9bf8da57b")])
         let selectedCardImageURL = PublishRelay<String>()
     }
     
@@ -70,8 +70,12 @@ extension GiftingDetailViewModel {
         self.input.selectedImageIndex
             .bind(with: self) { owner, index in
                 guard let index = index else { return }
-                let selectedImage = owner.output.cardImages.value[index].path
-                owner.output.selectedCardImageURL.accept(selectedImage)
+                do {
+                    let selectedImage = try owner.output.cardImages.value()
+                    owner.output.selectedCardImageURL.accept(selectedImage[index].path)
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                }
             }
             .disposed(by: self.disposeBag)
     }
@@ -97,8 +101,9 @@ extension GiftingDetailViewModel {
     
     private func fetchConcertDetail() {
         self.concertRepository.concertDetail(concertId: self.selectedTicket.concertId)
-            .asObservable()
-            .bind(to: self.output.concertDetail)
+            .subscribe(with: self) { owner, entity in
+                owner.output.concertDetail.onNext(entity)
+            }
             .disposed(by: self.disposeBag)
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  GiftingDetailViewModel.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 6/23/24.
+//
+
+import Foundation
+
+import RxSwift
+
+final class GiftingDetailViewModel {
+    
+    // MARK: Properties
+    
+    private let disposeBag = DisposeBag()
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -18,11 +18,17 @@ final class GiftingDetailViewModel {
     private let concertRepository: ConcertRepositoryType
     
     struct Input {
+        let receiverName = BehaviorRelay<String>(value: "")
+        let receiverPhoneNumber = BehaviorRelay<String>(value: "")
+        let senderName = BehaviorRelay<String>(value: "")
+        let senderPhoneNumber = BehaviorRelay<String>(value: "")
         let isAllAgreeButtonSelected = BehaviorRelay<Bool>(value: false)
+        let didPayButtonTap = PublishSubject<Void>()
     }
     
     struct Output {
         let concertDetail = BehaviorRelay<ConcertDetailEntity?>(value: nil)
+        let isPaybuttonEnable = PublishSubject<Bool>()
     }
     
     let input: Input
@@ -39,9 +45,38 @@ final class GiftingDetailViewModel {
         self.input = Input()
         self.output = Output()
         
+        self.bindInputs()
         self.fetchConcertDetail()
     }
+    
+}
 
+// MARK: - Methods
+
+extension GiftingDetailViewModel {
+    
+    private func bindInputs() {
+        Observable.combineLatest(self.checkInputViewTextFieldFilled(),
+                                 self.input.isAllAgreeButtonSelected)
+        .map { $0 && $1 }
+        .distinctUntilChanged()
+        .bind(to: self.output.isPaybuttonEnable)
+        .disposed(by: self.disposeBag)
+    }
+    
+    private func checkInputViewTextFieldFilled() -> Observable<Bool> {
+        return Observable.combineLatest(self.input.receiverName,
+                                        self.input.receiverPhoneNumber,
+                                        self.input.senderName,
+                                        self.input.senderPhoneNumber)
+        .map {
+            return !$0.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !$1.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !$2.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !$3.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+    }
+    
 }
 
 // MARK: - Network

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/GiftingDetailViewModel.swift
@@ -18,6 +18,8 @@ final class GiftingDetailViewModel {
     private let concertRepository: ConcertRepositoryType
     
     struct Input {
+        let message = BehaviorRelay<String>(value: "")
+        let selectedImageIndex = BehaviorRelay<IndexPath>(value: .init(index: 0))
         let receiverName = BehaviorRelay<String>(value: "")
         let receiverPhoneNumber = BehaviorRelay<String>(value: "")
         let senderName = BehaviorRelay<String>(value: "")

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/ConcertTicketInfoView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/ConcertTicketInfoView.swift
@@ -1,0 +1,187 @@
+//
+//  ConcertTicketInfoView.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 7/9/24.
+//
+
+import UIKit
+
+final class ConcertTicketInfoView: UIView {
+
+    // MARK: UI Components
+    
+    private let titleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .subhead2
+        label.textColor = .grey10
+        label.text = "공연 및 티켓 정보"
+        return label
+    }()
+    
+    private let posterImageView: UIImageView = {
+        let view = UIImageView()
+        view.backgroundColor = .grey30
+        view.layer.cornerRadius = 4
+        view.clipsToBounds = true
+        view.contentMode = .scaleAspectFill
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.grey80.cgColor
+        return view
+    }()
+    
+    private let concertTitleLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .point1
+        label.numberOfLines = 2
+        label.textColor = .grey15
+        return label
+    }()
+    
+    private let datetimeLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .body1
+        label.textColor = .grey30
+        return label
+    }()
+    
+    private lazy var concertInfoStackView: UIStackView = {
+        let view = UIStackView()
+        view.spacing = 8
+        view.axis = .vertical
+        view.alignment = .fill
+        
+        view.addArrangedSubviews([self.concertTitleLabel,
+                                  self.datetimeLabel])
+        return view
+    }()
+    
+    private lazy var ticketTypeTitleLabel = self.makeSelectedTitleLabel(title: "티켓 종류")
+    private lazy var ticketTypeDataLabel = self.makeSelectedDataLabel()
+    private lazy var ticketTypeStackView = self.makeStackView(with: [ticketTypeTitleLabel, ticketTypeDataLabel])
+    
+    private lazy var ticketCountTitleLabel = self.makeSelectedTitleLabel(title: "티켓 매수")
+    private lazy var ticketCountDataLabel = self.makeSelectedDataLabel()
+    private lazy var ticketCountStackView = self.makeStackView(with: [ticketCountTitleLabel, ticketCountDataLabel])
+    
+    private lazy var totalPriceTitleLabel = self.makeSelectedTitleLabel(title: "총 결제 금액")
+    private lazy var totalPriceDataLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .headline1
+        label.textColor = .orange01
+        label.textAlignment = .right
+        return label
+    }()
+    private lazy var totalPriceStackView = self.makeStackView(with: [self.totalPriceTitleLabel,
+                                                                     self.totalPriceDataLabel])
+    private lazy var ticketInfoStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.alignment = .fill
+        view.spacing = 16
+        
+        view.addArrangedSubviews([self.ticketTypeStackView,
+                                  self.ticketCountStackView,
+                                  self.totalPriceStackView])
+        return view
+    }()
+    
+    // MARK: Init
+    
+    init() {
+        super.init(frame: .zero)
+        
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}
+
+// MARK: - Methods
+
+extension ConcertTicketInfoView {
+    
+    private func makeSelectedTitleLabel(title: String) -> BooltiUILabel {
+        let label = BooltiUILabel()
+        label.font = .body3
+        label.textColor = .grey30
+        label.text = title
+        return label
+    }
+    
+    private func makeSelectedDataLabel() -> BooltiUILabel {
+        let label = BooltiUILabel()
+        label.font = .body3
+        label.textColor = .grey15
+        label.textAlignment = .right
+        return label
+    }
+    
+    private func makeStackView(with labels: [UILabel]) -> UIStackView {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.distribution = .equalSpacing
+        view.addArrangedSubviews(labels)
+        return view
+    }
+    
+    func setData(posterURL: String,
+                 title: String,
+                 datetime: Date,
+                 ticketInfo: SelectedTicketEntity) {
+        self.posterImageView.setImage(with: posterURL)
+        self.concertTitleLabel.text = title
+        self.datetimeLabel.text = datetime.format(.dateDayTime)
+        self.ticketTypeDataLabel.text = ticketInfo.ticketName
+        self.ticketCountDataLabel.text = "\(ticketInfo.count)매"
+        self.totalPriceDataLabel.text = "\((ticketInfo.count * ticketInfo.price).formattedCurrency())원"
+    }
+    
+}
+
+// MARK: - UI
+
+extension ConcertTicketInfoView {
+    
+    private func configureUI() {
+        self.backgroundColor = .grey90
+        
+        self.addSubviews([self.titleLabel,
+                          self.posterImageView,
+                          self.concertInfoStackView,
+                          self.ticketInfoStackView])
+        
+        self.configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(328)
+        }
+        
+        self.titleLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(20)
+        }
+        
+        self.posterImageView.snp.makeConstraints { make in
+            make.leading.equalTo(self.titleLabel)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(20)
+            make.width.equalTo(70)
+            make.height.equalTo(98)
+        }
+        
+        self.concertInfoStackView.snp.makeConstraints { make in
+            make.centerY.equalTo(self.posterImageView)
+            make.leading.equalTo(self.posterImageView.snp.trailing).offset(16)
+            make.trailing.equalToSuperview().inset(20)
+        }
+        
+        self.ticketInfoStackView.snp.makeConstraints { make in
+            make.top.equalTo(self.posterImageView.snp.bottom).offset(28)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -105,6 +105,8 @@ extension SelectCardView {
                 } else if changedText.count > 40 {
                     owner.messageTextView.deleteBackward()
                 }
+                
+                owner.messageTextView.setLineHeight(alignment: .center)
                 owner.messageCountLabel.text = "\(changedText.count)/40자"
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -34,7 +34,7 @@ final class SelectCardView: UIView {
         return view
     }()
     
-    private let messageTextView: UITextView = {
+    let messageTextView: UITextView = {
         let textView = UITextView()
         textView.font = .subhead2
         textView.text = "공연에 초대합니다."
@@ -61,7 +61,7 @@ final class SelectCardView: UIView {
         return imageView
     }()
     
-    private lazy var cardImageCollectionView: UICollectionView = {
+    lazy var cardImageCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         
@@ -82,7 +82,6 @@ final class SelectCardView: UIView {
         super.init(frame: .zero)
         
         self.configureUI()
-        //        self.selectFirstItem()
         self.bindUIComponent()
     }
     
@@ -110,11 +109,6 @@ extension SelectCardView {
             }
             .disposed(by: self.disposeBag)
     }
-    
-    //    private func selectFirstItem() {
-    //        self.cardImageCollectionView.selectItem(at: [0,1], animated: false, scrollPosition: .init())
-    //        self.collectionView(cardImageCollectionView.self, didSelectItemAt: IndexPath(item: 1, section: 0))
-    //    }
     
 }
 

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -1,0 +1,119 @@
+//
+//  SelectCardView.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 6/25/24.
+//
+
+import UIKit
+
+final class SelectCardView: UIView {
+    
+    // MARK: Properties
+    
+    private let cardWidth: CGFloat = UIScreen.main.bounds.width - 64
+    private lazy var cardHeight: CGFloat = cardWidth * 1.23
+    
+    // MARK: UI Component
+    
+    private lazy var selectedCardBackgroundView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 8
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.init("FFA883").cgColor
+        view.clipsToBounds = true
+        
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = .init(x: 0, y: 0, width: self.cardWidth, height: self.cardHeight)
+        gradientLayer.colors = [UIColor.init("FF5A14").cgColor,
+                                UIColor.init("FFA883").cgColor]
+        view.layer.addSublayer(gradientLayer)
+        return view
+    }()
+    
+    private let messageTextView: UITextView = {
+        let textView = UITextView()
+        textView.contentInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+        textView.font = .subhead2
+        textView.text = "공연에 초대합니다."
+        textView.backgroundColor = .clear
+        textView.textColor = .white00
+        textView.textAlignment = .center
+        textView.isScrollEnabled = false
+        textView.textContainer.lineFragmentPadding = 0
+        textView.textContainerInset = .zero
+        return textView
+    }()
+    
+    private let messageCountLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .caption
+        label.textColor = .grey10
+        label.text = "0/40자"
+        label.setAlignment(.center)
+        return label
+    }()
+    
+    private let selectedImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .white00
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+    
+    // MARK: Initailizer
+    
+    init() {
+        super.init(frame: .zero)
+        
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}
+
+// MARK: - Methods
+
+extension SelectCardView {
+    
+    private func configureUI() {
+        self.addSubviews([self.selectedCardBackgroundView,
+                          self.messageTextView,
+                          self.messageCountLabel,
+                          self.selectedImageView])
+        
+        self.configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(cardHeight + 156)
+        }
+        
+        self.selectedCardBackgroundView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(24)
+            make.horizontalEdges.equalToSuperview().inset(32)
+            make.height.equalTo(self.cardHeight)
+        }
+        
+        self.messageTextView.snp.makeConstraints { make in
+            make.top.equalTo(self.selectedCardBackgroundView).inset(32)
+            make.horizontalEdges.equalTo(self.selectedCardBackgroundView).inset(20)
+        }
+        
+        self.messageCountLabel.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(self.messageTextView)
+            make.bottom.equalTo(self.selectedImageView.snp.top).offset(-28)
+        }
+        
+        self.selectedImageView.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(self.messageTextView)
+            make.height.equalTo((self.cardWidth - 40) * (2/3))
+            make.bottom.equalTo(self.selectedCardBackgroundView).inset(32)
+        }
+    }
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -61,6 +61,21 @@ final class SelectCardView: UIView {
         return imageView
     }()
     
+    private lazy var cardImageCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.contentInset = .init(top: 0, left: 32, bottom: 0, right: 32)
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.backgroundColor = .clear
+        
+        collectionView.register(CardImageCollectionViewCell.self, forCellWithReuseIdentifier: CardImageCollectionViewCell.className)
+        return collectionView
+    }()
+    
     // MARK: Initailizer
     
     init() {
@@ -97,6 +112,37 @@ extension SelectCardView {
     
 }
 
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension SelectCardView: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 52, height: 52)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print(indexPath)
+//        self.selectedImageView.setImage(with: "")
+    }
+
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension SelectCardView: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CardImageCollectionViewCell.className, for: indexPath) as? CardImageCollectionViewCell else { return UICollectionViewCell() }
+//        cell.setData(with: "")
+        return cell
+    }
+
+}
+
 // MARK: - UI
 
 extension SelectCardView {
@@ -105,7 +151,8 @@ extension SelectCardView {
         self.addSubviews([self.selectedCardBackgroundView,
                           self.messageTextView,
                           self.messageCountLabel,
-                          self.selectedImageView])
+                          self.selectedImageView,
+                          self.cardImageCollectionView])
         
         self.configureConstraints()
     }
@@ -135,6 +182,12 @@ extension SelectCardView {
             make.horizontalEdges.equalTo(self.messageTextView)
             make.height.equalTo((self.cardWidth - 40) * (2/3))
             make.bottom.equalTo(self.selectedCardBackgroundView).inset(32)
+        }
+        
+        self.cardImageCollectionView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview()
+            make.top.equalTo(self.selectedCardBackgroundView.snp.bottom).offset(44)
+            make.bottom.equalToSuperview().inset(36)
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -7,10 +7,13 @@
 
 import UIKit
 
+import RxSwift
+
 final class SelectCardView: UIView {
     
     // MARK: Properties
     
+    private let disposeBag = DisposeBag()
     private let cardWidth: CGFloat = UIScreen.main.bounds.width - 64
     private lazy var cardHeight: CGFloat = cardWidth * 1.23
     
@@ -33,7 +36,6 @@ final class SelectCardView: UIView {
     
     private let messageTextView: UITextView = {
         let textView = UITextView()
-        textView.contentInset = .init(top: 0, left: 0, bottom: 0, right: 0)
         textView.font = .subhead2
         textView.text = "공연에 초대합니다."
         textView.backgroundColor = .clear
@@ -49,8 +51,6 @@ final class SelectCardView: UIView {
         let label = BooltiUILabel()
         label.font = .caption
         label.textColor = .grey10
-        label.text = "0/40자"
-        label.setAlignment(.center)
         return label
     }()
     
@@ -67,6 +67,7 @@ final class SelectCardView: UIView {
         super.init(frame: .zero)
         
         self.configureUI()
+        self.bindUIComponent()
     }
     
     required init?(coder: NSCoder) {
@@ -76,6 +77,27 @@ final class SelectCardView: UIView {
 }
 
 // MARK: - Methods
+
+extension SelectCardView {
+    
+    private func bindUIComponent() {
+        self.messageTextView.rx.text
+            .bind(with: self) { owner, changedText in
+                guard let changedText = changedText else { return }
+                
+                if changedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    owner.messageTextView.text = ""
+                } else if changedText.count > 40 {
+                    owner.messageTextView.deleteBackward()
+                }
+                owner.messageCountLabel.text = "\(changedText.count)/40자"
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+}
+
+// MARK: - UI
 
 extension SelectCardView {
     
@@ -105,7 +127,7 @@ extension SelectCardView {
         }
         
         self.messageCountLabel.snp.makeConstraints { make in
-            make.horizontalEdges.equalTo(self.messageTextView)
+            make.centerX.equalToSuperview()
             make.bottom.equalTo(self.selectedImageView.snp.top).offset(-28)
         }
         

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -41,7 +41,6 @@ final class SelectCardView: UIView {
         textView.backgroundColor = .clear
         textView.textColor = .white00
         textView.textAlignment = .center
-        textView.isScrollEnabled = false
         textView.textContainer.lineFragmentPadding = 0
         textView.textContainerInset = .zero
         return textView
@@ -171,6 +170,7 @@ extension SelectCardView {
         self.messageTextView.snp.makeConstraints { make in
             make.top.equalTo(self.selectedCardBackgroundView).inset(32)
             make.horizontalEdges.equalTo(self.selectedCardBackgroundView).inset(20)
+            make.height.lessThanOrEqualTo(80)
         }
         
         self.messageCountLabel.snp.makeConstraints { make in

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -68,8 +68,6 @@ final class SelectCardView: UIView {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.contentInset = .init(top: 0, left: 32, bottom: 0, right: 32)
         collectionView.showsHorizontalScrollIndicator = false
-        collectionView.delegate = self
-        collectionView.dataSource = self
         collectionView.backgroundColor = .clear
         
         collectionView.register(CardImageCollectionViewCell.self, forCellWithReuseIdentifier: CardImageCollectionViewCell.className)
@@ -94,6 +92,10 @@ final class SelectCardView: UIView {
 // MARK: - Methods
 
 extension SelectCardView {
+    
+    func setSelectedImage(with imageURL: String) {
+        self.selectedImageView.setImage(with: imageURL)
+    }
     
     private func bindUIComponent() {
         self.messageTextView.rx.text
@@ -120,27 +122,6 @@ extension SelectCardView: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 52, height: 52)
-    }
-    
-}
-
-// MARK: - UICollectionViewDataSource
-
-extension SelectCardView: UICollectionViewDataSource {
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CardImageCollectionViewCell.className, for: indexPath) as? CardImageCollectionViewCell else { return UICollectionViewCell() }
-        
-        if indexPath.item == 0 {
-            cell.isSelected = true
-            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
-        }
-        //        cell.setData(with: "")
-        return cell
     }
     
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -82,6 +82,7 @@ final class SelectCardView: UIView {
         super.init(frame: .zero)
         
         self.configureUI()
+        //        self.selectFirstItem()
         self.bindUIComponent()
     }
     
@@ -110,6 +111,11 @@ extension SelectCardView {
             .disposed(by: self.disposeBag)
     }
     
+    //    private func selectFirstItem() {
+    //        self.cardImageCollectionView.selectItem(at: [0,1], animated: false, scrollPosition: .init())
+    //        self.collectionView(cardImageCollectionView.self, didSelectItemAt: IndexPath(item: 1, section: 0))
+    //    }
+    
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
@@ -120,11 +126,6 @@ extension SelectCardView: UICollectionViewDelegateFlowLayout {
         return CGSize(width: 52, height: 52)
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print(indexPath)
-//        self.selectedImageView.setImage(with: "")
-    }
-
 }
 
 // MARK: - UICollectionViewDataSource
@@ -137,10 +138,15 @@ extension SelectCardView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CardImageCollectionViewCell.className, for: indexPath) as? CardImageCollectionViewCell else { return UICollectionViewCell() }
-//        cell.setData(with: "")
+        
+        if indexPath.item == 0 {
+            cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+        }
+        //        cell.setData(with: "")
         return cell
     }
-
+    
 }
 
 // MARK: - UI

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/GiftingDetail/Views/SelectCardView.swift
@@ -43,6 +43,7 @@ final class SelectCardView: UIView {
         textView.textAlignment = .center
         textView.textContainer.lineFragmentPadding = 0
         textView.textContainerInset = .zero
+        textView.tintColor = .white00
         return textView
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionDIContainer.swift
@@ -28,7 +28,7 @@ final class TicketSelectionDIContainer {
         let giftingDetailViewControllerFactory: (SelectedTicketEntity) -> GiftingDetailViewController = { selectedTicket in
             let DIContainer = self.createGiftingDetailViewDIContainer()
 
-            let viewController = DIContainer.createGiftingDetailViewController()
+            let viewController = DIContainer.createGiftingDetailViewController(selectedTicket: selectedTicket)
             return viewController
         }
         
@@ -44,7 +44,7 @@ final class TicketSelectionDIContainer {
     }
     
     private func createGiftingDetailViewDIContainer() -> GiftingDetailDIContainer {
-        return GiftingDetailDIContainer()
+        return GiftingDetailDIContainer(concertRepository: self.concertRepository)
     }
 
     private func createTicketSelectionViewModel(concertId: Int) -> TicketSelectionViewModel {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionDIContainer.swift
@@ -25,16 +25,26 @@ final class TicketSelectionDIContainer {
             return viewController
         }
         
-        let viewController = TicketSelectionViewController(
-            viewModel: viewModel,
-            ticketingDetailViewControllerFactory: ticketingDetailViewControllerFactory
-        )
+        let giftingDetailViewControllerFactory: (SelectedTicketEntity) -> GiftingDetailViewController = { selectedTicket in
+            let DIContainer = self.createGiftingDetailViewDIContainer()
+
+            let viewController = DIContainer.createGiftingDetailViewController()
+            return viewController
+        }
+        
+        let viewController = TicketSelectionViewController(viewModel: viewModel,
+                                                           ticketingDetailViewControllerFactory: ticketingDetailViewControllerFactory,
+                                                           giftingDetailViewControllerFactory: giftingDetailViewControllerFactory)
         
         return viewController
     }
     
     private func createTicketingDetailViewDIContainer() -> TicketingDetailDIContainer {
         return TicketingDetailDIContainer(concertRepository: self.concertRepository)
+    }
+    
+    private func createGiftingDetailViewDIContainer() -> GiftingDetailDIContainer {
+        return GiftingDetailDIContainer()
     }
 
     private func createTicketSelectionViewModel(concertId: Int) -> TicketSelectionViewModel {

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionViewController.swift
@@ -23,6 +23,7 @@ final class TicketSelectionViewController: BooltiViewController {
     let viewModel: TicketSelectionViewModel
     private let disposeBag = DisposeBag()
     private let ticketingDetailViewControllerFactory: (SelectedTicketEntity) -> TicketingDetailViewController
+    private let giftingDetailViewControllerFactory: (SelectedTicketEntity) -> GiftingDetailViewController
     var onDismiss: (() -> ())?
     
     // MARK: UI Component
@@ -34,9 +35,11 @@ final class TicketSelectionViewController: BooltiViewController {
     // MARK: Init
     
     init(viewModel: TicketSelectionViewModel,
-         ticketingDetailViewControllerFactory: @escaping (SelectedTicketEntity) -> TicketingDetailViewController) {
+         ticketingDetailViewControllerFactory: @escaping (SelectedTicketEntity) -> TicketingDetailViewController,
+         giftingDetailViewControllerFactory: @escaping (SelectedTicketEntity) -> GiftingDetailViewController) {
         self.viewModel = viewModel
         self.ticketingDetailViewControllerFactory = ticketingDetailViewControllerFactory
+        self.giftingDetailViewControllerFactory = giftingDetailViewControllerFactory
         
         super.init()
     }
@@ -179,7 +182,8 @@ extension TicketSelectionViewController {
         
         self.viewModel.output.navigateTicketingDetail
             .bind(with: self) { owner, entity in
-                let viewController = owner.ticketingDetailViewControllerFactory(entity)
+//                let viewController = owner.ticketingDetailViewControllerFactory(entity)
+                let viewController = owner.giftingDetailViewControllerFactory(entity)
 
                 guard let presentingViewController = owner.presentingViewController as? HomeTabBarController else { return }
                 guard let rootviewController = presentingViewController.children[0] as? UINavigationController else { return }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
@@ -371,9 +371,9 @@ extension TicketingDetailViewController {
         tapGesture.rx.event
             .bind(with: self, onNext: { owner, _ in
                 owner.view.endEditing(true)
-                if self.isScrollViewOffsetChanged {
-                    owner.scrollView.setContentOffset(CGPoint(x: 0, y: self.scrollView.contentOffset.y - self.changedScrollViewOffsetY), animated: true)
-                    self.isScrollViewOffsetChanged = false
+                if owner.isScrollViewOffsetChanged {
+                    owner.scrollView.setContentOffset(CGPoint(x: 0, y: owner.scrollView.contentOffset.y - owner.changedScrollViewOffsetY), animated: true)
+                    owner.isScrollViewOffsetChanged = false
                 }
             })
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewController.swift
@@ -41,9 +41,9 @@ final class TicketingDetailViewController: BooltiViewController {
     
     private let concertInfoView = ConcertInfoView()
     
-    private let ticketHolderInputView = UserInfoInputView(type: .ticketHolder)
+    private let ticketHolderInputView = UserInfoInputView(title: "방문자 정보", showEqualButton: false, showInfoLabel: false)
     
-    private let depositorInputView = UserInfoInputView(type: .depositor)
+    private let depositorInputView = UserInfoInputView(title: "결제자 정보", showEqualButton: true, showInfoLabel: false)
     
     private let ticketInfoView = TicketInfoView()
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewModel.swift
@@ -86,15 +86,15 @@ extension TicketingDetailViewModel {
         switch self.selectedTicket.ticketType {
         case .sale:
             if self.selectedTicket.price > 0 {
-                Observable.combineLatest(self.checkInputViewTextFieldFilled(inputViewType: .ticketHolder),
-                                         self.checkInputViewTextFieldFilled(inputViewType: .depositor),
+                Observable.combineLatest(self.checkInputViewTextFieldFilled(isTicketHolder: true),
+                                         self.checkInputViewTextFieldFilled(isTicketHolder: false),
                                          self.input.isAllAgreeButtonSelected)
                 .map { $0 && $1 && $2 }
                 .distinctUntilChanged()
                 .bind(to: self.output.isPaybuttonEnable)
                 .disposed(by: self.disposeBag)
             } else {
-                Observable.combineLatest(self.checkInputViewTextFieldFilled(inputViewType: .ticketHolder),
+                Observable.combineLatest(self.checkInputViewTextFieldFilled(isTicketHolder: true),
                                          self.input.isAllAgreeButtonSelected)
                 .map { $0 && $1 }
                 .distinctUntilChanged()
@@ -102,7 +102,7 @@ extension TicketingDetailViewModel {
                 .disposed(by: self.disposeBag)
             }
         case .invitation:
-            Observable.combineLatest(self.checkInputViewTextFieldFilled(inputViewType: .ticketHolder),
+            Observable.combineLatest(self.checkInputViewTextFieldFilled(isTicketHolder: true),
                                      self.output.invitationCodeState,
                                      self.input.isAllAgreeButtonSelected)
             .map { ( isTicketHolderFilled, codeState, isAgree ) in
@@ -114,23 +114,20 @@ extension TicketingDetailViewModel {
         }
     }
     
-    private func checkInputViewTextFieldFilled(inputViewType: UserInfoInputType)  -> Observable<Bool> {
-        switch inputViewType {
-        case .ticketHolder:
+    private func checkInputViewTextFieldFilled(isTicketHolder: Bool)  -> Observable<Bool> {
+        if isTicketHolder {
             return Observable.combineLatest(self.input.ticketHolderName,
                                             self.input.ticketHolderPhoneNumber)
             .map { ticketHolderName, ticketHolderPhoneNumber in
                 return !ticketHolderName.trimmingCharacters(in: .whitespaces).isEmpty && !ticketHolderPhoneNumber.trimmingCharacters(in: .whitespaces).isEmpty
             }
-        case .depositor:
+        } else {
             return Observable.combineLatest(self.input.depositorName,
                                             self.input.depositorPhoneNumber,
                                             self.input.isEqualButtonSelected)
             .map { depositorName, depositorPhoneNumber, isEqualButtonSelected in
                 return isEqualButtonSelected || (!depositorName.trimmingCharacters(in: .whitespaces).isEmpty && !depositorPhoneNumber.trimmingCharacters(in: .whitespaces).isEmpty)
             }
-        default:
-            return .just(false)
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/TicketingDetailViewModel.swift
@@ -129,6 +129,8 @@ extension TicketingDetailViewModel {
             .map { depositorName, depositorPhoneNumber, isEqualButtonSelected in
                 return isEqualButtonSelected || (!depositorName.trimmingCharacters(in: .whitespaces).isEmpty && !depositorPhoneNumber.trimmingCharacters(in: .whitespaces).isEmpty)
             }
+        default:
+            return .just(false)
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
@@ -10,13 +10,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-enum UserInfoInputType {
-    case ticketHolder
-    case depositor
-    case sender
-    case receiver
-}
-
 final class UserInfoInputView: UIView {
     
     // MARK: Properties
@@ -100,30 +93,23 @@ final class UserInfoInputView: UIView {
         return label
     }()
     
-    
-    
     // MARK: Init
     
-    init(type: UserInfoInputType) {
+    init(title: String,
+         showEqualButton: Bool,
+         showInfoLabel: Bool) {
         super.init(frame: .zero)
         
-        switch type {
-        case .ticketHolder:
-            self.configureTicketHolderUI()
-        case .depositor:
-            self.configureDepositorUI()
-        case .sender:
-            self.configureSenderUI()
-        case .receiver:
-            self.configureReceiverUI()
-        }
-        
+        self.configureUI(title: title,
+                         showEqualButton: showEqualButton,
+                         showInfoLabel: showInfoLabel)
         self.bindInputs()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+
 }
 
 // MARK: - Methods
@@ -161,44 +147,14 @@ extension UserInfoInputView {
         self.nameTextField.sendActions(for: .editingChanged)
         self.phoneNumberTextField.sendActions(for: .editingChanged)
     }
+
 }
 
 // MARK: - UI
 
 extension UserInfoInputView {
     
-    private func configureTicketHolderUI() {
-        self.configureDefaultUI()
-        
-        self.titleLabel.text = "방문자 정보"
-    }
-    
-    private func configureDepositorUI() {
-        self.configureDefaultUI()
-        
-        self.addSubview(self.isEqualButton)
-        self.configureDepositorConstraints()
-        
-        self.titleLabel.text = "결제자 정보"
-    }
-    
-    private func configureSenderUI() {
-        self.configureDefaultUI()
-
-        self.titleLabel.text = "보내는 분 정보"
-    }
-    
-    private func configureReceiverUI() {
-        self.configureDefaultUI()
-        
-        self.addSubviews([self.infoImageView,
-                          self.infoLabel])
-        self.configureReceiverConstraints()
-        
-        self.titleLabel.text = "받는 분 정보"
-    }
-    
-    private func configureDefaultUI() {
+    private func configureUI(title: String, showEqualButton: Bool, showInfoLabel: Bool) {
         self.addSubviews([self.titleLabel,
                           self.nameLabel,
                           self.nameTextField,
@@ -207,8 +163,20 @@ extension UserInfoInputView {
         self.configureDefaultConstraints()
         
         self.backgroundColor = .grey90
+        self.titleLabel.text = title
+
+        if showEqualButton {
+            self.addSubview(self.isEqualButton)
+            self.configureIsEqualButtonConstraints()
+        }
+        
+        if showInfoLabel {
+            self.addSubviews([self.infoImageView,
+                              self.infoLabel])
+            self.configureInfoConstraints()
+        }
     }
-    
+
     private func configureDefaultConstraints() {
         self.snp.makeConstraints { make in
             make.height.equalTo(210)
@@ -243,14 +211,14 @@ extension UserInfoInputView {
         }
     }
     
-    private func configureDepositorConstraints() {
+    private func configureIsEqualButtonConstraints() {
         self.isEqualButton.snp.makeConstraints { make in
             make.centerY.equalTo(self.titleLabel)
             make.right.equalToSuperview().inset(20)
         }
     }
     
-    private func configureReceiverConstraints() {
+    private func configureInfoConstraints() {
         self.snp.updateConstraints { make in
             make.height.equalTo(234)
         }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketingDetail/Views/UserInfoInputView.swift
@@ -13,6 +13,8 @@ import RxCocoa
 enum UserInfoInputType {
     case ticketHolder
     case depositor
+    case sender
+    case receiver
 }
 
 final class UserInfoInputView: UIView {
@@ -46,7 +48,6 @@ final class UserInfoInputView: UIView {
         return textField
     }()
 
-    
     private let phoneNumberLabel: BooltiUILabel = {
         let label = BooltiUILabel()
         label.font = .body1
@@ -63,7 +64,6 @@ final class UserInfoInputView: UIView {
         return textField
     }()
 
-    
     let isEqualButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.imagePadding = 4
@@ -86,6 +86,22 @@ final class UserInfoInputView: UIView {
         return button
     }()
     
+    private let infoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .info
+        return imageView
+    }()
+    
+    private let infoLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .pretendardR(14)
+        label.textColor = .grey40
+        label.text = "결제 후 카카오톡 친구 목록에서 받는 분을 선택해주세요."
+        return label
+    }()
+    
+    
+    
     // MARK: Init
     
     init(type: UserInfoInputType) {
@@ -96,6 +112,10 @@ final class UserInfoInputView: UIView {
             self.configureTicketHolderUI()
         case .depositor:
             self.configureDepositorUI()
+        case .sender:
+            self.configureSenderUI()
+        case .receiver:
+            self.configureReceiverUI()
         }
         
         self.bindInputs()
@@ -162,6 +182,22 @@ extension UserInfoInputView {
         self.titleLabel.text = "결제자 정보"
     }
     
+    private func configureSenderUI() {
+        self.configureDefaultUI()
+
+        self.titleLabel.text = "보내는 분 정보"
+    }
+    
+    private func configureReceiverUI() {
+        self.configureDefaultUI()
+        
+        self.addSubviews([self.infoImageView,
+                          self.infoLabel])
+        self.configureReceiverConstraints()
+        
+        self.titleLabel.text = "받는 분 정보"
+    }
+    
     private func configureDefaultUI() {
         self.addSubviews([self.titleLabel,
                           self.nameLabel,
@@ -213,4 +249,23 @@ extension UserInfoInputView {
             make.right.equalToSuperview().inset(20)
         }
     }
+    
+    private func configureReceiverConstraints() {
+        self.snp.updateConstraints { make in
+            make.height.equalTo(234)
+        }
+        
+        self.infoImageView.snp.makeConstraints { make in
+            make.top.equalTo(self.phoneNumberTextField.snp.bottom).offset(16)
+            make.leading.equalToSuperview().inset(20)
+            make.size.equalTo(20)
+        }
+        
+        self.infoLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.infoImageView)
+            make.leading.equalTo(self.infoImageView.snp.trailing).offset(6)
+            make.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
 }


### PR DESCRIPTION
## 작업한 내용
> 현재는 공연 상세 -> 예매하기 -> 티켓 선택 했을 때 바로 선물하기 detail로 들어가도록 구현해두었어요. 
나중에 공연 상세 하단 선물하기/예매하기 버튼 구현하면 수정하겠습니다~!

- 결제하기 상세랑 비슷해서 view를 재사용했어요. 메세지 카드 + 공연 및 티켓 정보는 새로 작업했습니다!
- textView의 lineheight 지정하는 함수를 새로 만들었어요. 기존의 setLineSpacing 대신 사용하면 될 것 같습니다. <- 요건 제가 차차 수정할게요~!
- asset의 accentColor를 .Orange01 색으로 변경해뒀어요 (기존에 설정 안되어있어서 커서가 blue로 뜨고 있어서..!)
    - accentColor를 orange로 바꾸면서 새로 작업한 메시지 카드뷰에 커서가 잘 안보여서 이 부분만 tintColor를 white로 변경했습니다! 

## 스크린샷
| 메시지 카드 뷰 | 입력창 | 버튼 활성화 & policy |
|-|-|-|
| ![RPReplay_Final1720519574](https://github.com/Nexters/Boolti-iOS/assets/58043306/b4d4849f-beaf-433e-ae0d-d1eaf05b1340) | ![RPReplay_Final1720519620](https://github.com/Nexters/Boolti-iOS/assets/58043306/a77e9ff8-044c-4b08-bcd3-3237f2a1435a) | ![RPReplay_Final1720519638](https://github.com/Nexters/Boolti-iOS/assets/58043306/565b6f8d-01f0-487e-a021-f7556d9489d8) |

## 관련 이슈
- Resolved: #254 
