### PR TITLE
Chore/#302 선물하기 메세지 미 입력 시 기본 메시지 보내는 로직 제거

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/Detail/GiftingDetail/GiftingDetailViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/Ticketing/Detail/GiftingDetail/GiftingDetailViewModel.swift
@@ -105,7 +105,7 @@ extension GiftingDetailViewModel {
                                           sender: senderData,
                                           receiver: receiverData,
                                           selectedTicket: self.selectedTicket,
-                                          message: self.input.message.value.isEmpty ? "공연에 초대합니다." : self.input.message.value,
+                                          message: self.input.message.value,
                                           giftImgId: selectedImage.id)
         
         self.output.giftingEntity = giftingEntity


### PR DESCRIPTION
## 작업한 내용
- 메세지 IsEmpty 판별 후 기본 텍스트를 보내고 있었는데, 이 로직을 삭제했어요!

## 스크린샷
<img src="https://github.com/user-attachments/assets/0251bed9-7923-4021-96f1-91108a0da07f" width=200>


## 관련 이슈
- Resolved: #302
