### PR TITLE
Feature/#271 gifting button

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
 		2233EAAF2BE142C900A315BF /* TicketingErrorResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */; };
+		224BEEDF2C4A0B7700863970 /* TicketingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224BEEDE2C4A0B7700863970 /* TicketingType.swift */; };
 		224FE70F2C3E520A00C09D28 /* GiftCardImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FE70E2C3E520A00C09D28 /* GiftCardImageEntity.swift */; };
 		2250FABD2C020BA100CCF487 /* ContactDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250FABC2C020BA100CCF487 /* ContactDIContainer.swift */; };
 		2250FABF2C020BC400CCF487 /* ContactViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250FABE2C020BC400CCF487 /* ContactViewController.swift */; };
@@ -332,6 +333,7 @@
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
 		2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorResponseDTO.swift; sourceTree = "<group>"; };
+		224BEEDE2C4A0B7700863970 /* TicketingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingType.swift; sourceTree = "<group>"; };
 		224FE70E2C3E520A00C09D28 /* GiftCardImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardImageEntity.swift; sourceTree = "<group>"; };
 		2250FABC2C020BA100CCF487 /* ContactDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDIContainer.swift; sourceTree = "<group>"; };
 		2250FABE2C020BC400CCF487 /* ContactViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactViewController.swift; sourceTree = "<group>"; };
@@ -1822,6 +1824,7 @@
 				87C7594B2BA93EA40009A83E /* NotificationMessage.swift */,
 				87826AED2BBFF7F2005176D4 /* LandingDestination.swift */,
 				220013D82BE39F62007FF9E6 /* TicketingErrorType.swift */,
+				224BEEDE2C4A0B7700863970 /* TicketingType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2058,6 +2061,7 @@
 				843918FA2B7A82B200CC62AA /* ReportDIContainer.swift in Sources */,
 				8753CA7D2B7228F2002871C7 /* TicketDetailItemEntity.swift in Sources */,
 				84D1C3852B7A14AD00527998 /* CheckInvitationCodeRequestDTO.swift in Sources */,
+				224BEEDF2C4A0B7700863970 /* TicketingType.swift in Sources */,
 				84781C772B5BEB8500D37921 /* UserDefaultsKey.swift in Sources */,
 				84DF59DA2B722E5B000816DA /* UpdatePopupViewController.swift in Sources */,
 				876C65E02B73907D000F2746 /* TicketType.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Enums/TicketingType.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/TicketingType.swift
@@ -1,0 +1,11 @@
+//
+//  TicketingType.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 7/19/24.
+//
+
+enum TicketingType {
+    case gifting
+    case ticketing
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailDIContainer.swift
@@ -58,10 +58,10 @@ final class ConcertDetailDIContainer {
             return viewController
         }
         
-        let ticketSelectionViewControllerFactory: (ConcertId) -> TicketSelectionViewController = { concertId in
+        let ticketSelectionViewControllerFactory: (ConcertId, TicketingType) -> TicketSelectionViewController = { concertId, type in
             let DIContainer = self.createTicketSelectionDIContainer()
 
-            let viewController = DIContainer.createTicketSelectionViewController(concertId: concertId)
+            let viewController = DIContainer.createTicketSelectionViewController(concertId: concertId, type: type)
             return viewController
         }
         

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionDIContainer.swift
@@ -15,8 +15,8 @@ final class TicketSelectionDIContainer {
         self.concertRepository = concertRepository
     }
 
-    func createTicketSelectionViewController(concertId: Int) -> TicketSelectionViewController {
-        let viewModel = createTicketSelectionViewModel(concertId: concertId)
+    func createTicketSelectionViewController(concertId: Int, type: TicketingType) -> TicketSelectionViewController {
+        let viewModel = createTicketSelectionViewModel(concertId: concertId, type: type)
         
         let ticketingDetailViewControllerFactory: (SelectedTicketEntity) -> TicketingDetailViewController = { selectedTicket in
             let DIContainer = self.createTicketingDetailViewDIContainer()
@@ -47,9 +47,10 @@ final class TicketSelectionDIContainer {
         return GiftingDetailDIContainer(concertRepository: self.concertRepository)
     }
 
-    private func createTicketSelectionViewModel(concertId: Int) -> TicketSelectionViewModel {
+    private func createTicketSelectionViewModel(concertId: Int, type: TicketingType) -> TicketSelectionViewModel {
         return TicketSelectionViewModel(concertRepository: self.concertRepository,
-                                        concertId: concertId)
+                                        concertId: concertId,
+                                        type: type)
     }
 
 }

--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/TicketSelection/TicketSelectionViewController.swift
@@ -182,8 +182,13 @@ extension TicketSelectionViewController {
         
         self.viewModel.output.navigateTicketingDetail
             .bind(with: self) { owner, entity in
-//                let viewController = owner.ticketingDetailViewControllerFactory(entity)
-                let viewController = owner.giftingDetailViewControllerFactory(entity)
+                var viewController: BooltiViewController
+                switch owner.viewModel.type {
+                case .ticketing:
+                    viewController = owner.ticketingDetailViewControllerFactory(entity)
+                case .gifting:
+                    viewController = owner.giftingDetailViewControllerFactory(entity)
+                }
 
                 guard let presentingViewController = owner.presentingViewController as? HomeTabBarController else { return }
                 guard let rootviewController = presentingViewController.children[0] as? UINavigationController else { return }


### PR DESCRIPTION
## 작업한 내용
- TicketingType enum을 만들어줬어요. 화면 넘어갈 때 type을 받아서 분기처리를 해주었어요
- 선물하기 예매하기 버튼을 어떻게 구현할까 고민하다가 button 두 개를 stack으로 감싸서 예매 가능 상황일 때만 선물하기 버튼을 hidden false로 주었어요! (그래서 예매 시작 전, 공연 종료 후에는 선물하기 버튼은 hidden되고 기존에 있던 예매하기 버튼 1개가 상태처리가 되고 있어요)

## 스크린샷
| 공연 상세 선물 & 예매 버튼 (선물에는 초청티켓 노출 x) | 예매 시작 전 | 공연 종료 |
|-|-|-|
| ![RPReplay_Final1721370856](https://github.com/user-attachments/assets/880c869c-d9fa-42e9-823c-4277664db540) | ![RPReplay_Final1721370868](https://github.com/user-attachments/assets/234b30e3-c970-4a13-a8aa-d8773fd5b764) | ![RPReplay_Final1721370880](https://github.com/user-attachments/assets/8024f50f-b735-40a6-a08b-eb577eec07d2) |

| 선물하기 화면 연결 | 예매하기 화면 연결 |
|-|-|
| ![RPReplay_Final1721370915](https://github.com/user-attachments/assets/a3b31866-fb0e-4132-a0ca-811905a1c67d) | ![RPReplay_Final1721370926](https://github.com/user-attachments/assets/4f8bfaac-e1fc-4d1f-b20f-e773cd22d74e) |

## 관련 이슈
- Resolved: #271 
