### PR TITLE
Fix/#451 프로필 이미지 뷰 크롭 오류 수정 및 높이 재수정

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -3170,7 +3170,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3212,7 +3212,7 @@
 				CODE_SIGN_ENTITLEMENTS = Boolti/Boolti.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 83B9Y749K7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -18,6 +18,7 @@ final class ProfileMainView: UIView {
         let imageView = UIImageView()
         imageView.backgroundColor = .grey90
         imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
         return imageView
     }()
     
@@ -105,14 +106,14 @@ extension ProfileMainView {
     
     func updateProfileImageViewUI(profileViewHeight: CGFloat) {
         self.profileImageView.snp.updateConstraints { make in
-            make.height.equalTo(max(profileViewHeight, self.bounds.width))
+            make.height.equalTo(min(profileViewHeight, self.bounds.width))
         }
     }
-    
+
     func addGradientLayer(profileViewHeight: CGFloat) {
         self.gradientView.layer.sublayers?.removeAll()
         let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: max(profileViewHeight, self.bounds.width))
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: min(profileViewHeight, self.bounds.width))
         gradientLayer.colors = [UIColor("121318").withAlphaComponent(0.2).cgColor,
                                 UIColor("121318").withAlphaComponent(1).cgColor]
         gradientLayer.locations = [0.0, 1.0]

--- a/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
+++ b/Boolti/Boolti/Sources/UILayer/MyPage/Profile/Main/Views/ProfileMainView.swift
@@ -105,14 +105,14 @@ extension ProfileMainView {
     
     func updateProfileImageViewUI(profileViewHeight: CGFloat) {
         self.profileImageView.snp.updateConstraints { make in
-            make.height.equalTo(min(profileViewHeight, self.bounds.width))
+            make.height.equalTo(max(profileViewHeight, self.bounds.width))
         }
     }
     
     func addGradientLayer(profileViewHeight: CGFloat) {
         self.gradientView.layer.sublayers?.removeAll()
         let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: min(profileViewHeight, self.bounds.width))
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: self.bounds.width, height: max(profileViewHeight, self.bounds.width))
         gradientLayer.colors = [UIColor("121318").withAlphaComponent(0.2).cgColor,
                                 UIColor("121318").withAlphaComponent(1).cgColor]
         gradientLayer.locations = [0.0, 1.0]
@@ -143,7 +143,7 @@ extension ProfileMainView {
     private func configureConstraints() {
         self.profileImageView.snp.makeConstraints { make in
             make.top.horizontalEdges.equalToSuperview()
-            make.height.equalTo(200)
+            make.height.equalTo(self.bounds.width)
         }
         
         self.gradientView.snp.makeConstraints { make in


### PR DESCRIPTION
## 작업한 내용
- 프로필 이미지 clipsToBounds 수정

## 스크린샷
<img src=https://github.com/user-attachments/assets/a6f325c3-5053-4f65-851e-c7cb6a874d11 width=250>

## 관련 이슈
- Resolved: #451
