### PR TITLE
Feature/#342 프로필 이미지 업로드 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		221D09FE2BA1E6C30035B0E6 /* BusinessInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */; };
 		2233EAAB2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */; };
 		2233EAAF2BE142C900A315BF /* TicketingErrorResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */; };
+		223698F92C8B36B6002C8081 /* GetUploadURLReponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223698F82C8B36B6002C8081 /* GetUploadURLReponseDTO.swift */; };
+		223698FB2C8B3BA3002C8081 /* UploadProfileImageRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223698FA2C8B3BA3002C8081 /* UploadProfileImageRequestDTO.swift */; };
 		224BEEDF2C4A0B7700863970 /* TicketingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224BEEDE2C4A0B7700863970 /* TicketingType.swift */; };
 		224BEEFF2C4CC9BA00863970 /* GiftingConfirmDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224BEEFE2C4CC9BA00863970 /* GiftingConfirmDIContainer.swift */; };
 		224BEF012C4CCA9A00863970 /* GiftingConfirmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224BEF002C4CCA9A00863970 /* GiftingConfirmViewController.swift */; };
@@ -425,6 +427,8 @@
 		221D09FD2BA1E6C30035B0E6 /* BusinessInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoViewController.swift; sourceTree = "<group>"; };
 		2233EAAA2BD7A1E200A315BF /* OrderPaymentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentResponseDTO.swift; sourceTree = "<group>"; };
 		2233EAAE2BE142C900A315BF /* TicketingErrorResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingErrorResponseDTO.swift; sourceTree = "<group>"; };
+		223698F82C8B36B6002C8081 /* GetUploadURLReponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUploadURLReponseDTO.swift; sourceTree = "<group>"; };
+		223698FA2C8B3BA3002C8081 /* UploadProfileImageRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadProfileImageRequestDTO.swift; sourceTree = "<group>"; };
 		224BEEDE2C4A0B7700863970 /* TicketingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingType.swift; sourceTree = "<group>"; };
 		224BEEFE2C4CC9BA00863970 /* GiftingConfirmDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingConfirmDIContainer.swift; sourceTree = "<group>"; };
 		224BEF002C4CCA9A00863970 /* GiftingConfirmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingConfirmViewController.swift; sourceTree = "<group>"; };
@@ -1407,6 +1411,7 @@
 				876BF16B2B6A43BB00DB4BCB /* TokenRefreshRequestDTO.swift */,
 				845D88582B877B0E00179F60 /* ResignRequestDTO.swift */,
 				221393692C89EBA800459A20 /* EditProfileRequestDTO.swift */,
+				223698FA2C8B3BA3002C8081 /* UploadProfileImageRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1418,6 +1423,7 @@
 				8757BAB72B600B1B008503B5 /* SignUpResponseDTO.swift */,
 				876BF16D2B6A45AD00DB4BCB /* TokenRefreshResponseDTO.swift */,
 				84D1C3822B79B71600527998 /* UserResponseDTO.swift */,
+				223698F82C8B36B6002C8081 /* GetUploadURLReponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -2512,6 +2518,7 @@
 				84FBBDF32B673877009462E9 /* ConcertInfoView.swift in Sources */,
 				84E5124B2B6E71FD002658D1 /* ConcertDetailDIContainer.swift in Sources */,
 				870099AE2B77434A001779FB /* TicketDetailRequestDTO.swift in Sources */,
+				223698FB2C8B3BA3002C8081 /* UploadProfileImageRequestDTO.swift in Sources */,
 				22DD8C8C2BD2897E0083622C /* TicketingAPI.swift in Sources */,
 				22739A462C510585000A357B /* RegisterGiftRequestDTO.swift in Sources */,
 				84781CB12B5BF85400D37921 /* HomeTabBarController.swift in Sources */,
@@ -2783,6 +2790,7 @@
 				84A7134A2B7C8999000BABCB /* QRExpandViewController.swift in Sources */,
 				877CAFC92B7BC2FB004799C8 /* TicketRefundConfirmViewModel.swift in Sources */,
 				84625A092B63A01100CC9077 /* TicketSelectionViewController.swift in Sources */,
+				223698F92C8B36B6002C8081 /* GetUploadURLReponseDTO.swift in Sources */,
 				8757BAAA2B5FDF29008503B5 /* KakaoOAuth.swift in Sources */,
 				84E5124F2B6E773F002658D1 /* ConcertDetailViewModel.swift in Sources */,
 				877CAFC72B7BC2ED004799C8 /* TicketRefundConfirmViewController.swift in Sources */,

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Request/UploadProfileImageRequestDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Request/UploadProfileImageRequestDTO.swift
@@ -1,0 +1,20 @@
+//
+//  UploadProfileImageRequestDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 9/6/24.
+//
+
+import UIKit
+
+struct UploadProfileImageRequestDTO {
+
+    let uploadUrl: String
+    let imageData: UIImage
+    
+    init(uploadUrl: String, image: UIImage) {
+        self.uploadUrl = uploadUrl
+        self.imageData = image
+    }
+
+}

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Response/GetUploadURLReponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Response/GetUploadURLReponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  GetUploadURLReponseDTO.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 9/6/24.
+//
+
+struct GetUploadURLReponseDTO: Decodable {
+
+    let uploadUrl: String
+    let expectedUrl: String
+
+}

--- a/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/AuthInterceptor.swift
@@ -21,10 +21,14 @@ final class AuthInterceptor: RequestInterceptor {
 
         var urlRequest = urlRequest
 
-        urlRequest.headers.add(.authorization(bearerToken: UserDefaults.accessToken))
-        
-        debugPrint("🔥 요청한 AccessToken: \(UserDefaults.accessToken) 🔥")
-        debugPrint("🔥 요청한 userId: \(UserDefaults.userId) 🔥")
+        if urlRequest.method == .put {
+            debugPrint("🔥 이미지 업로드 요청 🔥")
+        } else {
+            urlRequest.headers.add(.authorization(bearerToken: UserDefaults.accessToken))
+            
+            debugPrint("🔥 요청한 AccessToken: \(UserDefaults.accessToken) 🔥")
+            debugPrint("🔥 요청한 userId: \(UserDefaults.userId) 🔥")
+        }
 
         completion(.success(urlRequest))
     }

--- a/Boolti/Boolti/Sources/Network/Foundation/NetworkProvider.swift
+++ b/Boolti/Boolti/Sources/Network/Foundation/NetworkProvider.swift
@@ -23,6 +23,7 @@ final class NetworkProvider: NetworkProviderType {
     }
 
     func request(_ api: ServiceAPI) -> Single<Response> {
+        let baseURL = "\(api.baseURL)"
         let requestString = "\(api.path)"
         let endpoint = MultiTarget.target(api)
 
@@ -100,7 +101,7 @@ final class NetworkProvider: NetworkProviderType {
                     }
                 },
                 onSubscribed: {
-                    debugPrint("❓ REQUEST: [\(api.method.rawValue)] \(requestString)")
+                    debugPrint("❓ REQUEST: [\(api.method.rawValue)] \(baseURL)\(requestString)")
                 }
             )
     }

--- a/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
@@ -5,7 +5,7 @@
 //  Created by Miro on 1/23/24.
 //
 
-import Foundation
+import UIKit
 
 import RxSwift
 import KakaoSDKUser
@@ -23,6 +23,8 @@ protocol AuthRepositoryType {
     func userProfile() -> Single<UserResponseDTO>
     func resign(reason: String, appleIdAuthorizationCode: String?) -> Single<Void>
     func fetchProfile(profileImageUrl: String, nickname: String, introduction: String, links: [LinkEntity]) -> Single<Void>
+    func getUploadImageURL() -> Single<GetUploadURLReponseDTO>
+    func uploadProfileImage(uploadURL: String, imageData: UIImage) -> Single<String>
 }
 
 final class AuthRepository: AuthRepositoryType {
@@ -206,6 +208,20 @@ final class AuthRepository: AuthRepositoryType {
                 UserDefaults.userImageURLPath = user.imgPath ?? ""
                 return .just(())
             })
+    }
+    
+    func getUploadImageURL() -> Single<GetUploadURLReponseDTO> {
+        let api = AuthAPI.getUploadImageURL
+        
+        return self.networkService.request(api)
+            .map(GetUploadURLReponseDTO.self)
+    }
+    
+    func uploadProfileImage(uploadURL: String, imageData: UIImage) -> Single<String> {
+        let api = AuthAPI.uploadProfileImage(data: UploadProfileImageRequestDTO(uploadUrl: uploadURL, image: imageData))
+        
+        return self.networkService.request(api)
+            .map { _ in return uploadURL }
     }
 
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -182,10 +182,9 @@ extension EditProfileViewController {
         }
         
         self.viewModel.saveProfile(nickname: nickname,
-                                    introduction: introduction,
-                                    // TODO: - 이미지 변경 필요
-                                    profileImageUrl: UserDefaults.userImageURLPath,
-                                    links: self.viewModel.output.links)
+                                   introduction: introduction,
+                                   profileImage: self.editProfileImageView.profileImageView.image,
+                                   links: self.viewModel.output.links)
     }
     
     private func configureLinkCollectionView() {
@@ -251,7 +250,7 @@ extension EditProfileViewController {
 // MARK: - UIImagePickerControllerDelegate, UINavigationControllerDelegate
 
 extension EditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-
+    
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         picker.dismiss(animated: true) {
             if let image = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
@@ -259,7 +258,7 @@ extension EditProfileViewController: UIImagePickerControllerDelegate, UINavigati
             }
         }
     }
-
+    
 }
 
 // MARK: - UIScrollViewDelegate

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -59,6 +59,13 @@ final class EditProfileViewController: BooltiViewController {
     
     private let popupView = BooltiPopupView()
     
+    private let imagePickerController: UIImagePickerController = {
+        let imagePickerController = UIImagePickerController()
+        imagePickerController.sourceType = .photoLibrary
+        imagePickerController.allowsEditing = true
+        return imagePickerController
+    }()
+    
     // MARK: Initailizer
     
     init(viewModel: EditProfileViewModel) {
@@ -83,6 +90,7 @@ final class EditProfileViewController: BooltiViewController {
         self.configureKeyboardNotification()
         self.configureToastView(isButtonExisted: false)
         self.configureLinkCollectionView()
+        self.configureImagePickerController()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -128,7 +136,7 @@ extension EditProfileViewController {
             .when(.recognized)
             .asDriver(onErrorDriveWith: .never())
             .drive(with: self) { owner, _ in
-                // TODO: - 이미지 변경
+                owner.present(owner.imagePickerController, animated: true)
             }
             .disposed(by: self.disposeBag)
         
@@ -191,6 +199,10 @@ extension EditProfileViewController {
                                                       forCellWithReuseIdentifier: EditLinkCollectionViewCell.className)
     }
     
+    private func configureImagePickerController() {
+        self.imagePickerController.delegate = self
+    }
+    
     private func updateCollectionViewHeight() {
         self.editLinkView.linkCollectionView.layoutIfNeeded()
         let height = self.editLinkView.linkCollectionView.contentSize.height
@@ -236,6 +248,19 @@ extension EditProfileViewController {
     
 }
 
+// MARK: - UIImagePickerControllerDelegate, UINavigationControllerDelegate
+
+extension EditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        picker.dismiss(animated: true) {
+            if let image = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
+                self.editProfileImageView.profileImageView.image = image
+            }
+        }
+    }
+
+}
 
 // MARK: - UIScrollViewDelegate
 


### PR DESCRIPTION
## 작업한 내용
> 프로필 이미지 업로드
- aws의 presignedURL을 사용했어요.
- aws의 uploadUrl에 이미지를 넣어서 보낼 때 header에 accesstoken이 있으면 403 오류가 납니다. 그래서 AuthInterceptor를 아래와 같이 수정해주었습니다.

```swift
if urlRequest.method == .put {
    debugPrint("🔥 이미지 업로드 요청 🔥")
} else {
    urlRequest.headers.add(.authorization(bearerToken: UserDefaults.accessToken))
    
    debugPrint("🔥 요청한 AccessToken: \(UserDefaults.accessToken) 🔥")
    debugPrint("🔥 요청한 userId: \(UserDefaults.userId) 🔥")
}
```

- 프로필 이미지 업로드 흐름은 다음과 같습니다.
1. 이미지 업로드 url 받기
2. aws의 이미지 업로드 url로 이미지 업로드
3. 업로드한 이미지를 볼 수 있는 링크 (expectedUrl) 서버에게 전송

```swift
self.authRepository.getUploadImageURL()
    .flatMap({ [weak self] response -> Single<String> in
        guard let self = self else { return .just("") }
        return self.authRepository.uploadProfileImage(uploadURL: response.uploadUrl, imageData: profileImage)
            .map { _ in response.expectedUrl }
    })
    .flatMap({ [weak self] profileImageUrl -> Single<Void> in
        guard let self = self else { return .just(()) }
        return self.authRepository.fetchProfile(profileImageUrl: profileImageUrl,
                                                nickname: nickname,
                                                introduction: introduction,
                                                links: links)
    })
    .subscribe(with: self) { owner, _ in
        owner.output.didProfileSave.onNext(())
    }
    .disposed(by: self.disposeBag)
```

## 스크린샷
https://github.com/user-attachments/assets/c1a5e089-44bc-48a8-add9-633d215cf406


## 관련 이슈
- Resolved: #342