### PR TITLE
Feature/#352 mvp7 qa3

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -347,18 +347,6 @@ extension ConcertDetailViewController {
             link: link,
             domainURIPrefix: dynamicLinksDomainURIPrefix
         ) else { return nil }
-        
-        // iOS
-        linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: AppInfo.bundleID)
-
-        // Android
-        #if DEBUG
-        linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.androidDebugPackageName)
-        #elseif RELEASE
-        linkBuilder.androidParameters = DynamicLinkAndroidParameters(packageName: AppInfo.bundleID)
-        #endif
-        linkBuilder.androidParameters?.fallbackURL = link
-
         return linkBuilder.url
     }
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditLink/EditLinkViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditLink/EditLinkViewController.swift
@@ -134,6 +134,13 @@ final class EditLinkViewController: BooltiViewController {
             }
             .disposed(by: self.disposeBag)
 
+        self.linkNameTextField.rx.controlEvent([.editingDidBegin])
+            .bind(with: self) { owner, _ in
+                guard let nameText = owner.linkNameTextField.text else { return }
+                owner.linkNameTextField.isButtonHidden = nameText.isEmpty
+            }
+            .disposed(by: self.disposeBag)
+
         // URL 설정
         let URLTextFieldObservable = self.URLTextField.rx.text.orEmpty
 
@@ -150,6 +157,14 @@ final class EditLinkViewController: BooltiViewController {
                 owner.URLTextField.text = ""
                 owner.URLTextField.isButtonHidden = true
                 owner.navigationBar.completeButton.isEnabled = false
+            }
+            .disposed(by: self.disposeBag)
+
+        // textField를 선택하면 empty인 지 판단하여 button을 보여줄 지 말지 결정한다.
+        self.URLTextField.rx.controlEvent([.editingDidBegin])
+            .bind(with: self) { owner, _ in
+                guard let urlText = owner.URLTextField.text else { return }
+                owner.URLTextField.isButtonHidden = urlText.isEmpty
             }
             .disposed(by: self.disposeBag)
 
@@ -196,20 +211,13 @@ final class EditLinkViewController: BooltiViewController {
         self.bindPopUpViewComponents()
 
         // 키보드
+        /// 키보드가 내려갈 때는 무조건 button을 숨긴다.
         RxKeyboard.instance.isHidden
             .skip(1)
             .drive(with: self) { owner, isHidden in
-                print("isHidden = \(isHidden)")
                 if isHidden {
                     owner.linkNameTextField.isButtonHidden = true
                     owner.URLTextField.isButtonHidden = true
-                } else {
-                    if let nameText = owner.linkNameTextField.text {
-                        owner.linkNameTextField.isButtonHidden = nameText.isEmpty
-                    }
-                    if let urlText = owner.URLTextField.text {
-                        owner.URLTextField.isButtonHidden = urlText.isEmpty
-                    }
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditIntroductionView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditIntroductionView.swift
@@ -32,7 +32,7 @@ final class EditIntroductionView: UIView {
         textView.font = .body3
         textView.text = "예) 재즈와 펑크락을 좋아해요"
         textView.textColor = .grey70
-        textView.isScrollEnabled = false
+        textView.isScrollEnabled = true
         return textView
     }()
 
@@ -140,26 +140,25 @@ extension EditIntroductionView {
             make.top.leading.equalToSuperview().inset(20)
         }
 
-        self.introductionTextView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview().inset(32)
-            make.top.equalToSuperview().inset(74)
-            make.bottom.equalToSuperview().inset(58)
-            make.height.greaterThanOrEqualTo(72)
-        }
-
         self.backgroundView.snp.makeConstraints { make in
-            make.height.greaterThanOrEqualTo(122)
+            make.height.equalTo(122)
             make.horizontalEdges.equalToSuperview().inset(20)
             make.top.equalTo(self.introductionLabel.snp.bottom).offset(16)
-            make.bottom.equalTo(self.introductionTextView.snp.bottom).offset(38)
+        }
+
+        self.introductionTextView.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(self.backgroundView.snp.horizontalEdges).inset(12)
+            make.top.equalTo(self.backgroundView.snp.top).inset(12)
+            make.height.equalTo(72)
         }
         
         self.textCountLabel.snp.makeConstraints { make in
-            make.bottom.trailing.equalTo(self.backgroundView).inset(12)
+            make.top.equalTo(self.introductionTextView.snp.bottom).offset(8)
+            make.trailing.equalTo(self.backgroundView).inset(12)
         }
 
         self.snp.makeConstraints { make in
-            make.bottom.equalTo(self.backgroundView.snp.bottom).offset(20)
+            make.height.equalTo(204)
         }
     }
 }


### PR DESCRIPTION
## 작업한 내용
`프로필 소개`

- 3줄 입력 가능한 높이값으로 고정
- 3줄 이상 입력 시 먼저 입력한 줄이 상단으로 밀리고 미노출됨
- 저장 후 프로필 편집 페이지 재접근 시에는 1-3번째줄이 노출됨 (스크롤로 4-5번째줄 텍스트 확인 가능)

`링크 편집`

- 각각만 포커싱 되게 변경하기

`공연 공유`
- 앱이 있을 경우 -> 앱이 열리는 것이 아니라 웹으로 무조건 열리도록 변경


## 관련 이슈
- Resolved: #352 
