### PR TITLE
Chore/#375 공연 정보 공유 포맷 변경

### DIFF
--- a/Boolti/Boolti/Sources/Entities/Concert/ConcertDetailEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Concert/ConcertDetailEntity.swift
@@ -30,4 +30,19 @@ struct ConcertDetailEntity {
         let thumbnailPath: String
         let sequence: Int
     }
+    
+    func convertToShareConcertString() -> String {
+        let formattedString = """
+        공연 정보를 공유드려요!
+
+        공연명 : \(name)
+        일시 : \(date.format(.dateDayTimeWithDash))
+        장소 : \(placeName) / \(streetAddress), \(detailAddress)
+
+        공연 상세 정보 ▼ 
+        https://preview.boolti.in/show/\(id)
+        """
+        
+        return formattedString
+    }
 }

--- a/Boolti/Boolti/Sources/Global/Extensions/Date+.swift
+++ b/Boolti/Boolti/Sources/Global/Extensions/Date+.swift
@@ -14,6 +14,7 @@ enum DateFormatType: String {
     case dateTime = "yyyy.MM.dd HH:mm"
     case dateDayTimeWithSlash = "yyyy.MM.dd (E) / HH:mm"
     case isoDateTime = "yyyy-MM-dd'T'HH:mm:ss"
+    case dateDayTimeWithDash = "yyyy.MM.dd (E) HH:mm -"
 }
 
 extension DateFormatType {

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -351,21 +351,19 @@ extension ConcertDetailViewController {
         
         self.navigationBar.didShareButtonTap()
             .emit(with: self) { owner, _ in
-                guard let posterURL = owner.viewModel.output.concertDetail.value?.posters.first?.path
-                else { return }
-                guard let concertID = owner.viewModel.output.concertDetail.value?.id else { return }
+                guard let concertDetail = owner.viewModel.output.concertDetail.value else { return }
+                
+                let concertInfo = concertDetail.convertToShareConcertString()
 
-                let image = KFImage(URL(string: posterURL))
-
-                guard let link = URL(string: "https://preview.boolti.in/show/\(concertID)") else { return }
                 let activityViewController = UIActivityViewController(
-                    activityItems: [link, image],
+                    activityItems: [concertInfo],
                     applicationActivities: nil
                 )
                 activityViewController.popoverPresentationController?.sourceView = owner.view
                 owner.present(activityViewController, animated: true, completion: nil)
             }
             .disposed(by: self.disposeBag)
+
         self.navigationBar.didMoreButtonTap()
             .emit(with: self) { owner, _ in
                 let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)


### PR DESCRIPTION
## 작업한 내용
- 공연 정보 공유 포맷을 변경했어요.
- 기존에 있던 concertDetailEntity 구조체에 formatting하는 함수를 만들었어요.

#### 참고
- 공연 링크 아래에 있는 공백은 자동으로 들어가고 있어서 .. 어떻게 삭제하는지 더 찾아보겠습니다!!
- 현재 공연 상세 정보 링크가 prod으로 되어있어서 dev 버전에서 수정이 필요합니다!

## 스크린샷
<img src=https://github.com/user-attachments/assets/433af593-2f03-4bdb-8ca7-c08392899c06 width=300>


## 관련 이슈
- Resolved: #375 
