### PR TITLE
Fix/#395 sns dto 변경 및 concertEntity 재사용

### DIFF
--- a/Boolti/Boolti/Sources/Entities/Auth/ProfileEntity.swift
+++ b/Boolti/Boolti/Sources/Entities/Auth/ProfileEntity.swift
@@ -10,7 +10,7 @@ struct ProfileEntity {
     let nickname: String
     let introduction: String
     var links: [LinkEntity]
-    var performedConcerts: [PerformedConcertEntity]
+    var performedConcerts: [ConcertEntity]
     var snses: [SnsEntity]
 }
 
@@ -22,11 +22,4 @@ struct SnsEntity: Codable, Equatable {
 struct LinkEntity: Codable, Equatable {
     let title: String
     let link: String
-}
-
-struct PerformedConcertEntity {
-    let id: Int
-    let name: String
-    let date: String
-    let thumbnailPath: String
 }

--- a/Boolti/Boolti/Sources/Global/Enums/SNSType.swift
+++ b/Boolti/Boolti/Sources/Global/Enums/SNSType.swift
@@ -8,14 +8,14 @@
 import UIKit
 
 enum SNSType: String, Codable, CaseIterable {
-    case instagram = "Instagram"
-    case youtube = "YouTube"
+    case instagram = "INSTAGRAM"
+    case youtube = "YOUTUBE"
     
     init?(_ rawValue: String){
         switch rawValue {
-        case "Instagram":
+        case "INSTAGRAM":
             self  = .instagram
-        case "YouTube":
+        case "YOUTUBE":
             self = .youtube
         default:
             return nil

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Request/EditProfileRequestDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Request/EditProfileRequestDTO.swift
@@ -10,5 +10,5 @@ struct EditProfileRequestDTO: Encodable {
     let profileImagePath: String
     let introduction: String
     let link: [LinkDTO]
-    let sns: [LinkDTO]
+    let sns: [SNSDTO]
 }

--- a/Boolti/Boolti/Sources/Network/DTO/Auth/Response/UserResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Auth/Response/UserResponseDTO.swift
@@ -15,8 +15,8 @@ struct UserResponseDTO: UserProfileResponseDTO {
     let imgPath: String?
     let introduction: String?
     let link: [LinkDTO]?
-    let performedShow: [PerformedShowDTO]?
-    let sns: [LinkDTO]?
+    let performedShow: [ConcertListResponseDTOElement]?
+    let sns: [SNSDTO]?
     
     func convertToUserProfile() -> ProfileEntity {
         let links = self.link?.map { DTO in
@@ -25,15 +25,17 @@ struct UserResponseDTO: UserProfileResponseDTO {
         }
         
         let snses = self.sns?.map { DTO in
-            return SnsEntity(snsType: SNSType(rawValue: DTO.title) ?? .instagram ,
-                             name: DTO.link)
+            return SnsEntity(snsType: SNSType(rawValue: DTO.type) ?? .instagram ,
+                             name: DTO.username)
         }
         
         let performedConcerts = self.performedShow?.map { DTO in
-            return PerformedConcertEntity(id: DTO.id,
-                                          name: DTO.name,
-                                          date: DTO.date,
-                                          thumbnailPath: DTO.thumbnailPath)
+            return ConcertEntity(id: DTO.id,
+                                 name: DTO.name,
+                                 dateTime: DTO.date.formatToDate(),
+                                 salesStartTime: DTO.salesStartTime.formatToDate(),
+                                 salesEndTime: DTO.salesEndTime.formatToDate(),
+                                 posterPath: DTO.showImg ?? "")
         }
         
         return .init(profileImageURL: self.imgPath ?? "",

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertUserProfileResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertUserProfileResponseDTO.swift
@@ -13,8 +13,8 @@ protocol UserProfileResponseDTO: Decodable {
     var imgPath: String? { get }
     var introduction: String? { get }
     var link: [LinkDTO]? { get }
-    var performedShow: [PerformedShowDTO]? { get }
-    var sns: [LinkDTO]? { get }
+    var performedShow: [ConcertListResponseDTOElement]? { get }
+    var sns: [SNSDTO]? { get }
     
     func convertToUserProfile() -> ProfileEntity
 
@@ -27,8 +27,8 @@ struct ConcertUserProfileResponseDTO: UserProfileResponseDTO {
     let imgPath: String?
     let introduction: String?
     let link: [LinkDTO]?
-    let performedShow: [PerformedShowDTO]?
-    let sns: [LinkDTO]?
+    let performedShow: [ConcertListResponseDTOElement]?
+    let sns: [SNSDTO]?
     
     func convertToUserProfile() -> ProfileEntity {
         let links = self.link?.map { DTO in
@@ -37,15 +37,17 @@ struct ConcertUserProfileResponseDTO: UserProfileResponseDTO {
         }
         
         let snses = self.sns?.map { DTO in
-            return SnsEntity(snsType: SNSType(rawValue: DTO.title) ?? .instagram ,
-                             name: DTO.link)
+            return SnsEntity(snsType: SNSType(rawValue: DTO.type) ?? .instagram ,
+                             name: DTO.username)
         }
         
         let performedConcerts = self.performedShow?.map { DTO in
-            return PerformedConcertEntity(id: DTO.id,
-                                          name: DTO.name,
-                                          date: DTO.date,
-                                          thumbnailPath: DTO.thumbnailPath)
+            return ConcertEntity(id: DTO.id,
+                                 name: DTO.name,
+                                 dateTime: DTO.date.formatToDate(),
+                                 salesStartTime: DTO.salesStartTime.formatToDate(),
+                                 salesEndTime: DTO.salesEndTime.formatToDate(),
+                                 posterPath: DTO.showImg ?? "")
         }
         
         return .init(profileImageURL: self.imgPath ?? "",
@@ -63,9 +65,7 @@ struct LinkDTO: Codable {
     let link: String
 }
 
-struct PerformedShowDTO: Decodable {
-    let id: Int
-    let name: String
-    let date: String
-    let thumbnailPath: String
+struct SNSDTO: Codable {
+    let type: String
+    let username: String
 }

--- a/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
+++ b/Boolti/Boolti/Sources/Network/Repositories/Auth/AuthRepository.swift
@@ -203,7 +203,7 @@ final class AuthRepository: AuthRepositoryType {
         }
 
         let sns = snses.map { sns in
-            return LinkDTO(title: sns.snsType.rawValue, link: sns.name)
+            return SNSDTO(type: sns.snsType.rawValue, username: sns.name)
         }
         
         

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileDIContainer.swift
@@ -34,7 +34,7 @@ final class ProfileDIContainer {
             return viewController
         }
         
-        let performedConcertListControllerFactory: ([PerformedConcertEntity]) -> PerformedConcertListViewController = { concertList in
+        let performedConcertListControllerFactory: ([ConcertEntity]) -> PerformedConcertListViewController = { concertList in
             let DIContainer = PerformedConcertListDIContainer(repository: self.repository)
             let viewController = DIContainer.createPerformedConcertListViewController(performedConcertList: concertList)
             
@@ -65,7 +65,7 @@ final class ProfileDIContainer {
             return viewController
         }
         
-        let performedConcertListControllerFactory: ([PerformedConcertEntity]) -> PerformedConcertListViewController = { concertList in
+        let performedConcertListControllerFactory: ([ConcertEntity]) -> PerformedConcertListViewController = { concertList in
             let DIContainer = PerformedConcertListDIContainer(repository: self.repository)
             let viewController = DIContainer.createPerformedConcertListViewController(performedConcertList: concertList)
             

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -25,7 +25,7 @@ final class ProfileViewController: BooltiViewController {
     
     private let editProfileViewControllerFactory: (() -> EditProfileViewController)?
     private let linkListControllerFactory: ([LinkEntity]) -> LinkListViewController
-    private let performedConcertListControllerFactory: ([PerformedConcertEntity]) -> PerformedConcertListViewController
+    private let performedConcertListControllerFactory: ([ConcertEntity]) -> PerformedConcertListViewController
     private let concertDetailViewControllerFactory: (Int) -> ConcertDetailViewController
 
     // MARK: UI Components
@@ -75,7 +75,7 @@ final class ProfileViewController: BooltiViewController {
     init(viewModel: ProfileViewModel,
          editProfileViewControllerFactory: (() -> EditProfileViewController)? = nil,
          linkListControllerFactory: @escaping ([LinkEntity]) -> LinkListViewController,
-         performedConcertListControllerFactory: @escaping (([PerformedConcertEntity]) -> PerformedConcertListViewController),
+         performedConcertListControllerFactory: @escaping (([ConcertEntity]) -> PerformedConcertListViewController),
          concertDetailViewControllerFactory: @escaping (Int) -> ConcertDetailViewController
     ) {
         self.viewModel = viewModel
@@ -357,9 +357,9 @@ extension ProfileViewController: UICollectionViewDataSource {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileConcertCollectionViewCell.className,
                                                                     for: indexPath) as? ProfileConcertCollectionViewCell else { return UICollectionViewCell() }
                 let concert = self.viewModel.output.performedConcerts[indexPath.row]
-                cell.setData(posterURL: concert.thumbnailPath,
+                cell.setData(posterURL: concert.posterPath,
                              title: concert.name,
-                             datetime: concert.date.formatToDate())
+                             datetime: concert.dateTime)
                 return cell
             }
         }

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewModel.swift
@@ -25,7 +25,7 @@ final class ProfileViewModel {
 
     struct Output {
         var links: [LinkEntity] = []
-        var performedConcerts: [PerformedConcertEntity] = []
+        var performedConcerts: [ConcertEntity] = []
         var snses: [SnsEntity] = []
         var didProfileFetch = PublishSubject<(ProfileEntity)>()
         var isUnknownProfile = PublishSubject<Bool>()

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/PerformedConcertList/PerformedConcertListDIContainer.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/PerformedConcertList/PerformedConcertListDIContainer.swift
@@ -15,7 +15,7 @@ final class PerformedConcertListDIContainer {
         self.repository = repository
     }
 
-    func createPerformedConcertListViewController(performedConcertList: [PerformedConcertEntity]) -> PerformedConcertListViewController {
+    func createPerformedConcertListViewController(performedConcertList: [ConcertEntity]) -> PerformedConcertListViewController {
         
         let concertDetailViewControllerFactory: (Int) -> ConcertDetailViewController = { concertId in
             let DIContainer = ConcertDetailDIContainer(authRepository: AuthRepository(networkService: self.repository.networkService),

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/PerformedConcertList/PerformedConcertListViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/PerformedConcertList/PerformedConcertListViewController.swift
@@ -108,9 +108,9 @@ extension PerformedConcertListViewController: UICollectionViewDataSource {
                                                             for: indexPath) as? PerformedConcertCollectionViewCell else { return UICollectionViewCell() }
         
         let concert = self.viewModel.concertList[indexPath.row]
-        cell.setData(posterURL: concert.thumbnailPath,
+        cell.setData(posterURL: concert.posterPath,
                      title: concert.name,
-                     datetime: concert.date.formatToDate())
+                     datetime: concert.dateTime)
         return cell
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/PerformedConcertList/PerformedConcertListViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/PerformedConcertList/PerformedConcertListViewModel.swift
@@ -9,11 +9,11 @@ final class PerformedConcertListViewModel {
     
     // MARK: Properties
     
-    let concertList: [PerformedConcertEntity]
+    let concertList: [ConcertEntity]
     
     // MARK: Initailizer
     
-    init(concertList: [PerformedConcertEntity]) {
+    init(concertList: [ConcertEntity]) {
         self.concertList = concertList
     }
     


### PR DESCRIPTION
## 작업한 내용
- 서버 응답이 바뀜에 따라 SnsDTO를 새로 만들었어요.
- 출연한 공연 응답이 기존 concert response와 달라서 새로 만들었었는데 통합되어서 출연한 공연 response를 삭제해주었어요.

## 관련 이슈
- Resolved: #395 
