### PR TITLE
Fix/#443 공연 팀 멤버 유저 이미지 null인 경우 대응

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -3170,7 +3170,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3212,7 +3212,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertCastTeamListResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/Concert/Response/ConcertCastTeamListResponseDTO.swift
@@ -19,7 +19,7 @@ struct ConcertCastTeamListResponseDTO: Decodable {
             return TeamMember(
                 id: DTO.id,
                 code: DTO.userCode,
-                imagePath: DTO.userImgPath,
+                imagePath: DTO.userImgPath ?? "",
                 nickName: DTO.userNickname,
                 roleName: DTO.roleName,
                 createdAt: DTO.createdAt,
@@ -39,7 +39,7 @@ struct ConcertCastTeamListResponseDTO: Decodable {
 struct TeamMemberDTO: Codable {
     let id: Int
     let userCode: String
-    let userImgPath: String
+    let userImgPath: String?
     let userNickname: String
     let roleName: String
     let createdAt: String


### PR DESCRIPTION
## 작업한 내용
- member list를 받아올 때 유저 데이터 중 imgPath가 null값으로 들어와서 decoding 에러가 나는 오류 수정

## 관련 이슈
- Resolved: #443 
