### PR TITLE
Feature/#379 프로필 링크 UI 수정 및 전체보기 뷰 구현

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		22739A462C510585000A357B /* RegisterGiftRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A452C510585000A357B /* RegisterGiftRequestDTO.swift */; };
 		22739A482C511058000A357B /* GiftInfoRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A472C511058000A357B /* GiftInfoRequestDTO.swift */; };
 		22739A4A2C5110FB000A357B /* GiftInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A492C5110FB000A357B /* GiftInfoResponseDTO.swift */; };
+		22B67B362CE0618F004F6D4A /* LinkListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B67B352CE06187004F6D4A /* LinkListViewController.swift */; };
+		22B67B382CE06495004F6D4A /* LinkListDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B67B372CE0648A004F6D4A /* LinkListDIContainer.swift */; };
+		22B67B3A2CE065E1004F6D4A /* LinkListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B67B392CE065DA004F6D4A /* LinkListViewModel.swift */; };
 		22CDB2C62BA2635E00D2077D /* BusinessInfoDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB2C52BA2635E00D2077D /* BusinessInfoDIContainer.swift */; };
 		22CF3A2F2BB51A710094711C /* SelectedSalesTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF3A2E2BB51A710094711C /* SelectedSalesTicketView.swift */; };
 		22CF3A312BB586B50094711C /* SelectedInvitationTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF3A302BB586B50094711C /* SelectedInvitationTicketView.swift */; };
@@ -467,6 +470,9 @@
 		22739A452C510585000A357B /* RegisterGiftRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterGiftRequestDTO.swift; sourceTree = "<group>"; };
 		22739A472C511058000A357B /* GiftInfoRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftInfoRequestDTO.swift; sourceTree = "<group>"; };
 		22739A492C5110FB000A357B /* GiftInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftInfoResponseDTO.swift; sourceTree = "<group>"; };
+		22B67B352CE06187004F6D4A /* LinkListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkListViewController.swift; sourceTree = "<group>"; };
+		22B67B372CE0648A004F6D4A /* LinkListDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkListDIContainer.swift; sourceTree = "<group>"; };
+		22B67B392CE065DA004F6D4A /* LinkListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkListViewModel.swift; sourceTree = "<group>"; };
 		22CDB2C52BA2635E00D2077D /* BusinessInfoDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessInfoDIContainer.swift; sourceTree = "<group>"; };
 		22CF3A2E2BB51A710094711C /* SelectedSalesTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSalesTicketView.swift; sourceTree = "<group>"; };
 		22CF3A302BB586B50094711C /* SelectedInvitationTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedInvitationTicketView.swift; sourceTree = "<group>"; };
@@ -1025,6 +1031,16 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		22B67B342CE0617A004F6D4A /* LinkList */ = {
+			isa = PBXGroup;
+			children = (
+				22B67B372CE0648A004F6D4A /* LinkListDIContainer.swift */,
+				22B67B352CE06187004F6D4A /* LinkListViewController.swift */,
+				22B67B392CE065DA004F6D4A /* LinkListViewModel.swift */,
+			);
+			path = LinkList;
+			sourceTree = "<group>";
+		};
 		22CDB2C42BA2633600D2077D /* BusinessInfo */ = {
 			isa = PBXGroup;
 			children = (
@@ -1097,6 +1113,7 @@
 				221393532C88990A00459A20 /* Main */,
 				221393542C88991200459A20 /* EditProfile */,
 				8749F5812C88B8E200FC4365 /* EditLink */,
+				22B67B342CE0617A004F6D4A /* LinkList */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -2525,6 +2542,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22B67B3A2CE065E1004F6D4A /* LinkListViewModel.swift in Sources */,
 				87617F6D2B8ECC3500828C69 /* TicketInformationView.swift in Sources */,
 				84A024892B7B98710095A56E /* SelectedTicketEntity.swift in Sources */,
 				845F25442B89FA3800F6C328 /* PosterExpandDIContainer.swift in Sources */,
@@ -2558,6 +2576,7 @@
 				84E5124D2B6E7736002658D1 /* ConcertDetailViewController.swift in Sources */,
 				221393632C89CC7E00459A20 /* EditLinkView.swift in Sources */,
 				84FBBDF32B673877009462E9 /* ConcertInfoView.swift in Sources */,
+				22B67B382CE06495004F6D4A /* LinkListDIContainer.swift in Sources */,
 				87C7A5EE2CADB1CD0078213E /* SegmentedControlContainerView.swift in Sources */,
 				84E5124B2B6E71FD002658D1 /* ConcertDetailDIContainer.swift in Sources */,
 				870099AE2B77434A001779FB /* TicketDetailRequestDTO.swift in Sources */,
@@ -2617,6 +2636,7 @@
 				877CAFCE2B7BD281004799C8 /* RefundConfirmContentView.swift in Sources */,
 				843918FA2B7A82B200CC62AA /* ReportDIContainer.swift in Sources */,
 				8753CA7D2B7228F2002871C7 /* TicketDetailItemEntity.swift in Sources */,
+				22B67B362CE0618F004F6D4A /* LinkListViewController.swift in Sources */,
 				224BEF052C4CCB5200863970 /* GiftingEntity.swift in Sources */,
 				84D1C3852B7A14AD00527998 /* CheckInvitationCodeRequestDTO.swift in Sources */,
 				224BEEDF2C4A0B7700863970 /* TicketingType.swift in Sources */,

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditLink/EditLinkViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditLink/EditLinkViewController.swift
@@ -70,6 +70,7 @@ final class EditLinkViewController: BooltiViewController {
         self.configureUI()
         self.configureConstraints()
         self.bindUIComponents()
+        self.configureToastView(isButtonExisted: false)
     }
 
     private func configureUI() {
@@ -186,8 +187,10 @@ final class EditLinkViewController: BooltiViewController {
                 switch owner.editType {
                 case .add:
                     owner.delegate?.editLinkViewController(self, didAddedLink: LinkEntity(title: title, link: link))
+                    owner.showToast(message: "링크를 추가했어요")
                 case .edit:
                     owner.delegate?.editLinkViewController(self, didChangedLink: LinkEntity(title: title, link: link))
+                    owner.showToast(message: "링크를 편집했어요")
                 }
                 owner.navigationController?.popViewController(animated: true)
             }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -308,7 +308,6 @@ extension EditProfileViewController: UICollectionViewDataSource {
         return links.count
     }
     
-    /// 헤더를 결정하는 메서드
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard kind == UICollectionView.elementKindSectionHeader,
               let header = collectionView.dequeueReusableSupplementaryView(
@@ -316,6 +315,9 @@ extension EditProfileViewController: UICollectionViewDataSource {
                 withReuseIdentifier: AddLinkHeaderView.className,
                 for: indexPath
               ) as? AddLinkHeaderView else { return UICollectionReusableView() }
+        
+        // 기존 disposeBag이 있다면 초기화
+        header.disposeBag = DisposeBag()
         
         header.rx.tapGesture()
             .when(.recognized)
@@ -349,16 +351,6 @@ extension EditProfileViewController: UICollectionViewDataSource {
         let viewController = EditLinkViewController(editType: .edit(linkEntity))
         viewController.delegate = self
         self.navigationController?.pushViewController(viewController, animated: true)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath) {
-        guard let header = collectionView.dequeueReusableSupplementaryView(
-            ofKind: elementKind,
-            withReuseIdentifier: AddLinkHeaderView.className,
-            for: indexPath
-        ) as? AddLinkHeaderView else { return }
-        
-        header.disposeBag = DisposeBag()
     }
     
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/AddLinkHeaderView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/AddLinkHeaderView.swift
@@ -11,9 +11,11 @@ import RxSwift
 
 final class AddLinkHeaderView: UICollectionReusableView {
     
-    // MARK: UI Components
+    // MARK: Properties
     
     var disposeBag = DisposeBag()
+    
+    // MARK: UI Components
     
     private let addLinkImageView: UIImageView = {
         let imageView = UIImageView()

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/AddLinkHeaderView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/AddLinkHeaderView.swift
@@ -43,6 +43,13 @@ final class AddLinkHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: Life Cycle
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.disposeBag = DisposeBag()
+    }
+    
 }
 
 // MARK: - UI

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/LinkList/LinkListDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/LinkList/LinkListDIContainer.swift
@@ -1,0 +1,19 @@
+//
+//  LinkListDIContainer.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 11/10/24.
+//
+
+import UIKit
+
+final class LinkListDIContainer {
+
+    func createLinkListViewController(linkList: [LinkEntity]) -> LinkListViewController {
+        let viewModel = LinkListViewModel(linkList: linkList)
+        let viewController = LinkListViewController(viewModel: viewModel)
+
+        return viewController
+    }
+
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/LinkList/LinkListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/LinkList/LinkListViewController.swift
@@ -1,0 +1,152 @@
+//
+//  LinkListViewController.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 11/10/24.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class LinkListViewController: BooltiViewController {
+    
+    // MARK: Properties
+    
+    private let disposeBag = DisposeBag()
+    private var viewModel: LinkListViewModel
+    
+    // MARK: UI Components
+    
+    private let navigationBar = BooltiNavigationBar(type: .backButtonWithTitle(title: "링크"))
+    
+    private let linkCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.backgroundColor = .clear
+        collectionView.isScrollEnabled = false
+        collectionView.contentInset = .init(top: 20, left: 0, bottom: 20, right: 0)
+        return collectionView
+    }()
+    
+    // MARK: Initailizer
+    
+    init(viewModel: LinkListViewModel) {
+        self.viewModel = viewModel
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.configureUI()
+        self.configureToastView(isButtonExisted: false)
+        self.configureCollectionView()
+        self.bindUIComponents()
+    }
+    
+}
+
+// MARK: - Methods
+
+extension LinkListViewController {
+    
+    private func bindUIComponents() {
+        self.navigationBar.didBackButtonTap()
+            .emit(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.linkCollectionView.rx.itemSelected
+            .map { $0.row }
+            .subscribe(with: self) { owner, index in
+                guard let url = URL(string: owner.viewModel.linkList[index].link) else { return }
+                if UIApplication.shared.canOpenURL(url) {
+                    owner.openSafari(with: url)
+                } else {
+                    owner.showToast(message: "유효한 링크가 아니에요")
+                }
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func configureCollectionView() {
+        self.linkCollectionView.delegate = self
+        self.linkCollectionView.dataSource = self
+        
+        self.linkCollectionView.register(ProfileLinkCollectionViewCell.self, forCellWithReuseIdentifier: ProfileLinkCollectionViewCell.className)
+    }
+    
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension LinkListViewController: UICollectionViewDataSource {
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.viewModel.linkList.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileLinkCollectionViewCell.className,
+                                                            for: indexPath) as? ProfileLinkCollectionViewCell else { return UICollectionViewCell() }
+        cell.setData(linkName: self.viewModel.linkList[indexPath.row].title)
+        return cell
+    }
+    
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension LinkListViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: self.linkCollectionView.frame.width - 40, height: 56)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 16
+    }
+
+}
+
+
+// MARK: - UI
+
+extension LinkListViewController {
+    
+    private func configureUI() {
+        self.view.backgroundColor = .grey95
+        self.view.addSubviews([self.navigationBar,
+                               self.linkCollectionView])
+
+        self.configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        self.navigationBar.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+        }
+        
+        self.linkCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(self.navigationBar.snp.bottom)
+            make.horizontalEdges.bottom.equalToSuperview()
+        }
+    }
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/LinkList/LinkListViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/LinkList/LinkListViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  LinkListViewModel.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 11/10/24.
+//
+
+final class LinkListViewModel {
+    
+    // MARK: Properties
+    
+    let linkList: [LinkEntity]
+    
+    // MARK: Initailizer
+    
+    init(linkList: [LinkEntity]) {
+        self.linkList = linkList
+    }
+    
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileDIContainer.swift
@@ -17,6 +17,7 @@ final class ProfileDIContainer {
 
     func createMyProfileViewController() -> ProfileViewController {
         let authRepository = self.repository as? AuthRepository ?? AuthRepository(networkService: NetworkProvider())
+
         let editProfileViewControllerFactory = {
             let DIContainer = EditProfileDIContainer(
                 authRepository: authRepository
@@ -26,17 +27,33 @@ final class ProfileDIContainer {
             return viewController
         }
         
+        let linkListViewControllerFactory: ([LinkEntity]) -> LinkListViewController = { linkList in
+            let DIContainer = LinkListDIContainer()
+            let viewController = DIContainer.createLinkListViewController(linkList: linkList)
+            
+            return viewController
+        }
+
         let viewModel = ProfileViewModel(repository: self.repository)
         let viewController = ProfileViewController(viewModel: viewModel,
-                                                   editProfileViewControllerFactory: editProfileViewControllerFactory)
+                                                   editProfileViewControllerFactory: editProfileViewControllerFactory,
+                                                   linkListControllerFactory: linkListViewControllerFactory)
 
         return viewController
     }
 
     func createProfileViewController(userCode: String) -> ProfileViewController {
-
         let viewModel = ProfileViewModel(repository: self.repository, userCode: userCode)
-        let viewController = ProfileViewController(viewModel: viewModel)
+        
+        let linkListViewControllerFactory: ([LinkEntity]) -> LinkListViewController = { linkList in
+            let DIContainer = LinkListDIContainer()
+            let viewController = DIContainer.createLinkListViewController(linkList: linkList)
+            
+            return viewController
+        }
+
+        let viewController = ProfileViewController(viewModel: viewModel,
+                                                   linkListControllerFactory: linkListViewControllerFactory)
 
         return viewController
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -214,6 +214,9 @@ extension ProfileViewController: UICollectionViewDataSource {
               ) as? ProfileLinkHeaderView else { return UICollectionReusableView() }
         
         header.expandButton.isHidden = self.viewModel.output.links.count <= 3
+        
+        // 기존 disposeBag이 있다면 초기화
+        header.disposeBag = DisposeBag()
         return header
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -19,6 +19,7 @@ final class ProfileViewController: BooltiViewController {
     private let viewModel: ProfileViewModel
     
     private let editProfileViewControllerFactory: (() -> EditProfileViewController)?
+    private let linkListControllerFactory: ([LinkEntity]) -> LinkListViewController
 
     // MARK: UI Components
     
@@ -63,10 +64,12 @@ final class ProfileViewController: BooltiViewController {
     // MARK: Initailizer
     
     init(viewModel: ProfileViewModel,
-         editProfileViewControllerFactory: (() -> EditProfileViewController)? = nil
+         editProfileViewControllerFactory: (() -> EditProfileViewController)? = nil,
+         linkListControllerFactory: @escaping ([LinkEntity]) -> LinkListViewController
     ) {
         self.viewModel = viewModel
         self.editProfileViewControllerFactory = editProfileViewControllerFactory
+        self.linkListControllerFactory = linkListControllerFactory
         
         super.init()
     }
@@ -217,6 +220,14 @@ extension ProfileViewController: UICollectionViewDataSource {
         
         // 기존 disposeBag이 있다면 초기화
         header.disposeBag = DisposeBag()
+        
+        header.expandButton.rx.tap
+            .asDriver()
+            .drive(with: self) { owner, _ in
+                let viewController = self.linkListControllerFactory(owner.viewModel.output.links)
+                owner.navigationController?.pushViewController(viewController, animated: true)
+            }
+            .disposed(by: header.disposeBag)
         return header
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -138,7 +138,7 @@ extension ProfileViewController {
                 if UIApplication.shared.canOpenURL(url) {
                     owner.openSafari(with: url)
                 } else {
-                    owner.showToast(message: "링크를 열 수 없습니다")
+                    owner.showToast(message: "유효한 링크가 아니에요")
                 }
             }
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -201,7 +201,7 @@ extension ProfileViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return self.viewModel.output.links.count
+        return min(self.viewModel.output.links.count, 3)
     }
     
     /// 헤더를 결정하는 메서드
@@ -213,6 +213,7 @@ extension ProfileViewController: UICollectionViewDataSource {
                 for: indexPath
               ) as? ProfileLinkHeaderView else { return UICollectionReusableView() }
         
+        header.expandButton.isHidden = self.viewModel.output.links.count <= 3
         return header
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileLinkHeaderView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileLinkHeaderView.swift
@@ -19,6 +19,17 @@ final class ProfileLinkHeaderView: UICollectionReusableView {
         return label
     }()
     
+    let expandButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 40, bottom: 2, trailing: 0)
+        config.title = "전체보기"
+        config.attributedTitle?.font = .body1
+        config.baseForegroundColor = .grey50
+        
+        let button = UIButton(configuration: config)
+        return button
+    }()
+    
     // MARK: Initailizer
     
     override init(frame: CGRect) {
@@ -38,14 +49,21 @@ final class ProfileLinkHeaderView: UICollectionReusableView {
 extension ProfileLinkHeaderView {
     
     private func configureUI() {
-        self.addSubview(self.titleLabel)
+        self.addSubviews([self.titleLabel,
+                          self.expandButton])
         self.configureConstraints()
     }
     
     private func configureConstraints() {
         self.titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(32)
-            make.horizontalEdges.equalToSuperview().inset(20)
+            make.leading.equalToSuperview().inset(20)
+        }
+        
+        self.expandButton.snp.makeConstraints { make in
+            make.centerY.equalTo(self.titleLabel)
+            make.trailing.equalToSuperview().inset(20)
+            
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileLinkHeaderView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileLinkHeaderView.swift
@@ -21,7 +21,7 @@ final class ProfileLinkHeaderView: UICollectionReusableView {
         let label = BooltiUILabel()
         label.font = .subhead2
         label.textColor = .grey10
-        label.text = "SNS 링크"
+        label.text = "링크"
         return label
     }()
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileLinkHeaderView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileLinkHeaderView.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+import RxSwift
+
 final class ProfileLinkHeaderView: UICollectionReusableView {
+    
+    // MARK: Properties
+
+    var disposeBag = DisposeBag()
     
     // MARK: UI Components
     
@@ -40,6 +46,13 @@ final class ProfileLinkHeaderView: UICollectionReusableView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Life Cycle
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.disposeBag = DisposeBag()
     }
     
 }


### PR DESCRIPTION
## 작업한 내용
- 프로필 메인 링크가 3개가 넘어갈 경우 3개까지만 표시하고 전체보기 버튼을 노출시켰어요.
- didEndDisplaying에서 오류가 생겨서 재사용 이슈를 해결하려고 `viewForSupplementaryElementOfKind`함수에 DisposeBag을 초기화하는 코드를 넣었고, header view에도 prepareForReuse함수를 넣어줬어요.
- 유효하지 않은 경우 토스트 메시지를 띄워줬어요.

## 스크린샷
https://github.com/user-attachments/assets/170309f2-de9a-446c-8aae-2cd0a8b626f3

https://github.com/user-attachments/assets/dd25d694-0e73-4735-b377-e019d0a01cb6

## 관련 이슈
- Resolved: #379 
