### PR TITLE
Fix/#339 프로필 동적 높이 오류 수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -1073,8 +1073,8 @@
 		22DFC5642C7A00EC00C8433D /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				22DFC5622C7A00E900C8433D /* ProfileLinkHeaderView.swift */,
 				22DFC5572C79C1B900C8433D /* ProfileMainView.swift */,
+				22DFC5622C7A00E900C8433D /* ProfileLinkHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditIntroductionView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditIntroductionView.swift
@@ -34,7 +34,6 @@ final class EditIntroductionView: UIView {
         textView.font = .body3
         textView.text = "예) 재즈와 펑크락을 좋아해요"
         textView.textColor = .grey70
-        textView.isScrollEnabled = false
         return textView
     }()
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -141,6 +141,12 @@ extension ProfileViewController {
         self.dataCollectionView.snp.makeConstraints { make in
             make.height.equalTo(collectionViewHeight)
         }
+        
+        self.profileMainView.layoutIfNeeded()
+        let profileViewHeight = self.profileMainView.getHeight()
+        self.profileMainView.snp.updateConstraints { make in
+            make.height.equalTo(profileViewHeight)
+        }
     }
     
 }
@@ -230,6 +236,10 @@ extension ProfileViewController {
         
         self.dataCollectionView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
+        }
+        
+        self.profileMainView.snp.makeConstraints { make in
+            make.height.equalTo(400)
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -14,12 +14,6 @@ final class ProfileViewController: BooltiViewController {
     
     // MARK: Properties
     
-    enum Section: Int, CaseIterable {
-        case profile
-        case snsLink
-    }
-    
-    private var profileHeaderHeight: CGFloat = 400
     private let disposeBag = DisposeBag()
     private let viewModel: ProfileViewModel
     
@@ -29,15 +23,37 @@ final class ProfileViewController: BooltiViewController {
     
     private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "프로필"))
     
-    private let dataCollectionView: UICollectionView = {
+    private lazy var mainScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.keyboardDismissMode = .onDrag
+        scrollView.addSubview(self.stackView)
+        scrollView.bounces = false
+        scrollView.delegate = self
+        scrollView.contentInset = .init(top: 0, left: 0, bottom: 32, right: 0)
+        
+        return scrollView
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.addArrangedSubviews([self.profileMainView,
+                                       self.dataCollectionView])
+        
+        return stackView
+    }()
+    
+    private let profileMainView = ProfileMainView()
+    
+    let dataCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.showsVerticalScrollIndicator = false
         collectionView.backgroundColor = .clear
-        collectionView.bounces = false
-        collectionView.contentInset = .init(top: 0, left: 0, bottom: 32, right: 0)
+        collectionView.isScrollEnabled = false
         return collectionView
     }()
     
@@ -70,7 +86,7 @@ final class ProfileViewController: BooltiViewController {
         self.bindUIComponents()
         self.bindViewModel()
     }
-    
+
 }
 
 // MARK: - Methods
@@ -79,8 +95,10 @@ extension ProfileViewController {
     
     private func bindViewModel() {
         self.viewModel.output.didProfileFetch
-            .subscribe(with: self) { owner, _ in
+            .subscribe(with: self) { owner, introduction in
+                owner.profileMainView.setData(introduction: introduction)
                 owner.dataCollectionView.reloadData()
+                owner.updateCollectionViewHeight()
             }
             .disposed(by: self.disposeBag)
     }
@@ -99,19 +117,30 @@ extension ProfileViewController {
                 owner.openSafari(with: url)
             }
             .disposed(by: self.disposeBag)
+        
+        self.profileMainView.didEditButtonTap()
+            .emit(with: self) { owner, _ in
+                owner.navigationController?.pushViewController(owner.editProfileViewControllerFactory(), animated: true)
+            }
+            .disposed(by: self.disposeBag)
     }
     
     private func configureCollectionView() {
         self.dataCollectionView.delegate = self
         self.dataCollectionView.dataSource = self
         
-        self.dataCollectionView.register(ProfileMainView.self,
-                                         forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-                                         withReuseIdentifier: ProfileMainView.className)
         self.dataCollectionView.register(ProfileLinkHeaderView.self,
                                          forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
                                          withReuseIdentifier: ProfileLinkHeaderView.className)
         self.dataCollectionView.register(ProfileLinkCollectionViewCell.self, forCellWithReuseIdentifier: ProfileLinkCollectionViewCell.className)
+    }
+    
+    private func updateCollectionViewHeight() {
+        self.dataCollectionView.layoutIfNeeded()
+        let collectionViewHeight = self.dataCollectionView.contentSize.height
+        self.dataCollectionView.snp.makeConstraints { make in
+            make.height.equalTo(collectionViewHeight)
+        }
     }
     
 }
@@ -121,88 +150,32 @@ extension ProfileViewController {
 extension ProfileViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 2
+        return 1
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let section = Section(rawValue: section) else { return 0 }
-        
-        switch section {
-        case .profile:
-            return 0
-        case .snsLink:
-            return self.viewModel.output.links.count
-        }
+        return self.viewModel.output.links.count
     }
     
     /// 헤더를 결정하는 메서드
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        guard let section = Section(rawValue: indexPath.section) else { return .init() }
+        guard kind == UICollectionView.elementKindSectionHeader,
+              let header = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: ProfileLinkHeaderView.className,
+                for: indexPath
+              ) as? ProfileLinkHeaderView else { return UICollectionReusableView() }
         
-        switch section {
-        case .profile:
-            guard kind == UICollectionView.elementKindSectionHeader,
-                  let header = collectionView.dequeueReusableSupplementaryView(
-                    ofKind: kind,
-                    withReuseIdentifier: ProfileMainView.className,
-                    for: indexPath
-                  ) as? ProfileMainView else { return UICollectionReusableView() }
-            
-            header.setData(introduction: self.viewModel.output.introduction) { height in
-                self.profileHeaderHeight = height
-                self.dataCollectionView.collectionViewLayout.invalidateLayout()
-            }
-
-            header.didEditButtonTap()
-                .emit(with: self) { owner, _ in
-                    owner.navigationController?.pushViewController(owner.editProfileViewControllerFactory(), animated: true)
-                }
-                .disposed(by: self.disposeBag)
-            
-            return header
-        case .snsLink:
-            guard kind == UICollectionView.elementKindSectionHeader,
-                  let header = collectionView.dequeueReusableSupplementaryView(
-                    ofKind: kind,
-                    withReuseIdentifier: ProfileLinkHeaderView.className,
-                    for: indexPath
-                  ) as? ProfileLinkHeaderView else { return UICollectionReusableView() }
-            
-            return header
-        }
+        return header
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let section = Section(rawValue: indexPath.section) else { return .init() }
-        
-        switch section {
-        case .profile:
-            return .init()
-        case .snsLink:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileLinkCollectionViewCell.className,
-                                                                for: indexPath) as? ProfileLinkCollectionViewCell else { return UICollectionViewCell() }
-            cell.setData(linkName: self.viewModel.output.links[indexPath.row].title)
-            return cell
-        }
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileLinkCollectionViewCell.className,
+                                                            for: indexPath) as? ProfileLinkCollectionViewCell else { return UICollectionViewCell() }
+        cell.setData(linkName: self.viewModel.output.links[indexPath.row].title)
+        return cell
     }
-
-    func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath) {
-        guard let section = Section(rawValue: indexPath.section) else { return }
-        
-        switch section {
-        case .profile:
-            guard let header = collectionView.dequeueReusableSupplementaryView(
-                    ofKind: elementKind,
-                    withReuseIdentifier: ProfileMainView.className,
-                    for: indexPath
-                  ) as? ProfileMainView else { return }
-            
-            header.disposeBag = DisposeBag()
-        case .snsLink:
-            return
-        }
-    }
-
+    
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
@@ -210,37 +183,16 @@ extension ProfileViewController: UICollectionViewDataSource {
 extension ProfileViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        guard let section = Section(rawValue: indexPath.section) else { return .init() }
-        
-        switch section {
-        case .profile:
-            return .zero
-        case .snsLink:
-            return CGSize(width: self.dataCollectionView.frame.width - 40, height: 56)
-        }
+        return CGSize(width: self.dataCollectionView.frame.width - 40, height: 56)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        guard let section = Section(rawValue: section) else { return .init() }
-        
-        switch section {
-        case .profile:
-            return 0
-        case .snsLink:
-            return 16
-        }
+        return 16
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        guard let section = Section(rawValue: section) else { return .init() }
-        
-        switch section {
-        case .profile:
-            return CGSize(width: self.view.frame.width, height: self.profileHeaderHeight)
-        case .snsLink:
-            guard !self.viewModel.output.links.isEmpty else { return .zero }
-            return CGSize(width: self.view.frame.width, height: 74)
-        }
+        guard !self.viewModel.output.links.isEmpty else { return .zero }
+        return CGSize(width: self.view.frame.width, height: 74)
     }
 }
 
@@ -250,8 +202,8 @@ extension ProfileViewController {
     
     private func configureUI() {
         self.view.backgroundColor = .grey95
-        self.view.addSubviews([self.dataCollectionView,
-                               self.navigationBar])
+        self.view.addSubviews([self.navigationBar,
+                               self.mainScrollView])
         self.navigationBar.setBackgroundColor(with: .grey90)
         self.configureConstraints()
     }
@@ -261,9 +213,23 @@ extension ProfileViewController {
             make.top.horizontalEdges.equalToSuperview()
         }
         
-        self.dataCollectionView.snp.makeConstraints { make in
+        self.mainScrollView.snp.makeConstraints { make in
             make.top.equalTo(self.navigationBar.snp.bottom)
-            make.horizontalEdges.bottom.equalToSuperview()
+            make.width.equalToSuperview()
+            make.bottom.equalToSuperview()
+        }
+        
+        self.stackView.snp.makeConstraints { make in
+            make.verticalEdges.equalTo(self.mainScrollView)
+            make.width.equalTo(self.mainScrollView)
+        }
+        
+        self.profileMainView.snp.makeConstraints { make in
+            make.width.equalTo(UIScreen.main.bounds.width)
+        }
+        
+        self.dataCollectionView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview()
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewModel.swift
@@ -18,8 +18,7 @@ final class ProfileViewModel {
     
     struct Output {
         var links: [LinkEntity] = []
-        var didProfileFetch = PublishSubject<Void>()
-        var introduction: String?
+        var didProfileFetch = PublishSubject<String?>()
     }
     
     var output: Output
@@ -40,9 +39,8 @@ extension ProfileViewModel {
     func fetchLinkList() {
         self.authRepository.userProfile()
             .subscribe(with: self) { owner, profile in
-                owner.output.introduction = profile.introduction
                 owner.output.links = profile.link ?? []
-                owner.output.didProfileFetch.onNext(())
+                owner.output.didProfileFetch.onNext(profile.introduction)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -95,12 +95,10 @@ extension ProfileMainView {
         self.profileImageView.setImage(with: UserDefaults.userImageURLPath)
         self.nameLabel.text = UserDefaults.userName
         self.introductionLabel.text = introduction ?? ""
-        
-        self.layoutIfNeeded()
-        let profileViewHeight = self.frame.height
-        self.snp.makeConstraints { make in
-            make.height.equalTo(profileViewHeight)
-        }
+    }
+    
+    func getHeight() -> CGFloat {
+        return 222 + self.nameLabel.getLabelHeight() + self.introductionLabel.getLabelHeight()
     }
 
     func didEditButtonTap() -> Signal<Void> {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -10,7 +10,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class ProfileMainView: UICollectionReusableView {
+final class ProfileMainView: UIView {
     
     // MARK: Properties
     
@@ -91,14 +91,16 @@ final class ProfileMainView: UICollectionReusableView {
 
 extension ProfileMainView {
     
-    func setData(introduction: String?, completion: @escaping (CGFloat) -> ()) {
+    func setData(introduction: String?) {
         self.profileImageView.setImage(with: UserDefaults.userImageURLPath)
         self.nameLabel.text = UserDefaults.userName
         self.introductionLabel.text = introduction ?? ""
         
-        let height = 222 + self.nameLabel.getLabelHeight() + self.introductionLabel.getLabelHeight()
-//        completion(height)
-        completion(350)
+        self.layoutIfNeeded()
+        let profileViewHeight = self.frame.height
+        self.snp.makeConstraints { make in
+            make.height.equalTo(profileViewHeight)
+        }
     }
 
     func didEditButtonTap() -> Signal<Void> {


### PR DESCRIPTION
## 작업한 내용
- 프로필 메인 height 오류 이슈를 해결했어요.
- data패치 후에 아래의 updateViewHeight 함수 호출했어요.
    - collectionView의 contentSize를 가져와서 높이를 만들어줍니다.
    - profileMainView의 값을 가져오는 함수를 만들고 높이를 update 해줍니다!
        - profileMainView에서 updateConstarints대신 makeConstraints를 하게되면 프로필 편집 후에도 높이가 안바뀌는 오류가 있어서 update로 구현했어요. 만약 링크 수정 후 비슷한 오류가  발생한다면 dataCollectionView도 make대신 update를 사용하면 될 것 같습니다.
```swift
    private func updateViewHeight() {
        self.dataCollectionView.layoutIfNeeded()
        let collectionViewHeight = self.dataCollectionView.contentSize.height
        self.dataCollectionView.snp.makeConstraints { make in
            make.height.equalTo(collectionViewHeight)
        }
        
        self.profileMainView.layoutIfNeeded()
        let profileViewHeight = self.profileMainView.getHeight()
        self.profileMainView.snp.updateConstraints { make in
            make.height.equalTo(profileViewHeight)
        }
    }
```

## 스크린샷
https://github.com/user-attachments/assets/1400ca41-5d49-4add-ae61-c469fbc83ab6


## 관련 이슈
- Resolved: #339 
