### PR TITLE
Feature/#431 마이페이지 프로필 영역 변경

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -507,14 +507,16 @@ extension ConcertDetailViewController {
 // MARK: - UIScrollViewDelegate
 
 extension ConcertDetailViewController: UIScrollViewDelegate {
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offset = scrollView.contentOffset.y
-        if offset <= self.concertPosterView.frame.height {
-            self.navigationBar.setBackgroundColor(with: .grey90)
+        if offset == 0 {
+            self.navigationBar.setBackgroundColor(with: .clear)
         } else {
-            self.navigationBar.setBackgroundColor(with: .grey95)
+            self.navigationBar.setBackgroundColor(with: .grey90)
         }
     }
+
 }
 
 // MARK: - UI

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewController.swift
@@ -186,17 +186,12 @@ extension EditProfileViewController {
         
         self.navigationBar.didRightTextButtonTap()
             .emit(with: self, onNext: { owner, _ in
-                // TODO: 아래와 같이 url이랑 image 따로 보내는 거 해결하기 (vm 참고)
-                let image = owner.editProfileImageView.profileImageView.image ?? UIImage()
-                owner.viewModel.input.didProfileImageSelected.accept(image)
                 owner.viewModel.input.didNavigationBarCompleteButtonTapped.onNext(())
             })
             .disposed(by: self.disposeBag)
 
         self.popupView.didConfirmButtonTap()
             .emit(with: self, onNext: { owner, _ in
-                let image = owner.editProfileImageView.profileImageView.image ?? UIImage()
-                owner.viewModel.input.didProfileImageSelected.accept(image)
                 owner.viewModel.input.didPopUpConfirmButtonTapped.onNext(())
             })
             .disposed(by: self.disposeBag)

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewModel.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/EditProfile/EditProfileViewModel.swift
@@ -15,7 +15,7 @@ final class EditProfileViewModel {
     // TODO: DOMAIN 객체 제대로 정의하기
     // - Domain 객체
     struct Profile: Equatable {
-        var image: UIImage? = UIImage() // TODO: URL 뽑아오는 로직 변경하기!..
+        var image: UIImage? = nil // TODO: URL 뽑아오는 로직 변경하기!..
         var imageURL: String? = ""
         var nickName: String? = ""
         var introduction: String? = ""
@@ -145,7 +145,10 @@ extension EditProfileViewModel {
     func save(_ profile: Profile) {
         self.authRepository.getUploadImageURL()
             .flatMap({ [weak self] response -> Single<String> in
-                guard let self = self else { return .just("") }
+                guard let self = self else { return .just(UserDefaults.userImageURLPath) }
+                guard let _ = self.output.profile.image else {
+                    return .just(self.output.profile.imageURL ?? UserDefaults.userImageURLPath)
+                }
                 return self.authRepository.uploadProfileImage(uploadURL: response.uploadUrl, imageData: profile.image ?? UIImage())
                     .map { _ in response.expectedUrl }
             })

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -227,8 +227,8 @@ extension ProfileViewController {
         let snsCollectionViewHeight = self.profileMainView.snsCollectionView.contentSize.height
         let snsCollectionViewTopOffset: CGFloat = self.viewModel.output.snses.isEmpty ? 0 : 20
         
-        self.profileMainView.updateUI(snsCollectionViewHeight: snsCollectionViewHeight,
-                                      snsCollectionViewTopOffset: snsCollectionViewTopOffset)
+        self.profileMainView.updateSnsCollectionViewUI(snsCollectionViewHeight: snsCollectionViewHeight,
+                                                       snsCollectionViewTopOffset: snsCollectionViewTopOffset)
         
         self.profileMainView.layoutIfNeeded()
         let profileViewHeight = self.navigationBar.frame.height + 144 + self.profileMainView.getLabelStackViewHeight() + snsCollectionViewHeight + 32
@@ -237,7 +237,8 @@ extension ProfileViewController {
             make.height.equalTo(profileViewHeight)
         }
         
-        self.profileMainView.addGradientLayer()
+        self.profileMainView.updateProfileImageViewUI(minHeight: profileViewHeight - snsCollectionViewHeight)
+        self.profileMainView.addGradientLayer(height: profileViewHeight)
         
         self.dataCollectionView.layoutIfNeeded()
         let dataCollectionViewHeight = self.dataCollectionView.contentSize.height

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -270,10 +270,8 @@ extension ProfileViewController: UIScrollViewDelegate {
         let offset = scrollView.contentOffset.y
         if offset == 0 {
             self.navigationBar.setBackgroundColor(with: .clear)
-        } else if offset <= self.profileMainView.frame.height - self.navigationBar.frame.height {
-            self.navigationBar.setBackgroundColor(with: .grey90)
         } else {
-            self.navigationBar.setBackgroundColor(with: .grey95)
+            self.navigationBar.setBackgroundColor(with: .grey90)
         }
     }
     

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -17,11 +17,12 @@ final class ProfileMainView: UIView {
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .grey80
-        imageView.layer.cornerRadius = 35
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
-        imageView.layer.borderColor = UIColor.grey80.cgColor
-        imageView.image = .defaultProfile
+        imageView.layer.cornerRadius = 20
+        imageView.layer.maskedCorners = CACornerMask(
+            arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
+        )
 
         return imageView
     }()
@@ -94,8 +95,26 @@ extension ProfileMainView {
         self.introductionLabel.text = entity.introduction
     }
     
-    func getHeight() -> CGFloat {
-        return 162 + self.nameLabel.getLabelHeight() + self.introductionLabel.getLabelHeight()
+    func getLabelStackViewHeight() -> CGFloat {
+        return self.nameLabel.getLabelHeight() + 2 + self.introductionLabel.getLabelHeight()
+    }
+    
+    func addGradientLayer() {
+        self.profileImageView.layer.sublayers?.removeAll()
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = self.profileImageView.bounds
+        gradientLayer.colors = [UIColor("121318").withAlphaComponent(0.2).cgColor,
+                                UIColor("121318").withAlphaComponent(1).cgColor]
+        gradientLayer.locations = [0.0, 1.0]
+        self.profileImageView.layer.addSublayer(gradientLayer)
+    }
+    
+    func updateUI(snsCollectionViewHeight: CGFloat,
+                  snsCollectionViewTopOffset: CGFloat) {
+        self.snsCollectionView.snp.updateConstraints { make in
+            make.height.equalTo(snsCollectionViewHeight)
+            make.top.equalTo(self.labelStackView.snp.bottom).offset(snsCollectionViewTopOffset)
+        }
     }
 
 }
@@ -119,20 +138,18 @@ extension ProfileMainView {
     
     private func configureConstraints() {
         self.profileImageView.snp.makeConstraints { make in
-            make.size.equalTo(70)
-            make.top.equalToSuperview().inset(40)
-            make.leading.equalToSuperview().inset(20)
+            make.edges.equalToSuperview()
         }
-
+        
         self.labelStackView.snp.makeConstraints { make in
-            make.top.equalTo(self.profileImageView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
         }
         
         self.snsCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(self.labelStackView.snp.bottom).offset(16)
             make.horizontalEdges.equalToSuperview().inset(20)
+            make.top.equalTo(self.labelStackView.snp.bottom).offset(20)
             make.height.equalTo(0)
+            make.bottom.equalToSuperview().inset(32)
         }
     }
 

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -19,6 +19,7 @@ final class ProfileMainView: UIView {
         imageView.backgroundColor = .grey90
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 20
         imageView.layer.maskedCorners = CACornerMask(
             arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
         )
@@ -110,7 +111,7 @@ extension ProfileMainView {
     }
     
     func updateSnsCollectionViewUI(snsCollectionViewHeight: CGFloat,
-                  snsCollectionViewTopOffset: CGFloat) {
+                                   snsCollectionViewTopOffset: CGFloat) {
         self.snsCollectionView.snp.updateConstraints { make in
             make.height.equalTo(snsCollectionViewHeight)
             make.top.equalTo(self.labelStackView.snp.bottom).offset(snsCollectionViewTopOffset)
@@ -121,7 +122,6 @@ extension ProfileMainView {
         self.profileImageView.snp.updateConstraints { make in
             make.height.equalTo(min(minHeight, self.bounds.width))
         }
-        self.profileImageView.layer.cornerRadius = minHeight >= self.bounds.width ? 20 : 0
     }
     
     func addGradientLayer(height: CGFloat) {

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -16,15 +16,25 @@ final class ProfileMainView: UIView {
 
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = .grey80
+        imageView.backgroundColor = .grey90
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
-        imageView.layer.cornerRadius = 20
         imageView.layer.maskedCorners = CACornerMask(
             arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
         )
 
         return imageView
+    }()
+    
+    private let gradientView: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 20
+        view.layer.maskedCorners = CACornerMask(
+            arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
+        )
+        
+        return view
     }()
 
     private let nameLabel: BooltiUILabel = {
@@ -99,22 +109,29 @@ extension ProfileMainView {
         return self.nameLabel.getLabelHeight() + 2 + self.introductionLabel.getLabelHeight()
     }
     
-    func addGradientLayer() {
-        self.profileImageView.layer.sublayers?.removeAll()
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = self.profileImageView.bounds
-        gradientLayer.colors = [UIColor("121318").withAlphaComponent(0.2).cgColor,
-                                UIColor("121318").withAlphaComponent(1).cgColor]
-        gradientLayer.locations = [0.0, 1.0]
-        self.profileImageView.layer.addSublayer(gradientLayer)
-    }
-    
-    func updateUI(snsCollectionViewHeight: CGFloat,
+    func updateSnsCollectionViewUI(snsCollectionViewHeight: CGFloat,
                   snsCollectionViewTopOffset: CGFloat) {
         self.snsCollectionView.snp.updateConstraints { make in
             make.height.equalTo(snsCollectionViewHeight)
             make.top.equalTo(self.labelStackView.snp.bottom).offset(snsCollectionViewTopOffset)
         }
+    }
+    
+    func updateProfileImageViewUI(minHeight: CGFloat) {
+        self.profileImageView.snp.updateConstraints { make in
+            make.height.equalTo(min(minHeight, self.bounds.width))
+        }
+        self.profileImageView.layer.cornerRadius = minHeight >= self.bounds.width ? 20 : 0
+    }
+    
+    func addGradientLayer(height: CGFloat) {
+        self.gradientView.layer.sublayers?.removeAll()
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: height)
+        gradientLayer.colors = [UIColor("121318").withAlphaComponent(0.2).cgColor,
+                                UIColor("121318").withAlphaComponent(1).cgColor]
+        gradientLayer.locations = [0.0, 1.0]
+        self.gradientView.layer.addSublayer(gradientLayer)
     }
 
 }
@@ -130,6 +147,7 @@ extension ProfileMainView {
             arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
         )
         self.addSubviews([self.profileImageView,
+                          self.gradientView,
                           self.labelStackView,
                           self.snsCollectionView])
         
@@ -138,6 +156,11 @@ extension ProfileMainView {
     
     private func configureConstraints() {
         self.profileImageView.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+            make.height.equalTo(200)
+        }
+        
+        self.gradientView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
         


### PR DESCRIPTION
## 작업한 내용
- 마이페이지 이미지를 프로필 카드 영역 배경으로 확장했습니다.
- 마이페이지 수정 시 이미지 수정 안했을 때는 이미지 업로드가 안되도록 로직 수정했습니다.
    - save 함수에 아래 코드를 추가했습니다.
        ```swift
        guard let _ = self.output.profile.image else {
            return .just(self.output.profile.imageURL ?? UserDefaults.userImageURLPath)
        }
        ``` 
- 스크롤 시 navigation bar 색상이 수정되도록 했습니다.

## 스크린샷
|이미지 영역이 카드보다 클 때| 이미지 영역이 카드 영역보다 작은 경우|
|-|-|
|![Simulator Screenshot - iPhone 16 Pro - 2025-01-05 at 16 34 30](https://github.com/user-attachments/assets/9993d509-e57b-466c-80bb-a88bb04af067)|![Simulator Screenshot - iPhone 16 Pro - 2025-01-05 at 16 34 41](https://github.com/user-attachments/assets/911ce93f-ef13-4f1d-92e4-4754b4553bf9)|

## 관련 이슈
- Resolved: #431 
