### PR TITLE
Feature/#385 프로필 편집 뷰 sns view 추가

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		2251F6B42CE48E9B00906FF5 /* ProfileSnsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6B32CE48E9000906FF5 /* ProfileSnsCollectionViewCell.swift */; };
 		2251F6B62CE48F6F00906FF5 /* SNSType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6B52CE48F6B00906FF5 /* SNSType.swift */; };
 		2251F6B82CE5E95200906FF5 /* SnsCollectionViewLeftAlignedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6B72CE5E94B00906FF5 /* SnsCollectionViewLeftAlignedLayout.swift */; };
+		2251F6BD2CE6074300906FF5 /* EditSnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6BC2CE6073D00906FF5 /* EditSnsView.swift */; };
 		226D42BF2B9EBA3E00680198 /* BooltiBusinessInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */; };
 		22739A3B2C4F86BA000A357B /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A3A2C4F86BA000A357B /* SettingViewController.swift */; };
 		22739A3D2C4F86DA000A357B /* SettingDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A3C2C4F86DA000A357B /* SettingDIContainer.swift */; };
@@ -475,6 +476,7 @@
 		2251F6B32CE48E9000906FF5 /* ProfileSnsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSnsCollectionViewCell.swift; sourceTree = "<group>"; };
 		2251F6B52CE48F6B00906FF5 /* SNSType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSType.swift; sourceTree = "<group>"; };
 		2251F6B72CE5E94B00906FF5 /* SnsCollectionViewLeftAlignedLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnsCollectionViewLeftAlignedLayout.swift; sourceTree = "<group>"; };
+		2251F6BC2CE6073D00906FF5 /* EditSnsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSnsView.swift; sourceTree = "<group>"; };
 		226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiBusinessInfoView.swift; sourceTree = "<group>"; };
 		22739A3A2C4F86BA000A357B /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		22739A3C2C4F86DA000A357B /* SettingDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDIContainer.swift; sourceTree = "<group>"; };
@@ -924,6 +926,7 @@
 				2213935C2C889FA200459A20 /* EditProfileImageView.swift */,
 				2213935E2C88A6DB00459A20 /* EditNicknameView.swift */,
 				221393602C89C17300459A20 /* EditIntroductionView.swift */,
+				2251F6BC2CE6073D00906FF5 /* EditSnsView.swift */,
 				221393622C89CC7E00459A20 /* EditLinkView.swift */,
 				221393672C89D97F00459A20 /* AddLinkHeaderView.swift */,
 			);
@@ -2609,6 +2612,7 @@
 				22DEF7832C28396D00EA492A /* GiftingDetailViewController.swift in Sources */,
 				8769BF962B625DB200DA9A67 /* TermsAgreementViewController.swift in Sources */,
 				22739A3B2C4F86BA000A357B /* SettingViewController.swift in Sources */,
+				2251F6BD2CE6074300906FF5 /* EditSnsView.swift in Sources */,
 				84A024902B7B99830095A56E /* QRScannerViewModel.swift in Sources */,
 				2251F6B22CE464AA00906FF5 /* PerformedConcertCollectionViewCell.swift in Sources */,
 				2213935F2C88A6DB00459A20 /* EditNicknameView.swift in Sources */,

--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		2251F6B62CE48F6F00906FF5 /* SNSType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6B52CE48F6B00906FF5 /* SNSType.swift */; };
 		2251F6B82CE5E95200906FF5 /* SnsCollectionViewLeftAlignedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6B72CE5E94B00906FF5 /* SnsCollectionViewLeftAlignedLayout.swift */; };
 		2251F6BD2CE6074300906FF5 /* EditSnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6BC2CE6073D00906FF5 /* EditSnsView.swift */; };
+		2251F6BF2CE626F400906FF5 /* EditSnsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2251F6BE2CE626EB00906FF5 /* EditSnsCollectionViewCell.swift */; };
 		226D42BF2B9EBA3E00680198 /* BooltiBusinessInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */; };
 		22739A3B2C4F86BA000A357B /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A3A2C4F86BA000A357B /* SettingViewController.swift */; };
 		22739A3D2C4F86DA000A357B /* SettingDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22739A3C2C4F86DA000A357B /* SettingDIContainer.swift */; };
@@ -477,6 +478,7 @@
 		2251F6B52CE48F6B00906FF5 /* SNSType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSType.swift; sourceTree = "<group>"; };
 		2251F6B72CE5E94B00906FF5 /* SnsCollectionViewLeftAlignedLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnsCollectionViewLeftAlignedLayout.swift; sourceTree = "<group>"; };
 		2251F6BC2CE6073D00906FF5 /* EditSnsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSnsView.swift; sourceTree = "<group>"; };
+		2251F6BE2CE626EB00906FF5 /* EditSnsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSnsCollectionViewCell.swift; sourceTree = "<group>"; };
 		226D42BE2B9EBA3E00680198 /* BooltiBusinessInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooltiBusinessInfoView.swift; sourceTree = "<group>"; };
 		22739A3A2C4F86BA000A357B /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		22739A3C2C4F86DA000A357B /* SettingDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDIContainer.swift; sourceTree = "<group>"; };
@@ -936,6 +938,7 @@
 		221393642C89CEB900459A20 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				2251F6BE2CE626EB00906FF5 /* EditSnsCollectionViewCell.swift */,
 				221393652C89CECB00459A20 /* EditLinkCollectionViewCell.swift */,
 			);
 			path = Cells;
@@ -2796,6 +2799,7 @@
 				87EFEEE12C7F597700A8993C /* AgreementViewController.swift in Sources */,
 				87A3716F2B76534B0061814E /* TicketReservationItemEntity.swift in Sources */,
 				8755A1602B8BA5510067C5CE /* QRCodeResponsePopUpView.swift in Sources */,
+				2251F6BF2CE626F400906FF5 /* EditSnsCollectionViewCell.swift in Sources */,
 				8730F02E2B7BAA2B00D4F339 /* RefundAccountNumberView.swift in Sources */,
 				87F63D732C3F8504001D7A56 /* GiftReservationDetailResponseDTO.swift in Sources */,
 				8746AD202B6932B30037A1B1 /* ConcertEnterView.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Enums/SNSType.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/SNSType.swift
@@ -5,6 +5,8 @@
 //  Created by Juhyeon Byun on 11/13/24.
 //
 
+import UIKit
+
 enum SNSType: String, Codable {
     case instagram = "Instagram"
     case youtube = "YouTube"
@@ -26,6 +28,15 @@ enum SNSType: String, Codable {
             return "https://www.instagram.com/"
         case .youtube:
             return "https://www.youtube.com/@"
+        }
+    }
+    
+    var image: UIImage {
+        switch self {
+        case .instagram:
+            return .instagram
+        case .youtube:
+            return .youtube
         }
     }
 }

--- a/Boolti/Boolti/Sources/Global/Enums/SNSType.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/SNSType.swift
@@ -39,4 +39,13 @@ enum SNSType: String, Codable {
             return .youtube
         }
     }
+    
+    var description: String {
+        switch self {
+        case .instagram:
+            return "instagram"
+        case .youtube:
+            return "youtube"
+        }
+    }
 }

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Request/EditProfileRequestDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Request/EditProfileRequestDTO.swift
@@ -9,5 +9,6 @@ struct EditProfileRequestDTO: Encodable {
     let nickname: String
     let profileImagePath: String
     let introduction: String
-    let link: [LinkEntity]
+    let link: [LinkDTO]
+    let sns: [LinkDTO]
 }

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertUserProfileResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertUserProfileResponseDTO.swift
@@ -58,7 +58,7 @@ struct ConcertUserProfileResponseDTO: UserProfileResponseDTO {
 
 }
 
-struct LinkDTO: Decodable {
+struct LinkDTO: Codable {
     let title: String
     let link: String
 }

--- a/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
@@ -23,7 +23,7 @@ protocol AuthRepositoryType: RepositoryType {
     func userInfo() -> Single<Void>
     func userProfile() -> Single<ProfileEntity>
     func resign(reason: String, appleIdAuthorizationCode: String?) -> Single<Void>
-    func editProfile(profileImageUrl: String, nickname: String, introduction: String, links: [LinkEntity]) -> Single<Void>
+    func editProfile(profileImageUrl: String, nickname: String, introduction: String, links: [LinkEntity], snses: [SnsEntity]) -> Single<Void>
     func getUploadImageURL() -> Single<GetUploadURLReponseDTO>
     func uploadProfileImage(uploadURL: String, imageData: UIImage) -> Single<String>
 }
@@ -197,11 +197,21 @@ final class AuthRepository: AuthRepositoryType {
             .map { _ in return () }
     }
     
-    func editProfile(profileImageUrl: String, nickname: String, introduction: String, links: [LinkEntity]) -> Single<Void> {
+    func editProfile(profileImageUrl: String, nickname: String, introduction: String, links: [LinkEntity], snses: [SnsEntity]) -> Single<Void> {
+        let link = links.map { link in
+            return LinkDTO(title: link.title, link: link.link)
+        }
+
+        let sns = snses.map { sns in
+            return LinkDTO(title: sns.snsType.rawValue, link: sns.name)
+        }
+        
+        
         let api = AuthAPI.editProfile(requestDTO: EditProfileRequestDTO(nickname: nickname,
                                                                          profileImagePath: profileImageUrl,
                                                                          introduction: introduction,
-                                                                         link: links))
+                                                                         link: link,
+                                                                         sns: sns))
         
         return self.networkService.request(api)
             .map(UserResponseDTO.self)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Cells/EditLinkCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Cells/EditLinkCollectionViewCell.swift
@@ -10,6 +10,13 @@ import UIKit
 final class EditLinkCollectionViewCell: UICollectionViewCell {
     
     // MARK: UI Components
+    
+    private let linkImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .link
+        imageView.tintColor = .grey30
+        return imageView
+    }()
 
     private let titleLabel: BooltiUILabel = {
         let label = BooltiUILabel()
@@ -38,7 +45,7 @@ final class EditLinkCollectionViewCell: UICollectionViewCell {
     private let editImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = .pencil
-        imageView.tintColor = .grey50
+        imageView.tintColor = .grey70
         return imageView
     }()
     
@@ -72,9 +79,9 @@ extension EditLinkCollectionViewCell {
         self.urlLabel.text = nil
     }
     
-    func setData(title: String, url: String) {
-        self.titleLabel.text = title
-        self.urlLabel.text = url
+    func setData(with data: LinkEntity) {
+        self.titleLabel.text = data.title
+        self.urlLabel.text = data.link
     }
 
 }
@@ -85,20 +92,26 @@ extension EditLinkCollectionViewCell {
 
     private func configureUI() {
         self.contentView.backgroundColor = .grey90
-        self.contentView.addSubviews([self.labelStackView,
+        self.contentView.addSubviews([self.linkImageView,
+                                      self.labelStackView,
                                       self.editImageView])
     }
     
     private func configureConstraints() {
+        self.linkImageView.snp.makeConstraints { make in
+            make.centerY.leading.equalToSuperview()
+            make.size.equalTo(24)
+        }
+
         self.labelStackView.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.leading.equalToSuperview()
-            make.trailing.equalToSuperview().inset(40)
+            make.centerY.equalTo(self.linkImageView)
+            make.leading.equalTo(self.linkImageView.snp.trailing).offset(12)
+            make.trailing.equalTo(self.editImageView.snp.leading).offset(-20)
         }
         
         self.editImageView.snp.makeConstraints { make in
+            make.centerY.equalTo(self.linkImageView)
             make.trailing.equalToSuperview()
-            make.centerY.equalTo(self.labelStackView)
             make.size.equalTo(20)
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Cells/EditSnsCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Cells/EditSnsCollectionViewCell.swift
@@ -1,0 +1,117 @@
+//
+//  EditSnsCollectionViewCell.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 11/14/24.
+//
+
+import UIKit
+
+final class EditSnsCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: UI Components
+    
+    private let snsImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .instagram
+        imageView.tintColor = .grey30
+        return imageView
+    }()
+
+    private let typeLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .body3
+        label.textColor = .grey30
+        return label
+    }()
+    
+    private let nameLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .subhead1
+        label.textColor = .grey15
+        return label
+    }()
+    
+    private let editImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .pencil
+        imageView.tintColor = .grey70
+        return imageView
+    }()
+    
+    // MARK: Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.configureUI()
+        self.configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Override
+    
+    override func prepareForReuse() {
+        self.resetData()
+    }
+
+}
+
+// MARK: - Methods
+
+extension EditSnsCollectionViewCell {
+    
+    private func resetData() {
+        self.snsImageView.image = nil
+        self.typeLabel.text = nil
+        self.nameLabel.text = nil
+    }
+    
+    func setData(with data: SnsEntity) {
+        self.snsImageView.image = data.snsType.image
+        self.typeLabel.text = data.snsType.rawValue
+        self.nameLabel.text = data.name
+    }
+
+}
+
+// MARK: - UI
+
+extension EditSnsCollectionViewCell {
+
+    private func configureUI() {
+        self.contentView.backgroundColor = .grey90
+        self.contentView.addSubviews([self.snsImageView,
+                                      self.typeLabel,
+                                      self.nameLabel,
+                                      self.editImageView])
+    }
+    
+    private func configureConstraints() {
+        self.snsImageView.snp.makeConstraints { make in
+            make.centerY.leading.equalToSuperview()
+            make.size.equalTo(24)
+        }
+        
+        self.typeLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.snsImageView)
+            make.leading.equalTo(self.snsImageView.snp.trailing).offset(8)
+            make.width.equalTo(72)
+        }
+        
+        self.nameLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.snsImageView)
+            make.leading.equalTo(self.typeLabel.snp.trailing).offset(16)
+            make.trailing.equalTo(self.editImageView.snp.leading).offset(-16)
+        }
+        
+        self.editImageView.snp.makeConstraints { make in
+            make.centerY.equalTo(self.snsImageView)
+            make.trailing.equalToSuperview()
+            make.size.equalTo(20)
+        }
+    }
+}

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Cells/EditSnsCollectionViewCell.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Cells/EditSnsCollectionViewCell.swift
@@ -72,7 +72,7 @@ extension EditSnsCollectionViewCell {
     
     func setData(with data: SnsEntity) {
         self.snsImageView.image = data.snsType.image
-        self.typeLabel.text = data.snsType.rawValue
+        self.typeLabel.text = data.snsType.description
         self.nameLabel.text = data.name
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -223,9 +223,8 @@ extension EditProfileViewController {
                                                       forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
                                                       withReuseIdentifier: AddLinkHeaderView.className)
         
-        // TODO: - sns cell로 변경
-        self.editSnsView.snsCollectionView.register(EditLinkCollectionViewCell.self,
-                                                      forCellWithReuseIdentifier: EditLinkCollectionViewCell.className)
+        self.editSnsView.snsCollectionView.register(EditSnsCollectionViewCell.self,
+                                                      forCellWithReuseIdentifier: EditSnsCollectionViewCell.className)
 
         self.editLinkView.linkCollectionView.dataSource = self
         self.editLinkView.linkCollectionView.delegate = self
@@ -376,23 +375,18 @@ extension EditProfileViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == self.editSnsView.snsCollectionView {
-            // TODO: - sns cell로 변경 필요
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditLinkCollectionViewCell.className,
-                                                                for: indexPath) as? EditLinkCollectionViewCell else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditSnsCollectionViewCell.className,
+                                                                for: indexPath) as? EditSnsCollectionViewCell else { return UICollectionViewCell() }
             guard let snses = self.viewModel.output.profile.snses else { return UICollectionViewCell() }
 
-            let data = snses[indexPath.row]
-
-            cell.setData(title: data.snsType.rawValue, url: data.name)
+            cell.setData(with: snses[indexPath.row])
             return cell
         } else {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditLinkCollectionViewCell.className,
                                                                 for: indexPath) as? EditLinkCollectionViewCell else { return UICollectionViewCell() }
             guard let links = self.viewModel.output.profile.links else { return UICollectionViewCell() }
 
-            let data = links[indexPath.row]
-
-            cell.setData(title: data.title, url: data.link)
+            cell.setData(with: links[indexPath.row])
             return cell
         }
     }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -303,6 +303,7 @@ extension EditProfileViewController: UIImagePickerControllerDelegate, UINavigati
             self.viewModel.input.didProfileImageSelected.accept(selectedImage)
         }
     }
+
 }
 
 // MARK: - UIScrollViewDelegate
@@ -325,8 +326,13 @@ extension EditProfileViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let links = self.viewModel.output.profile.links else { return 0 }
-        return links.count
+        if collectionView == self.editSnsView.snsCollectionView {
+            guard let snses = self.viewModel.output.profile.snses else { return 0 }
+            return snses.count
+        } else {
+            guard let links = self.viewModel.output.profile.links else { return 0 }
+            return links.count
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
@@ -346,6 +352,7 @@ extension EditProfileViewController: UICollectionViewDataSource {
             header.rx.tapGesture()
                 .when(.recognized)
                 .bind(with: self) { owner, _ in
+                    // TODO: - editSnsViewController로 변경 필요
                     let viewController = EditLinkViewController(editType: .add)
                     viewController.delegate = self
                     owner.navigationController?.pushViewController(viewController, animated: true)
@@ -368,25 +375,49 @@ extension EditProfileViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditLinkCollectionViewCell.className,
-                                                            for: indexPath) as? EditLinkCollectionViewCell else { return UICollectionViewCell() }
-        guard let links = self.viewModel.output.profile.links else { return UICollectionViewCell() }
+        if collectionView == self.editSnsView.snsCollectionView {
+            // TODO: - sns cell로 변경 필요
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditLinkCollectionViewCell.className,
+                                                                for: indexPath) as? EditLinkCollectionViewCell else { return UICollectionViewCell() }
+            guard let snses = self.viewModel.output.profile.snses else { return UICollectionViewCell() }
 
-        let data = links[indexPath.row]
+            let data = snses[indexPath.row]
 
-        cell.setData(title: data.title, url: data.link)
-        return cell
+            cell.setData(title: data.snsType.rawValue, url: data.name)
+            return cell
+        } else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditLinkCollectionViewCell.className,
+                                                                for: indexPath) as? EditLinkCollectionViewCell else { return UICollectionViewCell() }
+            guard let links = self.viewModel.output.profile.links else { return UICollectionViewCell() }
+
+            let data = links[indexPath.row]
+
+            cell.setData(title: data.title, url: data.link)
+            return cell
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let links = self.viewModel.output.profile.links else { return }
+        if collectionView == self.editSnsView.snsCollectionView {
+            guard let snses = self.viewModel.output.profile.snses else { return }
 
-        let linkEntity = links[indexPath.row]
-        self.selectedItemIndex = indexPath.row
+            let snsEntity = snses[indexPath.row]
+            self.selectedItemIndex = indexPath.row
 
-        let viewController = EditLinkViewController(editType: .edit(linkEntity))
-        viewController.delegate = self
-        self.navigationController?.pushViewController(viewController, animated: true)
+            // TODO: - sns edit vc로 이동
+//            let viewController = EditLinkViewController(editType: .edit(linkEntity))
+//            viewController.delegate = self
+//            self.navigationController?.pushViewController(viewController, animated: true)
+        } else {
+            guard let links = self.viewModel.output.profile.links else { return }
+
+            let linkEntity = links[indexPath.row]
+            self.selectedItemIndex = indexPath.row
+
+            let viewController = EditLinkViewController(editType: .edit(linkEntity))
+            viewController.delegate = self
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }
     }
     
 }
@@ -396,7 +427,11 @@ extension EditProfileViewController: UICollectionViewDataSource {
 extension EditProfileViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        CGSize(width: UIScreen.main.bounds.width - 40, height: 56)
+        if collectionView == self.editSnsView.snsCollectionView {
+            return CGSize(width: UIScreen.main.bounds.width - 40, height: 44)
+        } else {
+            return CGSize(width: UIScreen.main.bounds.width - 40, height: 56)
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewModel.swift
@@ -20,6 +20,7 @@ final class EditProfileViewModel {
         var nickName: String? = ""
         var introduction: String? = ""
         var links: [LinkEntity]? = []
+        var snses: [SnsEntity]? = []
     }
 
     // MARK: Properties
@@ -32,6 +33,7 @@ final class EditProfileViewModel {
         let didIntroductionTyped = PublishRelay<String>()
         let didProfileImageSelected = PublishRelay<UIImage>()
         let didLinkChanged = PublishRelay<[LinkEntity]>()
+        let didSnsChanged = PublishRelay<[SnsEntity]>()
 
         let didNavigationBarCompleteButtonTapped = PublishSubject<Void>()
         let didPopUpConfirmButtonTapped = PublishSubject<Void>()
@@ -93,6 +95,12 @@ extension EditProfileViewModel {
                 owner.output.profile.links = links
             })
             .disposed(by: self.disposeBag)
+        
+        self.input.didSnsChanged
+            .subscribe(with: self, onNext: { owner, snses in
+                owner.output.profile.snses = snses
+            })
+            .disposed(by: self.disposeBag)
 
         self.input.didBackButtonTapped
             .subscribe(with: self) { owner, _ in
@@ -122,7 +130,8 @@ extension EditProfileViewModel {
                                              imageURL: DTO.profileImageURL,
                                              nickName: DTO.nickname,
                                              introduction: DTO.introduction,
-                                             links: DTO.links)
+                                             links: DTO.links,
+                                             snses: DTO.snses)
                 self?.output.initialProfile = fetchedProfile
                 return fetchedProfile
             })
@@ -145,7 +154,8 @@ extension EditProfileViewModel {
                 return self.authRepository.editProfile(profileImageUrl: profileImageUrl,
                                                        nickname: profile.nickName ?? "",
                                                        introduction: profile.introduction ?? "",
-                                                       links: profile.links ?? [])
+                                                       links: profile.links ?? [],
+                                                       snses: profile.snses ?? [])
             })
             .subscribe(with: self) { owner, _ in
                 owner.output.didProfileSaved.onNext(())

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/AddLinkHeaderView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/AddLinkHeaderView.swift
@@ -29,7 +29,6 @@ final class AddLinkHeaderView: UICollectionReusableView {
         let label = BooltiUILabel()
         label.font = .subhead1
         label.textColor = .grey15
-        label.text = "링크 추가"
         return label
     }()
     
@@ -50,6 +49,16 @@ final class AddLinkHeaderView: UICollectionReusableView {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.disposeBag = DisposeBag()
+    }
+    
+}
+
+// MARK: - Methods
+
+extension AddLinkHeaderView {
+    
+    func setTitle(with title: String) {
+        self.titleLabel.text = title
     }
     
 }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditSnsView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/Views/EditSnsView.swift
@@ -1,0 +1,77 @@
+//
+//  LinkSnsView.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 11/14/24.
+//
+
+import UIKit
+
+import RxSwift
+
+final class EditSnsView: UIView {
+
+    // MARK: Properties
+    
+    private let disposeBag = DisposeBag()
+    
+    // MARK: UI Components
+    
+    private let snsLabel: BooltiUILabel = {
+        let label = BooltiUILabel()
+        label.font = .subhead2
+        label.textColor = .grey10
+        label.text = "SNS"
+        return label
+    }()
+    
+    let snsCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.backgroundColor = .clear
+        collectionView.contentInset = .zero
+        collectionView.isScrollEnabled = false
+        return collectionView
+    }()
+    
+    // MARK: Initailizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: - UI
+
+extension EditSnsView {
+    
+    private func configureUI() {
+        self.backgroundColor = .grey90
+        self.addSubviews([self.snsLabel,
+                          self.snsCollectionView])
+        
+        self.configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        self.snsLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(20)
+        }
+        
+        self.snsCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(self.snsLabel.snp.bottom).offset(20)
+            make.horizontalEdges.bottom.equalToSuperview().inset(20)
+        }
+    }
+    
+}


### PR DESCRIPTION
## 작업한 내용
- edit sns view를 만들었어요.
- snsType에 아래 변수들 추가했습니다.
```swift
var image: UIImage {
    switch self {
    case .instagram:
        return .instagram
    case .youtube:
        return .youtube
    }
}

var description: String {
    switch self {
    case .instagram:
        return "instagram"
    case .youtube:
        return "youtube"
    }
}
```
- AddLinkHeaderView는 재사용 했습니다!

## 스크린샷
https://github.com/user-attachments/assets/63d5427f-ca48-4c74-8db9-29a33b9c2bf6

## 관련 이슈
- Resolved: #385 
