### PR TITLE
Fix/#350 MVP7 QA(2) 수정사항 반영 완료

### DIFF
--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Response/UserResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Response/UserResponseDTO.swift
@@ -19,7 +19,7 @@ struct UserResponseDTO: Decodable {
     
 }
 
-struct LinkEntity: Codable {
+struct LinkEntity: Codable, Equatable {
     let title: String
     let link: String
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -129,10 +129,20 @@ extension EditProfileViewController {
             }
             .disposed(by: self.disposeBag)
         
-        self.viewModel.output.didProfileSave
+        self.viewModel.output.didProfileSaved
             .subscribe(with: self) { owner, _ in
                 owner.showToast(message: "프로필 편집을 완료했어요")
                 owner.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: self.disposeBag)
+
+        self.viewModel.output.isProfileChanged
+            .subscribe(with: self) { owner, isChanged in
+                if isChanged {
+                    owner.popupView.showPopup(with: .saveProfile, withCancelButton: true)
+                } else {
+                    owner.navigationController?.popViewController(animated: true)
+                }
             }
             .disposed(by: self.disposeBag)
     }
@@ -166,9 +176,7 @@ extension EditProfileViewController {
             .disposed(by: self.disposeBag)
 
         self.navigationBar.didBackButtonTap()
-            .emit(with: self) { owner, _ in
-                owner.popupView.showPopup(with: .saveProfile, withCancelButton: true)
-            }
+            .emit(to: self.viewModel.input.didBackButtonTapped)
             .disposed(by: self.disposeBag)
         
         self.navigationBar.didCompleteButtonTap()

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewModel.swift
@@ -14,7 +14,7 @@ final class EditProfileViewModel {
 
     // TODO: DOMAIN 객체 제대로 정의하기
     // - Domain 객체
-    struct Profile {
+    struct Profile: Equatable {
         var image: UIImage? = UIImage() // TODO: URL 뽑아오는 로직 변경하기!..
         var imageURL: String? = ""
         var nickName: String? = ""
@@ -35,14 +35,19 @@ final class EditProfileViewModel {
 
         let didNavigationBarCompleteButtonTapped = PublishSubject<Void>()
         let didPopUpConfirmButtonTapped = PublishSubject<Void>()
+        let didBackButtonTapped = PublishSubject<Void>()
     }
 
     struct Output {
         // Links - RxCocoa Datasource로 변경하기
         let fetchedProfile = BehaviorRelay<Profile?>(value: nil)
         // Edit이된 Profile
+        // TODO: 아래의 로직을 Rx로 바꾸기..
+        // Profile이 변경되었는 지 아닌 지를 판단하는 로직 변경하기.. -> 현재는 두 개의 객체를 생성해서 Equatable로 비교
         var profile = Profile()
-        let didProfileSave = PublishSubject<Void>()
+        var initialProfile = Profile()
+        let didProfileSaved = PublishSubject<Void>()
+        let isProfileChanged = PublishSubject<Bool>()
     }
     
     var input: Input
@@ -89,6 +94,13 @@ extension EditProfileViewModel {
             })
             .disposed(by: self.disposeBag)
 
+        self.input.didBackButtonTapped
+            .subscribe(with: self) { owner, _ in
+                let isChanged = !(owner.output.profile == owner.output.initialProfile)
+                owner.output.isProfileChanged.onNext(isChanged)
+            }
+            .disposed(by: self.disposeBag)
+
         Observable.merge(self.input.didNavigationBarCompleteButtonTapped, self.input.didPopUpConfirmButtonTapped)
             .subscribe(with: self) { owner, _ in
                 owner.save(owner.output.profile)
@@ -105,8 +117,10 @@ extension EditProfileViewModel {
     func fetchProfile() {
         // TODO: 추후에 Domain 객체로 변경
         self.authRepository.userProfile()
-            .map({ DTO in
-                return Profile(image: nil, imageURL: DTO.imgPath, nickName: DTO.nickname, introduction: DTO.introduction, links: DTO.link)
+            .map({ [weak self] DTO in
+                let fetchedProfile = Profile(image: nil, imageURL: DTO.imgPath, nickName: DTO.nickname, introduction: DTO.introduction, links: DTO.link)
+                self?.output.initialProfile = fetchedProfile
+                return fetchedProfile
             })
             .subscribe(with: self) { owner, profile in
                 owner.output.profile = profile
@@ -131,7 +145,7 @@ extension EditProfileViewModel {
                                                        links: profile.links ?? [])
             })
             .subscribe(with: self) { owner, _ in
-                owner.output.didProfileSave.onNext(())
+                owner.output.didProfileSaved.onNext(())
             }
             .disposed(by: self.disposeBag)
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditNicknameView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditNicknameView.swift
@@ -62,12 +62,12 @@ extension EditNicknameView {
     
     func setData(with name: String) {
         self.nicknameTextField.text = name
-        self.nicknameTextField.sendActions(for: .editingChanged)
     }
     
     private func bindTextField() {
         self.nicknameTextField.rx.text
             .asDriver()
+            .skip(1)
             .drive(with: self) { owner, changedText in
                 guard let changedText = changedText else { return }
                 owner.nicknameTextField.text = changedText


### PR DESCRIPTION
## 작업한 내용
- 프로필 변경사항이 있는 지 판단하는 로직을 추가했어요.
  - Profile 객체에 Equatable 프로토콜을 채택하게해서 변경전 Profile과 변경 후 Profile이 동일한 지 판단하게 했어요.
  - 근데 위 방법은 굳이 객체를 두 개를 만들어야해요. 요건 담에 Rx를 활용해서 두 객체를 만들지 않아도 되게 변경해볼게요.
- NickNameTextField 초기 이벤트를 Skip해서 화면 진입 보이는 에러 문구를 보이지 않게 변경했어요.

## 관련 이슈
- Resolved: #350 
