### PR TITLE
Fix/#380 business info cell 재사용 이슈 해결

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/BusinessInfoCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/Cells/BusinessInfoCollectionViewCell.swift
@@ -32,6 +32,14 @@ final class BusinessInfoCollectionViewCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError()
     }
+    
+    // MARK: Life Cycle
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.disposeBag = DisposeBag()
+    }
 }
 
 // MARK: - UI

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertList/ConcertListViewController.swift
@@ -188,11 +188,7 @@ extension ConcertListViewController: UICollectionViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         self.view.endEditing(true)
     }
-    
-    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BusinessInfoCollectionViewCell.className, for: indexPath) as? BusinessInfoCollectionViewCell else { return }
-        cell.disposeBag = DisposeBag()
-    }
+
 }
 
 // MARK: - UICollectionViewDataSource
@@ -254,6 +250,8 @@ extension ConcertListViewController: UICollectionViewDataSource {
             return cell
         case .information:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BusinessInfoCollectionViewCell.className, for: indexPath) as? BusinessInfoCollectionViewCell else { return UICollectionViewCell() }
+            
+            cell.disposeBag = DisposeBag()
             
             cell.businessInfoView.didInfoButtonTap()
                 .emit(with: self) { owner, _ in


### PR DESCRIPTION
## 작업한 내용
- 메인에서 business info collectionview cell에서 재사용 이슈가 나면서 화면 UI가 깨지는 오류를 수정했어요.
- cell에는 `prepareForReuse()` 함수를 추가했어요
```swift
override func prepareForReuse() {
    super.prepareForReuse()
    
    self.disposeBag = DisposeBag()
}
```
- 뷰에는 `cellForItemAt` 함수에 disposeBag 초기화 하는 함수를 넣어줬어요
```swift
case .information:
    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BusinessInfoCollectionViewCell.className, for: indexPath) as? BusinessInfoCollectionViewCell else { return UICollectionViewCell() }
    
    cell.disposeBag = DisposeBag()
    
    cell.businessInfoView.didInfoButtonTap()
        .emit(with: self) { owner, _ in
            let viewController = self.businessInfoViewControllerFactory()
            owner.navigationController?.pushViewController(viewController, animated: true)
        }
        .disposed(by: cell.disposeBag)
    return cell
```

## 관련 이슈
- Resolved: #380 
