### PR TITLE
Chore/#310 선물하기 카카오톡 링크 섹션 에러 픽스

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/GiftReservationDetail/GiftReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/GiftReservationDetail/GiftReservationDetailViewController.swift
@@ -419,11 +419,12 @@ final class GiftReservationDetailViewController: BooltiViewController {
                 self.requestRefundButton.isHidden = true
             }
             self.requestRefundButton.isHidden = true
+            self.giftInformationStackView.removeFromSuperview()
             self.giftInformationStackView.isHidden = true
             self.refundInformationStackView.isHidden = true
         case .refundCompleted:
             self.requestRefundButton.isHidden = true
-            self.giftInformationStackView.isHidden = true
+            self.giftInformationStackView.removeFromSuperview()
             self.refundInformationStackView.isHidden = false
             self.configureRefundInformationStackView(with: entity)
         case .waitingForReceipt:


### PR DESCRIPTION
## 작업한 내용
[구현 사항]
방문자 정보에 이름과 연락처, [선물 링크 다시 보내기] 와 안내 텍스트가 노출됨
펼치기 아이콘 터치 시, 모든 정보 미노출됨
펼치기 아이콘 재터치 시, 다시 모든 정보가 노출됨

## 스크린샷

![Simulator Screen Recording - iPhone 15 - 2024-07-28 at 14 26 57](https://github.com/user-attachments/assets/7c0be6cb-ab22-4f1e-9b60-b73e3111a54b)

## 관련 이슈
- Resolved: #310 
