### PR TITLE
Fix/#292 card image kakao

### DIFF
--- a/Boolti/Boolti/Sources/Network/DTO/Reservation/Response/GiftReservationDetailResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Reservation/Response/GiftReservationDetailResponseDTO.swift
@@ -31,6 +31,7 @@ struct GiftReservationDetailResponseDTO: Decodable, ReservationDetailDTOProtocol
     let giftUuid: String
     let giftMessage: String
     let giftImgPath: String
+    let giftInvitePath: String
     let senderName: String
     let senderPhoneNumber: String
 }
@@ -64,7 +65,7 @@ extension GiftReservationDetailResponseDTO {
             giftID: self.giftId,
             giftUUID: self.giftUuid,
             giftMessage: self.giftMessage,
-            giftImageURLPath: self.giftImgPath,
+            giftImageURLPath: self.giftInvitePath,
             recipientName: self.recipientName,
             recipientPhoneNumber: self.recipientPhoneNumber,
             senderName: self.senderName,

--- a/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/GiftReservationDetail/GiftReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/GiftReservationDetail/GiftReservationDetailViewController.swift
@@ -280,7 +280,7 @@ final class GiftReservationDetailViewController: BooltiViewController {
                     let content = Content(
                         title: "\(giftReservationDetail.senderName)님이 보낸 선물이 도착했어요.",
                         imageUrl: URL(string:giftReservationDetail.giftImageURLPath)!,
-                        description: "\(giftReservationDetail.salesEndTime.formatToDate().format(.simple))일까지 불티앱에서 선물을 등록해주세요.",
+                        description: "\(giftReservationDetail.salesEndTime.formatToDate().format(.simple))까지 불티앱에서 선물을 등록해주세요.",
                         link: link
                     )
                     let template = FeedTemplate(content: content, itemContent: itemContent, buttons: [button])


### PR DESCRIPTION
## 작업한 내용
- 선물하기 카카오톡 공유시 이미지를 변경했어요. 원래는 서버에서 내려주던 giftImgPath를 사용하고 있었어요. giftInvitePath 추가로 받아서 변경했어요!

## 스크린샷
<img src="https://github.com/user-attachments/assets/2bf89e17-0c1a-430f-8230-48c0373d276a" witdh=382 height=812>


## 관련 이슈
- Resolved: #292 
