### PR TITLE
Fix/#315 선물 등록완료 시에도 카카오버튼, 안내문구 노출

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -2787,7 +2787,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2829,7 +2829,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/GiftReservationDetail/GiftReservationDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/ReservationDetail/GiftReservationDetail/GiftReservationDetailViewController.swift
@@ -419,8 +419,7 @@ final class GiftReservationDetailViewController: BooltiViewController {
                 self.requestRefundButton.isHidden = true
             }
             self.requestRefundButton.isHidden = true
-            self.giftInformationStackView.removeFromSuperview()
-            self.giftInformationStackView.isHidden = true
+            self.giftInformationStackView.isHidden = false
             self.refundInformationStackView.isHidden = true
         case .refundCompleted:
             self.requestRefundButton.isHidden = true


### PR DESCRIPTION
## 작업한 내용
- 선물 등록완료 시에도 카카오버튼, 안내문구 노출

## 스크린샷
<img src="https://github.com/user-attachments/assets/11e6f7a6-373c-4c6d-a632-aedc790dfec7" width=200>


## 관련 이슈
- Resolved: #315 
