### PR TITLE
Fix/#304 선물 결제 내역 환불 내역 UI 추가 및 데이터 연결

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2785,7 +2785,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2827,7 +2827,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/TicketReservationDetail/TicketReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/TicketReservationDetail/TicketReservationDetailViewController.swift
@@ -357,7 +357,7 @@ final class TicketReservationDetailViewController: BooltiViewController {
             self.refundInformationStackView.isHidden = false
             self.configureRefundInformationStackView(with: entity)
         case .waitingForReceipt:
-            print("good")
+            return
         }
     }
 


### PR DESCRIPTION
## 작업한 내용
- 선물 결제 내역에서 환불 내역 UI를 추가했어요!
- 용재가 작업했던 기존 결제 내역에 있는 환불 UI를 가져온거라 나중에 reservation 쪽 합칠 때 코드 정리 필요해보입니다~!!

## 스크린샷
https://github.com/user-attachments/assets/17747d89-2f06-47c5-8834-578c9ad705ad

## 관련 이슈
- Resolved: #304 
