### PR TITLE
Chore/#440 profile card qa

### DIFF
--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/ProfileViewController.swift
@@ -231,14 +231,14 @@ extension ProfileViewController {
                                                        snsCollectionViewTopOffset: snsCollectionViewTopOffset)
         
         self.profileMainView.layoutIfNeeded()
-        let profileViewHeight = self.navigationBar.frame.height + 144 + self.profileMainView.getLabelStackViewHeight() + snsCollectionViewHeight + 32
+        let profileViewHeight = self.navigationBar.frame.height + 144 + self.profileMainView.getLabelStackViewHeight() + snsCollectionViewTopOffset + snsCollectionViewHeight + 32
 
         self.profileMainView.snp.updateConstraints { make in
             make.height.equalTo(profileViewHeight)
         }
         
-        self.profileMainView.updateProfileImageViewUI(minHeight: profileViewHeight - snsCollectionViewHeight)
-        self.profileMainView.addGradientLayer(height: profileViewHeight)
+        self.profileMainView.updateProfileImageViewUI(profileViewHeight: profileViewHeight)
+        self.profileMainView.addGradientLayer(profileViewHeight: profileViewHeight)
         
         self.dataCollectionView.layoutIfNeeded()
         let dataCollectionViewHeight = self.dataCollectionView.contentSize.height

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -18,25 +18,10 @@ final class ProfileMainView: UIView {
         let imageView = UIImageView()
         imageView.backgroundColor = .grey90
         imageView.contentMode = .scaleAspectFill
-        imageView.clipsToBounds = true
-        imageView.layer.cornerRadius = 20
-        imageView.layer.maskedCorners = CACornerMask(
-            arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
-        )
-
         return imageView
     }()
     
-    private let gradientView: UIView = {
-        let view = UIView()
-        view.clipsToBounds = true
-        view.layer.cornerRadius = 20
-        view.layer.maskedCorners = CACornerMask(
-            arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner
-        )
-        
-        return view
-    }()
+    private let gradientView = UIView()
 
     private let nameLabel: BooltiUILabel = {
         let label = BooltiUILabel()
@@ -142,6 +127,7 @@ extension ProfileMainView {
     
     private func configureUI() {
         self.backgroundColor = .grey90
+        self.clipsToBounds = true
         self.layer.cornerRadius = 20
         self.layer.maskedCorners = CACornerMask(
             arrayLiteral: .layerMinXMaxYCorner, .layerMaxXMaxYCorner

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -118,16 +118,16 @@ extension ProfileMainView {
         }
     }
     
-    func updateProfileImageViewUI(minHeight: CGFloat) {
+    func updateProfileImageViewUI(profileViewHeight: CGFloat) {
         self.profileImageView.snp.updateConstraints { make in
-            make.height.equalTo(min(minHeight, self.bounds.width))
+            make.height.equalTo(min(profileViewHeight, self.bounds.width))
         }
     }
     
-    func addGradientLayer(height: CGFloat) {
+    func addGradientLayer(profileViewHeight: CGFloat) {
         self.gradientView.layer.sublayers?.removeAll()
         let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: height)
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: min(profileViewHeight, self.bounds.width))
         gradientLayer.colors = [UIColor("121318").withAlphaComponent(0.2).cgColor,
                                 UIColor("121318").withAlphaComponent(1).cgColor]
         gradientLayer.locations = [0.0, 1.0]


### PR DESCRIPTION
## 작업한 내용
- 이미지 정사각형 비율 안맞는 오류를 수정했습니다. 
    - profile height과 전체 화면 width중 작은 값을 선택했어야하는데 profile height - sns height을 하고 있었습니다.
- 이미지 radius값이 gradient radius값 자체는 같은데 image radius가 묘하게 튀어나오는 현상을 해결했습니다.
    - 이미지와 gradient view에 각각 radius 값을 주는 것이 아닌 profile card view에 radius를 줬습니다.
    - 알고보니 card view radius가 제대로 잘리지 않고 있던 오류가 있었습니다. 아래 코드를 추가해서 해결했습니다.
```swift
self.clipsToBounds = true
```

## 스크린샷
<img src=https://github.com/user-attachments/assets/13871f7a-6075-448f-8cbc-810ab8ac4485 width=200>
<img src=https://github.com/user-attachments/assets/903e44d5-fef5-4ad3-a201-ace566c490fc width=200>
<img src=https://github.com/user-attachments/assets/d7686db4-afe0-45bf-9f81-f69b23bdfb5f width=200>


## 관련 이슈
- Resolved: #440
