### PR TITLE
Chore/#407 프로필 sns 앱으로 연결

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -198,7 +198,7 @@ extension ProfileViewController {
 
                 guard let url = URL(string: "\(sns.snsType.urlPath)\(sns.name)") else { return }
                 if UIApplication.shared.canOpenURL(url) {
-                    owner.openSafari(with: url)
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 } else {
                     owner.showToast(message: "유효한 SNS가 아니에요")
                 }


### PR DESCRIPTION
## 작업한 내용
- 프로필 sns 기존에 safari로 바로 연결되던 것을 앱으로 연결되게 해두었습니다.
- 만약 앱이 없을 시 safari로 연결됩니다.

## 스크린샷
https://github.com/user-attachments/assets/11175f13-2c1b-45d7-a697-004e9c17a566

## 관련 이슈
- Resolved: #407 
