### PR TITLE
Feature/#274 구글 analytics 설정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2426,6 +2426,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.6.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2467,6 +2468,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.6.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.boolti;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## 작업한 내용
- 구글 analytics를 설정했어요.
- 기존에 plist사용하면 되는데 안되었던 이유는 objc때문이었던 것 같아요! 아래처럼 추가해주니 되었어요 .. [참고](https://firebase.google.com/docs/ios/installation-methods?hl=ko#analytics)
![image](https://github.com/user-attachments/assets/6394be2a-db5a-4bf5-bf7f-fe6f17db39dd)
- 저거 설정할 때 debug, release 둘 다 추가되던데 release에만 objc 설정해주면 프로덕션 데이터만 받을 수도 있지 않을까하는.. 생각이 들어요 😅

## 관련 이슈
- Resolved: #274 
