### PR TITLE
Fix/#445 QR scanner 활성화 조건 변경 (공연 당일까지)

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -3170,7 +3170,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3212,7 +3212,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Boolti/Boolti/Sources/Network/DTO/QR/Response/QRScannerListResponseDTO.swift
+++ b/Boolti/Boolti/Sources/Network/DTO/QR/Response/QRScannerListResponseDTO.swift
@@ -24,8 +24,7 @@ extension QRScannerListResponseDTO {
     
     func convertToQRScannerEntities() -> [QRScannerEntity] {
         return self.map { scanner in
-            let concertEndDatetime = scanner.date.formatToDate().addingTimeInterval(TimeInterval(scanner.runningTime * 60))
-            let isConcertEnd = concertEndDatetime < Date()
+            let isConcertEnd = scanner.date.formatToDate().getBetweenDay(to: Date()) > 0
             
             return QRScannerEntity(concertId: scanner.showId,
                                    concertName: scanner.showName,


### PR DESCRIPTION
## 작업한 내용
- qr scanner list에서 활성화를 공연 당일까지로 변경했습니다.
    - 원래 러닝타임 (공연 종료) 까지로 되어있었음.

## 관련 이슈
- Resolved: #445 
