### PR TITLE
Feature/#465 공연 상세 webview 추가 (UI 작업)

### DIFF
--- a/Boolti/Boolti.xcodeproj/project.pbxproj
+++ b/Boolti/Boolti.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		22DFC5632C7A00E900C8433D /* ProfileDataHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DFC5622C7A00E900C8433D /* ProfileDataHeaderView.swift */; };
 		22DFC56D2C7F60E600C8433D /* BannerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DFC56C2C7F60E600C8433D /* BannerCollectionViewCell.swift */; };
 		22FA98232C3D0BE500831F64 /* ConcertTicketInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FA98222C3D0BE500831F64 /* ConcertTicketInfoView.swift */; };
+		22FD84552D9EA3A100CB807C /* UpdateWebViewHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD84542D9EA39400CB807C /* UpdateWebViewHeight.swift */; };
 		840B39552B7667D500E7F8C8 /* ConcertCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */; };
 		840B39572B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39562B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift */; };
 		840B39592B7670FC00E7F8C8 /* ConcertEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B39582B7670FC00E7F8C8 /* ConcertEntity.swift */; };
@@ -531,6 +532,7 @@
 		22DFC5622C7A00E900C8433D /* ProfileDataHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDataHeaderView.swift; sourceTree = "<group>"; };
 		22DFC56C2C7F60E600C8433D /* BannerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerCollectionViewCell.swift; sourceTree = "<group>"; };
 		22FA98222C3D0BE500831F64 /* ConcertTicketInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertTicketInfoView.swift; sourceTree = "<group>"; };
+		22FD84542D9EA39400CB807C /* UpdateWebViewHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateWebViewHeight.swift; sourceTree = "<group>"; };
 		840B39542B7667D500E7F8C8 /* ConcertCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertCollectionViewCell.swift; sourceTree = "<group>"; };
 		840B39562B76688C00E7F8C8 /* ConcertCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		840B39582B7670FC00E7F8C8 /* ConcertEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertEntity.swift; sourceTree = "<group>"; };
@@ -1278,6 +1280,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		22FD84532D9EA38B00CB807C /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				22FD84542D9EA39400CB807C /* UpdateWebViewHeight.swift */,
+			);
+			path = WebView;
+			sourceTree = "<group>";
+		};
 		840B39532B7667B100E7F8C8 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -1784,6 +1794,7 @@
 		849FBD4F2B5E91F7006EB865 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
+				22FD84532D9EA38B00CB807C /* WebView */,
 				849FBD502B5E920A006EB865 /* AppInfo.swift */,
 				84781C762B5BEB8500D37921 /* UserDefaultsKey.swift */,
 			);
@@ -2780,6 +2791,7 @@
 				224BEEDF2C4A0B7700863970 /* TicketingType.swift in Sources */,
 				84781C772B5BEB8500D37921 /* UserDefaultsKey.swift in Sources */,
 				84DF59DA2B722E5B000816DA /* UpdatePopupViewController.swift in Sources */,
+				22FD84552D9EA3A100CB807C /* UpdateWebViewHeight.swift in Sources */,
 				876C65E02B73907D000F2746 /* TicketType.swift in Sources */,
 				84781CC22B5BF9A700D37921 /* MyPageViewModel.swift in Sources */,
 				2201AC972C2AB35100CEBD31 /* CardImageCollectionViewCell.swift in Sources */,

--- a/Boolti/Boolti/Sources/Global/Constants/WebView/UpdateWebViewHeight.swift
+++ b/Boolti/Boolti/Sources/Global/Constants/WebView/UpdateWebViewHeight.swift
@@ -1,0 +1,74 @@
+//
+//  UpdateWebViewHeight.swift
+//  Boolti
+//
+//  Created by Juhyeon Byun on 4/3/25.
+//
+
+import WebKit
+
+enum WebViewJsCode {
+    static let UpdateWebViewHeight = "updateWebViewHeight"
+    static let UpdateWebViewHeightScript = WKUserScript(
+          source: """
+              function updateWebViewHeight() {
+                  // 문서 전체 높이 계산을 위한 함수
+                  function getMaxHeight() {
+                      // 기본 body 높이
+                      var height = document.body.scrollHeight;
+                      
+                      // iframe 엘리먼트들의 높이 고려
+                      var iframes = document.getElementsByTagName('iframe');
+                      for (var i = 0; i < iframes.length; i++) {
+                          var iframe = iframes[i];
+                          var iframeBottom = iframe.getBoundingClientRect().bottom + window.pageYOffset;
+                          height = Math.max(height, iframeBottom);
+                      }
+                      
+                      // 모든 DOM 요소의 위치를 고려한 총 높이 계산
+                      var allElements = document.getElementsByTagName('*');
+                      for (var i = 0; i < allElements.length; i++) {
+                          var element = allElements[i];
+                          var elementBottom = element.getBoundingClientRect().bottom + window.pageYOffset;
+                          height = Math.max(height, elementBottom);
+                      }
+
+                      return height + 16;
+                  }
+                  
+                  // 유튜브 iframe이 로드되기까지 약간의 시간이 지연
+                  setTimeout(function() {
+                      var calculatedHeight = getMaxHeight();
+                      window.webkit.messageHandlers.updateWebViewHeight.postMessage(calculatedHeight);
+                  }, 500);
+              }
+
+              // 페이지 로드 시 실행
+              window.addEventListener('load', function() {
+                          updateWebViewHeight();
+                  
+                  // 유튜브 iframe을 위한 추가 지연 업데이트
+                  setTimeout(updateWebViewHeight, 1000);
+                  setTimeout(updateWebViewHeight, 2000);
+              });
+
+              // DOM 변경 감지
+              const observer = new MutationObserver(function() {
+                  updateWebViewHeight();
+              });
+
+              observer.observe(document.body, { 
+                  subtree: true, 
+                  childList: true,
+                  attributes: true,
+                  characterData: true
+              });
+
+              window.addEventListener('resize', function() {
+                  updateWebViewHeight();
+              });
+          """,
+          injectionTime: .atDocumentEnd,
+          forMainFrameOnly: true
+      )
+}

--- a/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
+++ b/Boolti/Boolti/Sources/UILayer/Concert/ConcertDetail/ConcertDetailViewController.swift
@@ -246,7 +246,7 @@ extension ConcertDetailViewController {
                 guard let entity = entity else { return }
                 owner.concertPosterView.setData(images: entity.posters, title: entity.name,
                                                 date: entity.date, runningTime: entity.runningTime, placeName: entity.placeName)
-                let request = URLRequest(url: URL(string: "\(Environment.PREVIEW_URL_PREFIX)\(entity.id)/notice")!, cachePolicy: .returnCacheDataElseLoad)
+                let request = URLRequest(url: URL(string: "\(Environment.PREVIEW_URL_PREFIX)\(entity.id)/info")!, cachePolicy: .returnCacheDataElseLoad)
                 owner.webview.load(request)
                 owner.configureRemainingSaleTimerBanner(salesEndTime: entity.salesEndTime, ticketingStatus: entity.ticketingState)
             }


### PR DESCRIPTION
## 작업한 내용
- 공연 상세 아래부분 webview로 변경했습니다.

### todo
- youtube 동영상 때문에 js 코드가 좀 길어져서 일단 빼놨는데,, 차차 수정 필요해보입니다.

## 스크린샷
https://github.com/user-attachments/assets/0b52606c-186d-440f-8054-bebdaa02a289

<링크 변경 후>
<img src="https://github.com/user-attachments/assets/3b975742-121a-4fa1-bbf0-ef71ef0b44ad" width=250>


## 관련 이슈
- Resolved: #465 
